### PR TITLE
ci: add autofix.ci

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -1,0 +1,40 @@
+name: autofix.ci # needed to securely identify the workflow
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  autofix:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: ⎔ Setup pnpm
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
+
+      - name: ⎔ Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: 📥 Install dependencies
+        run: pnpm install --ignore-scripts --frozen-lockfile
+
+      # Applies oxlint --fix. Unfixable lint errors are CI's job to report
+      # (see the lint step in test.yml); don't let them block uploading the
+      # fixes that did apply.
+      - name: 🧹 Apply lint fixes
+        run: pnpm run lint || true
+
+      - uses: autofix-ci/action@c5b2d67aa2274e7b5a18224e8171550871fc7e4a # v1.3.4


### PR DESCRIPTION
## What this does

Adds an `autofix.ci` workflow that automatically **pushes** lint fixes onto pull requests. When a contributor opens or updates a PR, the workflow runs the repo's mutating fixer (`pnpm run lint`, i.e. `oxlint --fix`) and, via the [autofix.ci](https://autofix.ci) GitHub App, commits any resulting fixes straight back onto the PR branch. Contributors never see a red lint check they have to reproduce and fix by hand.

The autofix.ci GitHub App is **installed org-wide** for marimo-team (confirmed by an org admin), so this works as soon as it merges — no per-repo setup required.

## How it composes with the existing lint gate

CI's `oxlint` lint step stays exactly as-is: it's non-mutating and still fails the build on anything that can't be auto-fixed (genuine lint errors are meant to be surfaced, not silently rewritten). autofix.ci is the complement — it handles the *mechanical* fixes (safe lint autofixes) so that class of failure disappears from the contributor's plate. The fixer step is guarded with `|| true` so unfixable lint errors don't block uploading the fixes that *did* apply; CI remains the source of truth for reporting them.

The setup steps (checkout / pnpm / Node) mirror `test.yml` exactly, with the same SHA-pinned action versions.

## Verification

- Cloned, `pnpm install --ignore-scripts --frozen-lockfile`, ran `pnpm run lint` → **no diff** (tree stays clean; only a pre-existing non-fixable warning, which CI already reports).
- Workflow YAML parses cleanly and passes `actionlint`.
- Workflow `name` is exactly `autofix.ci` (required — the service identifies the workflow by name for security) and the `autofix-ci/action` step runs last.

Part of the marimo-team engineering-excellence initiative.
