### PR TITLE
chore: pin pnpm via packageManager

### DIFF
--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -20,8 +20,6 @@ jobs:
 
       - name: ⎔ Setup pnpm
         uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
-        with:
-          version: 10
 
       - name: ⎔ Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,8 +19,6 @@ jobs:
 
       - name: ⎔ Setup pnpm
         uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
-        with:
-          version: 10
 
       - name: ⎔ Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,8 +25,6 @@ jobs:
 
       - name: ⎔ Setup pnpm
         uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
-        with:
-          version: 10
 
       - name: ⎔ Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "sql"
   ],
   "license": "Apache-2.0",
+  "packageManager": "pnpm@10.28.2",
   "peerDependencies": {
     "@codemirror/autocomplete": "^6",
     "@codemirror/lint": "^6",


### PR DESCRIPTION
Adds `"packageManager": "pnpm@10.28.2"` to `package.json` and drops the redundant `version:` arg from `pnpm/action-setup` in CI.

The action now reads the version from `packageManager`, giving a single source of truth shared between local dev and CI. Matches the convention used in `marimo` and `marimo-lsp`.