### PR TITLE
fix(ci): download artifact before pnpm setup in release publish job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,6 +80,11 @@ jobs:
       id-token: write
       contents: read
     steps:
+      - name: 📥 Download package artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: package
+
       - name: ⎔ Setup pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
 
@@ -88,11 +93,6 @@ jobs:
         with:
           node-version: 24
           registry-url: 'https://registry.npmjs.org'
-
-      - name: 📥 Download package artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          name: package
 
       - name: 📦 Publish to NPM
         run: pnpm publish --no-git-checks --ignore-scripts


### PR DESCRIPTION
The `publish` job in the release workflow has no checkout step and only consumes the build artifact, but `Setup pnpm` ran before the artifact was downloaded. Since `pnpm/action-setup@v6` resolves its version from `package.json`'s `packageManager` field and no `package.json` existed in the workspace yet, the job failed with "No pnpm version is specified" — which broke the v0.2.6 release.

This reorders the publish job so the artifact (which includes `package.json`) is downloaded before `Setup pnpm`, keeping the pnpm version in a single source of truth. Note: v0.2.6 never published, so a tag will need to be re-pushed after this merges.