### PR TITLE
fix(ci): correct YAML indentation in release publish job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,7 @@ jobs:
       - name: ⎔ Setup pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
 
-            - name: ⎔ Setup Node.js
+      - name: ⎔ Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: 24


### PR DESCRIPTION
The `Setup Node.js` step in the `publish` job was over-indented, making `release.yml` invalid YAML. This caused the v0.2.5 release runs to fail at 0s ("workflow file issue") so the publish job never ran — npm latest is still 0.2.4.

Introduced in #128. Fix re-aligns the step to 6 spaces; YAML now parses.