### PR TITLE
ci: enforce lint and report coverage on PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,11 +35,20 @@ jobs:
       - name: 📥 Install dependencies
         run: pnpm install --ignore-scripts --frozen-lockfile
 
+      - name: 🧹 Lint
+        run: pnpm exec oxlint
+
       - name: 🔍 Type Check
         run: pnpm run typecheck
 
       - name: 🧪 Test
         run: pnpm run test
+
+      - name: 📊 Report Coverage
+        if: always()
+        uses: davelosert/vitest-coverage-report-action@3c50566c523e04813df28de8f7c48dd97d663f1c # v2
+        with:
+          pr-number: auto
 
   security:
     runs-on: ubuntu-latest

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,8 +6,10 @@ export default defineConfig({
   test: {
     watch: false,
     coverage: {
+      enabled: true,
       provider: "v8",
-      reporter: ["text", "json", "html"],
+      reportOnFailure: true,
+      reporter: ["text", "json", "html", "json-summary"],
       include: ["src/**/*.ts"],
       exclude: ["src/**/*.test.ts", "src/**/__tests__/**", "src/debug.ts"],
     },


### PR DESCRIPTION
## What changed

- **Lint in CI**: added a plain `pnpm exec oxlint` step to the `test` job. The existing `lint` script is `oxlint --fix` (mutating), so CI runs the non-mutating variant. There is no oxlint config file, which is fine — oxlint applies its defaults.
- **Coverage config** (`vite.config.ts`): the coverage block was defined but not `enabled`, and its `reporter` list lacked `json-summary` (required by the report action). Added `enabled: true`, `reportOnFailure: true`, and `json-summary` to the reporter list. Provider/include/exclude unchanged.
- **Coverage reporting**: added the SHA-pinned `davelosert/vitest-coverage-report-action@…3c50566 # v2` step (`if: always()`, `pr-number: auto`) matching codemirror-mcp. The job already has `pull-requests: write`.

## Why

The lint script and a coverage config already existed but CI never ran lint, and coverage was neither enabled nor emitting the `json-summary` the reporter needs — so coverage was effectively invisible on PRs. This turns both into visible PR gates.

## How verified

- `pnpm install --frozen-lockfile`
- `pnpm exec oxlint` — exit 0 (1 pre-existing `no-unused-expressions` warning, non-blocking; no source changes needed)
- `pnpm run test` — 206 passed + 1 expected-fail across 11 test files (including the Playwright browser project); `coverage/coverage-summary.json` is generated and `coverage/` is gitignored.

No mechanical source fixes were required. Part of the marimo-team engineering-excellence initiative to make existing-but-unenforced quality gates actually run in CI.