### PR TITLE
fix(ci): download artifact before pnpm setup in publish job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,6 +80,11 @@ jobs:
       id-token: write
       contents: read
     steps:
+      - name: 📥 Download package artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: package
+
       - name: ⎔ Setup pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
 
@@ -88,11 +93,6 @@ jobs:
         with:
           node-version: 24
           registry-url: 'https://registry.npmjs.org'
-
-      - name: 📥 Download package artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          name: package
 
       - name: 📦 Publish to NPM
         run: pnpm publish --no-git-checks --ignore-scripts


### PR DESCRIPTION
The `publish` job has no `checkout` step, so `package.json` (with the `packageManager` field) only exists after the artifact download. Running `pnpm/action-setup` first left it with no pnpm version to read, causing "No pnpm version is specified".

Fix: reorder so the artifact download runs before pnpm setup.

Fixes the failure in [this run](https://github.com/marimo-team/codemirror-sql/actions/runs/27144993776/job/80120275403).