### PR TITLE
fix: correctness bugs in analyzer cache, hover, parser, gutter, and CTE completion

### DIFF
--- a/src/sql/__tests__/cte-completion-source.test.ts
+++ b/src/sql/__tests__/cte-completion-source.test.ts
@@ -280,4 +280,41 @@ describe("cteCompletionSource", () => {
       expect(completion?.boost).toBe(10);
     });
   });
+
+  describe("CTE bodies containing parentheses", () => {
+    it("detects CTEs after a body with a function call", async () => {
+      const sql = "WITH a AS (SELECT max(x) FROM t), b AS (SELECT 1) SELECT * FROM ";
+
+      const context = createMockContext(sql, sql.length, true);
+      const result = await getCompletionResult(context);
+
+      const labels = result?.options.map((option) => option.label) ?? [];
+      expect(labels).toContain("a");
+      expect(labels).toContain("b");
+    });
+
+    it("detects CTEs after a body with a nested subquery", async () => {
+      const sql =
+        "WITH a AS (SELECT * FROM (SELECT 1) sub), b AS (SELECT 2), c AS (SELECT 3) SELECT * FROM ";
+
+      const context = createMockContext(sql, sql.length, true);
+      const result = await getCompletionResult(context);
+
+      const labels = result?.options.map((option) => option.label) ?? [];
+      expect(labels).toContain("a");
+      expect(labels).toContain("b");
+      expect(labels).toContain("c");
+    });
+
+    it("detects CTEs declared with a column list", async () => {
+      const sql = "WITH a(x, y) AS (SELECT 1, 2), b AS (SELECT 3) SELECT * FROM ";
+
+      const context = createMockContext(sql, sql.length, true);
+      const result = await getCompletionResult(context);
+
+      const labels = result?.options.map((option) => option.label) ?? [];
+      expect(labels).toContain("a");
+      expect(labels).toContain("b");
+    });
+  });
 });

--- a/src/sql/__tests__/hover-integration.test.ts
+++ b/src/sql/__tests__/hover-integration.test.ts
@@ -2,7 +2,8 @@ import type { Completion } from "@codemirror/autocomplete";
 import type { SQLNamespace } from "@codemirror/lang-sql";
 import { EditorState } from "@codemirror/state";
 import { describe, expect, it, vi } from "vitest";
-import { defaultSqlHoverTheme, sqlHover } from "../hover.js";
+import type { EditorView } from "@codemirror/view";
+import { defaultSqlHoverTheme, exportedForTesting, sqlHover } from "../hover.js";
 import { resolveNamespaceItem } from "../namespace-utils.js";
 
 // Helper function to create completion objects
@@ -797,6 +798,63 @@ describe("Query-aware hover behavior - edge cases", () => {
       expect(columnResult).toBeTruthy();
       expect(columnResult?.semanticType).toBe("column");
       expect(columnResult?.completion?.label).toBe("username");
+    });
+  });
+
+  describe("hover source keyword handling", () => {
+    const { createHoverSource } = exportedForTesting;
+
+    function createMockView(doc: string): EditorView {
+      const state = EditorState.create({ doc });
+      return { state } as unknown as EditorView;
+    }
+
+    it("does not show keyword tooltips for Object.prototype members", async () => {
+      const source = createHoverSource({ keywords: {}, schema: {} });
+
+      for (const word of ["constructor", "toString", "valueOf", "hasOwnProperty"]) {
+        const doc = `SELECT ${word} FROM users`;
+        const view = createMockView(doc);
+        const pos = doc.indexOf(word) + 2;
+
+        const tooltip = await source(view, pos, 1);
+        expect(tooltip, `hovering '${word}' must not produce a tooltip`).toBeNull();
+      }
+    });
+
+    it("still shows tooltips for real custom keywords", async () => {
+      const source = createHoverSource({
+        keywords: { select: { description: "Selects rows" } },
+      });
+      const doc = "SELECT id FROM users";
+      const view = createMockView(doc);
+
+      const tooltip = await source(view, doc.indexOf("SELECT") + 2, 1);
+      expect(tooltip).not.toBeNull();
+    });
+
+    it("does not permanently disable hovers when the keywords promise rejects", async () => {
+      const keywords = vi.fn(async (): Promise<Record<string, { description: string }>> => {
+        if (keywords.mock.calls.length === 1) {
+          throw new Error("network");
+        }
+        return { select: { description: "Selects rows" } };
+      });
+      const source = createHoverSource({
+        keywords,
+        schema: { users: ["id", "name"] },
+      });
+      const doc = "SELECT id FROM users";
+      const view = createMockView(doc);
+
+      // First hover: the keywords fetch fails, but schema hovers must still work
+      const tableTooltip = await source(view, doc.indexOf("users") + 2, 1);
+      expect(tableTooltip).not.toBeNull();
+
+      // Second hover: the failed fetch is retried and keyword tooltips recover
+      const keywordTooltip = await source(view, doc.indexOf("SELECT") + 2, 1);
+      expect(keywordTooltip).not.toBeNull();
+      expect(keywords).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/src/sql/__tests__/namespace-utils.test.ts
+++ b/src/sql/__tests__/namespace-utils.test.ts
@@ -616,3 +616,32 @@ describe("performance and memory", () => {
     expect(true).toBe(true);
   });
 });
+
+describe("namespaces containing a table named 'self'", () => {
+  const schemaWithSelfTable: SQLNamespace = {
+    self: ["id", "name"],
+    users: ["id", "email"],
+  };
+
+  it("treats a plain object with a 'self' key (but no 'children') as an object namespace", () => {
+    expect(isObjectNamespace(schemaWithSelfTable)).toBe(true);
+    expect(isSelfChildrenNamespace(schemaWithSelfTable)).toBe(false);
+  });
+
+  it("does not treat tables literally named 'self' and 'children' as a self-children namespace", () => {
+    const schema: SQLNamespace = { self: ["id"], children: ["id"] };
+    expect(isSelfChildrenNamespace(schema)).toBe(false);
+    expect(isObjectNamespace(schema)).toBe(true);
+  });
+
+  it("resolves a table literally named 'self'", () => {
+    const result = resolveNamespaceItem(schemaWithSelfTable, "self");
+    expect(result).toBeTruthy();
+    expect(result?.semanticType).toBe("table");
+  });
+
+  it("still detects real self-children namespaces", () => {
+    expect(isSelfChildrenNamespace(mockNamespaces.selfChildren)).toBe(true);
+    expect(isObjectNamespace(mockNamespaces.selfChildren)).toBe(false);
+  });
+});

--- a/src/sql/__tests__/parser.test.ts
+++ b/src/sql/__tests__/parser.test.ts
@@ -372,3 +372,38 @@ describe("replaceBracketsWithQuotes", () => {
     expect(result.sql).toBe("SELECT 'user\\'s {id}' FROM users");
   });
 });
+
+describe("error positions with ignoreBrackets", () => {
+  const bracketParser = new NodeSqlParser({
+    getParserOptions: () => ({
+      database: "PostgreSQL",
+      ignoreBrackets: true,
+    }),
+  });
+  const state = EditorState.create({ doc: "" });
+
+  it("adjusts the column for errors after a bracket on the same line", async () => {
+    // Sanitized to "SELECT '{id}' FRO users"; the parser's column 19 maps back to 17
+    const result = await bracketParser.parse("SELECT {id} FRO users", { state });
+
+    expect(result.success).toBe(false);
+    expect(result.errors[0].line).toBe(1);
+    expect(result.errors[0].column).toBe(17);
+  });
+
+  it("does not shift error columns on lines after a replaced bracket", async () => {
+    // Line 2 is unmodified, so the parser's column 22 must not shift
+    const result = await bracketParser.parse("SELECT {id}\nFROM users WHERE xyz abc", { state });
+
+    expect(result.success).toBe(false);
+    expect(result.errors[0].line).toBe(2);
+    expect(result.errors[0].column).toBe(22);
+  });
+
+  it("never reports a column below 1", async () => {
+    const result = await bracketParser.parse("{x}\nFROM WHERE", { state });
+
+    expect(result.success).toBe(false);
+    expect(result.errors[0].column).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/src/sql/__tests__/structure-analyzer.test.ts
+++ b/src/sql/__tests__/structure-analyzer.test.ts
@@ -331,4 +331,17 @@ WHERE u.active = true
       });
     });
   });
+
+  describe("cache correctness", () => {
+    it("does not return cached statements for a different document with a colliding hash", async () => {
+      // "select Aa" and "select BB" collide under a 31-based 32-bit string hash
+      const first = await analyzer.analyzeDocument(createState("select Aa"));
+      expect(first).toHaveLength(1);
+      expect(first[0].content).toBe("select Aa");
+
+      const second = await analyzer.analyzeDocument(createState("select BB"));
+      expect(second).toHaveLength(1);
+      expect(second[0].content).toBe("select BB");
+    });
+  });
 });

--- a/src/sql/__tests__/structure-extension.test.ts
+++ b/src/sql/__tests__/structure-extension.test.ts
@@ -1,7 +1,17 @@
 import { EditorState, Text } from "@codemirror/state";
-import type { EditorView } from "@codemirror/view";
+import { EditorView } from "@codemirror/view";
 import { describe, expect, it } from "vitest";
 import { sqlStructureGutter } from "../structure-extension.js";
+
+async function waitFor(condition: () => boolean, timeoutMs = 3000): Promise<void> {
+  const start = Date.now();
+  while (!condition()) {
+    if (Date.now() - start > timeoutMs) {
+      throw new Error("Timed out waiting for condition");
+    }
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+}
 
 // Type for gutter extension with markers function
 interface GutterExtension {
@@ -122,5 +132,41 @@ DELETE FROM users WHERE id = 2;`;
         expect(() => markersFn(view)).not.toThrow();
       }
     }).not.toThrow();
+  });
+
+  it("renders gutter markers for pre-filled content without user interaction", async () => {
+    const view = new EditorView({
+      doc: "SELECT 1;\nSELECT 2;",
+      extensions: [sqlStructureGutter()],
+      parent: document.body,
+    });
+
+    try {
+      await waitFor(() => view.dom.querySelectorAll(".cm-sql-gutter-marker").length >= 2);
+      expect(view.dom.querySelectorAll(".cm-sql-gutter-marker").length).toBeGreaterThanOrEqual(2);
+    } finally {
+      view.destroy();
+    }
+  });
+
+  it("honors an explicit inactiveOpacity of 0", async () => {
+    const view = new EditorView({
+      doc: "SELECT 1;\nSELECT 2;",
+      extensions: [sqlStructureGutter({ inactiveOpacity: 0 })],
+      parent: document.body,
+    });
+
+    try {
+      // Put the cursor in the first statement so the second one is inactive
+      view.dispatch({ selection: { anchor: 0 } });
+      await waitFor(() => view.dom.querySelectorAll(".cm-sql-gutter-marker").length >= 2);
+
+      const opacities = Array.from(
+        view.dom.querySelectorAll<HTMLElement>(".cm-sql-gutter-marker"),
+      ).map((marker) => marker.style.opacity);
+      expect(opacities).toContain("0");
+    } finally {
+      view.destroy();
+    }
   });
 });

--- a/src/sql/cte-completion-source.ts
+++ b/src/sql/cte-completion-source.ts
@@ -1,6 +1,52 @@
 import type { Completion, CompletionContext, CompletionSource } from "@codemirror/autocomplete";
 
 /**
+ * Extracts the names of all CTEs declared in WITH clauses in the document
+ */
+function extractCteNames(doc: string): Set<string> {
+  const cteNames = new Set<string>();
+
+  // Start of a WITH clause (optionally recursive)
+  const withPattern = /\bWITH\s+(?:RECURSIVE\s+)?/gi;
+  // CTE name with an optional column list, followed by AS (
+  const ctePattern = /^([a-zA-Z_][a-zA-Z0-9_]*)\s*(?:\([^)]*\)\s*)?\bAS\s*\(/i;
+
+  let withMatch = withPattern.exec(doc);
+  while (withMatch !== null) {
+    let pos = withMatch.index + withMatch[0].length;
+
+    for (;;) {
+      const cteMatch = ctePattern.exec(doc.slice(pos));
+      const cteName = cteMatch?.[1];
+      if (!cteName) {
+        break;
+      }
+      cteNames.add(cteName);
+
+      // Skip past the CTE body, tracking nested parentheses
+      let i = pos + cteMatch[0].length;
+      let depth = 1;
+      while (i < doc.length && depth > 0) {
+        if (doc[i] === "(") depth++;
+        else if (doc[i] === ")") depth--;
+        i++;
+      }
+
+      // A comma introduces the next CTE in the same WITH clause
+      const separator = /^\s*,\s*/.exec(doc.slice(i));
+      if (!separator) {
+        break;
+      }
+      pos = i + separator[0].length;
+    }
+
+    withMatch = withPattern.exec(doc);
+  }
+
+  return cteNames;
+}
+
+/**
  * A completion source for Common Table Expressions (CTEs) in SQL
  *
  * This function provides autocomplete suggestions for CTE references based on
@@ -22,42 +68,7 @@ import type { Completion, CompletionContext, CompletionSource } from "@codemirro
  */
 export const cteCompletionSource: CompletionSource = (context: CompletionContext) => {
   const doc = context.state.doc.toString();
-  const cteNames = new Set<string>();
-
-  // Find all CTEs in the document using regex pattern
-  // Match WITH clause and extract CTE names
-  const ctePattern = /WITH\s+(?:RECURSIVE\s+)?([a-zA-Z_][a-zA-Z0-9_]*)\s+AS\s*\(/gi;
-  let match: RegExpExecArray | null;
-
-  match = ctePattern.exec(doc);
-  while (match !== null) {
-    const cteName = match[1];
-    if (cteName) {
-      cteNames.add(cteName);
-    }
-    match = ctePattern.exec(doc);
-  }
-
-  // Also match additional CTEs in the same WITH clause (comma-separated)
-  const additionalCtePattern =
-    /WITH\s+(?:RECURSIVE\s+)?[a-zA-Z_][a-zA-Z0-9_]*\s+AS\s*\([^)]*\)(?:\s*,\s*([a-zA-Z_][a-zA-Z0-9_]*)\s+AS\s*\([^)]*\))*/gi;
-
-  match = additionalCtePattern.exec(doc);
-  while (match !== null) {
-    // Extract all comma-separated CTEs
-    const fullMatch = match[0];
-    const cteChainPattern = /([a-zA-Z_][a-zA-Z0-9_]*)\s+AS\s*\(/g;
-    let cteMatch: RegExpExecArray | null = cteChainPattern.exec(fullMatch);
-
-    while (cteMatch !== null) {
-      const cteName = cteMatch[1];
-      if (cteName) {
-        cteNames.add(cteName);
-      }
-      cteMatch = cteChainPattern.exec(fullMatch);
-    }
-    match = additionalCtePattern.exec(doc);
-  }
+  const cteNames = extractCteNames(doc);
 
   // If no CTEs found, return null (no completions)
   if (cteNames.size === 0) {

--- a/src/sql/hover.ts
+++ b/src/sql/hover.ts
@@ -144,13 +144,14 @@ export interface SqlHoverConfig {
 }
 
 /**
- * Creates a hover tooltip extension for SQL
+ * Creates the hover source used by the sqlHover extension
  */
-export function sqlHover(config: SqlHoverConfig = {}): Extension {
+function createHoverSource(
+  config: SqlHoverConfig = {},
+): (view: EditorView, pos: number, side: number) => Promise<Tooltip | null> {
   const {
     schema = {},
     keywords = {},
-    hoverTime = 300,
     enableKeywords = true,
     enableTables = true,
     enableColumns = true,
@@ -162,170 +163,188 @@ export function sqlHover(config: SqlHoverConfig = {}): Extension {
 
   let keywordsPromise: Promise<Record<string, SqlKeywordInfo>> | null = null;
 
-  return hoverTooltip(
-    async (view: EditorView, pos: number, side: number): Promise<Tooltip | null> => {
-      const { from, to, text } = view.state.doc.lineAt(pos);
-      let start = pos;
-      let end = pos;
+  return async (view: EditorView, pos: number, side: number): Promise<Tooltip | null> => {
+    const { from, to, text } = view.state.doc.lineAt(pos);
+    let start = pos;
+    let end = pos;
 
-      if (keywordsPromise === null) {
-        keywordsPromise =
-          typeof keywords === "function" ? keywords(view) : Promise.resolve(keywords);
+    if (keywordsPromise === null) {
+      keywordsPromise =
+        typeof keywords === "function" ? keywords(view) : Promise.resolve(keywords);
+    }
+
+    let resolvedKeywords: Record<string, SqlKeywordInfo>;
+    try {
+      resolvedKeywords = await keywordsPromise;
+    } catch (error) {
+      // Don't cache a failed fetch; retry on the next hover
+      keywordsPromise = null;
+      debug("failed to resolve keywords", error);
+      resolvedKeywords = {};
+    }
+
+    // Find word boundaries (including dots for table.column syntax)
+    while (start > from && /[\w.]/.test(text[start - from - 1] ?? "")) start--;
+    while (end < to && /[\w.]/.test(text[end - from] ?? "")) end++;
+
+    // Validate pointer position within word
+    if ((start === pos && side < 0) || (end === pos && side > 0)) {
+      return null;
+    }
+
+    const word = text.slice(start - from, end - from).toLowerCase();
+    if (!word || word.length === 0) {
+      return null;
+    }
+
+    const resolvedSchema = typeof schema === "function" ? schema(view) : schema;
+
+    let createData: TooltipCreateData | null = null;
+
+    debug(`hover word: '${word}'`);
+
+    // Implement preference order:
+    // 1. Look in keywords if it exists
+    // 2. Look for it in SQLNamespace as is
+    // 3. If neither, look in SQLNamespace and try to guess (fuzzy match)
+
+    // Step 1: If no namespace match, try keywords
+    // Own-property check so Object.prototype members don't match
+    const keywordInfo = Object.hasOwn(resolvedKeywords, word)
+      ? resolvedKeywords[word]
+      : undefined;
+    if (!createData && enableKeywords && keywordInfo) {
+      debug("keywordResult", word, keywordInfo);
+      const keywordData: KeywordTooltipData = { keyword: word, info: keywordInfo };
+      createData = {
+        word,
+        view,
+        pos,
+        tooltipType: "keyword",
+        keywordData,
+      };
+    }
+
+    // Step 2: Try to resolve directly in SQLNamespace (query-aware)
+    if (!createData && (enableTables || enableColumns) && resolvedSchema) {
+      // Get the current SQL query to filter schema by referenced tables
+      const currentQuery = view.state.doc.toString();
+      const tableList = await parser.extractTableReferences(currentQuery);
+      const tableRefs = new Set(tableList.map((table: string) => table.toLowerCase()));
+
+      // Filter schema to only include tables referenced in the current query
+      const filteredSchema = filterSchemaByTableRefs(resolvedSchema, tableRefs);
+
+      // Try to resolve in the filtered schema first (query-aware)
+      let namespaceResult = resolveNamespaceItem(filteredSchema, word, {
+        enableFuzzySearch,
+      });
+
+      // If no result in filtered schema and no tables were found in query,
+      // fall back to the full schema to show any relevant information
+      if (!namespaceResult && tableRefs.size === 0) {
+        namespaceResult = resolveNamespaceItem(resolvedSchema, word, {
+          enableFuzzySearch,
+        });
       }
 
-      const resolvedKeywords = await keywordsPromise;
+      if (namespaceResult) {
+        debug(
+          "namespaceResult (query-aware)",
+          word,
+          namespaceResult,
+          "tableRefs:",
+          Array.from(tableRefs),
+        );
+        const namespaceData: NamespaceTooltipData = {
+          item: namespaceResult,
+          word,
+          resolvedSchema: tableRefs.size > 0 ? filteredSchema : resolvedSchema,
+        };
 
-      // Find word boundaries (including dots for table.column syntax)
-      while (start > from && /[\w.]/.test(text[start - from - 1] ?? "")) start--;
-      while (end < to && /[\w.]/.test(text[end - from] ?? "")) end++;
-
-      // Validate pointer position within word
-      if ((start === pos && side < 0) || (end === pos && side > 0)) {
-        return null;
-      }
-
-      const word = text.slice(start - from, end - from).toLowerCase();
-      if (!word || word.length === 0) {
-        return null;
-      }
-
-      const resolvedSchema = typeof schema === "function" ? schema(view) : schema;
-
-      let createData: TooltipCreateData | null = null;
-
-      debug(`hover word: '${word}'`);
-
-      // Implement preference order:
-      // 1. Look in keywords if it exists
-      // 2. Look for it in SQLNamespace as is
-      // 3. If neither, look in SQLNamespace and try to guess (fuzzy match)
-
-      // Step 1: If no namespace match, try keywords
-      const keywordInfo = resolvedKeywords[word];
-      if (!createData && enableKeywords && keywordInfo) {
-        debug("keywordResult", word, keywordInfo);
-        const keywordData: KeywordTooltipData = { keyword: word, info: keywordInfo };
         createData = {
           word,
           view,
           pos,
-          tooltipType: "keyword",
-          keywordData,
+          tooltipType: "namespace",
+          namespaceData,
         };
+      } else {
+        debug("No namespace item found for:", word);
       }
+    }
 
-      // Step 2: Try to resolve directly in SQLNamespace (query-aware)
-      if (!createData && (enableTables || enableColumns) && resolvedSchema) {
-        // Get the current SQL query to filter schema by referenced tables
-        const currentQuery = view.state.doc.toString();
-        const tableList = await parser.extractTableReferences(currentQuery);
-        const tableRefs = new Set(tableList.map((table: string) => table.toLowerCase()));
+    // Step 3: Fuzzy matching is handled by resolveNamespaceItem if enableFuzzySearch is true
 
-        // Filter schema to only include tables referenced in the current query
-        const filteredSchema = filterSchemaByTableRefs(resolvedSchema, tableRefs);
+    if (!createData) {
+      return null;
+    }
 
-        // Try to resolve in the filtered schema first (query-aware)
-        let namespaceResult = resolveNamespaceItem(filteredSchema, word, {
-          enableFuzzySearch,
-        });
+    const tooltipData = createData;
 
-        // If no result in filtered schema and no tables were found in query,
-        // fall back to the full schema to show any relevant information
-        if (!namespaceResult && tableRefs.size === 0) {
-          namespaceResult = resolveNamespaceItem(resolvedSchema, word, {
-            enableFuzzySearch,
-          });
+    return {
+      pos: start,
+      end,
+      above: true,
+      create(createView: EditorView) {
+        // Priority 1: Custom tooltipRender function
+        if (tooltipRender) {
+          const customElement = tooltipRender(word, createView, pos);
+          if (customElement) {
+            return { dom: customElement };
+          }
         }
 
-        if (namespaceResult) {
-          debug(
-            "namespaceResult (query-aware)",
-            word,
-            namespaceResult,
-            "tableRefs:",
-            Array.from(tableRefs),
-          );
-          const namespaceData: NamespaceTooltipData = {
-            item: namespaceResult,
-            word,
-            resolvedSchema: tableRefs.size > 0 ? filteredSchema : resolvedSchema,
-          };
+        // Priority 2: Custom renderers and default renderers
+        let tooltipContent: string | null = null;
 
-          createData = {
-            word,
-            view,
-            pos,
-            tooltipType: "namespace",
-            namespaceData,
-          };
-        } else {
-          debug("No namespace item found for:", word);
+        if (tooltipData.tooltipType === "keyword" && tooltipData.keywordData) {
+          tooltipContent = tooltipRenderers.keyword
+            ? tooltipRenderers.keyword(tooltipData.keywordData)
+            : createKeywordTooltip(tooltipData.keywordData);
+        } else if (tooltipData.tooltipType === "namespace" && tooltipData.namespaceData) {
+          const namespaceData = tooltipData.namespaceData;
+          const { semanticType } = namespaceData.item;
+
+          if (semanticType === "table" && tooltipRenderers.table) {
+            tooltipContent = tooltipRenderers.table(namespaceData);
+          } else if (semanticType === "column" && tooltipRenderers.column) {
+            tooltipContent = tooltipRenderers.column(namespaceData);
+          } else if (
+            (semanticType === "database" ||
+              semanticType === "schema" ||
+              semanticType === "namespace") &&
+            tooltipRenderers.namespace
+          ) {
+            tooltipContent = tooltipRenderers.namespace(namespaceData);
+          } else {
+            // Fallback to default renderer
+            tooltipContent = createNamespaceTooltip(namespaceData.item);
+          }
         }
-      }
 
-      // Step 3: Fuzzy matching is handled by resolveNamespaceItem if enableFuzzySearch is true
+        if (!tooltipContent) {
+          return { dom: document.createElement("div") };
+        }
 
-      if (!createData) {
-        return null;
-      }
-
-      const tooltipData = createData;
-
-      return {
-        pos: start,
-        end,
-        above: true,
-        create(createView: EditorView) {
-          // Priority 1: Custom tooltipRender function
-          if (tooltipRender) {
-            const customElement = tooltipRender(word, createView, pos);
-            if (customElement) {
-              return { dom: customElement };
-            }
-          }
-
-          // Priority 2: Custom renderers and default renderers
-          let tooltipContent: string | null = null;
-
-          if (tooltipData.tooltipType === "keyword" && tooltipData.keywordData) {
-            tooltipContent = tooltipRenderers.keyword
-              ? tooltipRenderers.keyword(tooltipData.keywordData)
-              : createKeywordTooltip(tooltipData.keywordData);
-          } else if (tooltipData.tooltipType === "namespace" && tooltipData.namespaceData) {
-            const namespaceData = tooltipData.namespaceData;
-            const { semanticType } = namespaceData.item;
-
-            if (semanticType === "table" && tooltipRenderers.table) {
-              tooltipContent = tooltipRenderers.table(namespaceData);
-            } else if (semanticType === "column" && tooltipRenderers.column) {
-              tooltipContent = tooltipRenderers.column(namespaceData);
-            } else if (
-              (semanticType === "database" ||
-                semanticType === "schema" ||
-                semanticType === "namespace") &&
-              tooltipRenderers.namespace
-            ) {
-              tooltipContent = tooltipRenderers.namespace(namespaceData);
-            } else {
-              // Fallback to default renderer
-              tooltipContent = createNamespaceTooltip(namespaceData.item);
-            }
-          }
-
-          if (!tooltipContent) {
-            return { dom: document.createElement("div") };
-          }
-
-          const dom = document.createElement("div");
-          dom.className = "cm-sql-hover-tooltip";
-          dom.innerHTML = tooltipContent;
-          return { dom };
-        },
-      };
-    },
-    { hoverTime },
-  );
+        const dom = document.createElement("div");
+        dom.className = "cm-sql-hover-tooltip";
+        dom.innerHTML = tooltipContent;
+        return { dom };
+      },
+    };
+  };
 }
+
+/**
+ * Creates a hover tooltip extension for SQL
+ */
+export function sqlHover(config: SqlHoverConfig = {}): Extension {
+  const { hoverTime = 300 } = config;
+  return hoverTooltip(createHoverSource(config), { hoverTime });
+}
+
+export const exportedForTesting = { createHoverSource };
 
 /**
  * Creates HTML content for namespace-resolved items

--- a/src/sql/namespace-utils.ts
+++ b/src/sql/namespace-utils.ts
@@ -44,7 +44,9 @@ export interface NamespaceSearchConfig {
 export function isObjectNamespace(
   namespace: SQLNamespace,
 ): namespace is { [name: string]: SQLNamespace } {
-  return typeof namespace === "object" && !Array.isArray(namespace) && !("self" in namespace);
+  return (
+    typeof namespace === "object" && !Array.isArray(namespace) && !isSelfChildrenNamespace(namespace)
+  );
 }
 
 /**
@@ -53,11 +55,19 @@ export function isObjectNamespace(
 export function isSelfChildrenNamespace(
   namespace: SQLNamespace,
 ): namespace is { self: Completion; children: SQLNamespace } {
+  if (typeof namespace !== "object" || Array.isArray(namespace)) {
+    return false;
+  }
+  if (!("self" in namespace) || !("children" in namespace)) {
+    return false;
+  }
+  // A self tag is a Completion; a table named "self" holds a namespace instead
+  const self: unknown = namespace.self;
   return (
-    typeof namespace === "object" &&
-    !Array.isArray(namespace) &&
-    "self" in namespace &&
-    "children" in namespace
+    typeof self === "object" &&
+    self !== null &&
+    !Array.isArray(self) &&
+    typeof (self as { label?: unknown }).label === "string"
   );
 }
 

--- a/src/sql/parser.ts
+++ b/src/sql/parser.ts
@@ -184,19 +184,32 @@ export class NodeSqlParser implements SqlParser {
     }
 
     /**
-     * Add offset to the column position to get the correct position of the error
+     * Map the error column back to the original (pre-replacement) SQL
      * SELECT {id} FRO users
      *             ^ error position should be here
      *
-     * SELECT {id} FRO users
-     *                   ^ user sees this
+     * SELECT '{id}' FRO users
+     *                   ^ parser reports this
      * So in this case, we subtract the offset from the column position.
      *
-     * If the error is before the brackets, we don't need to add the offset because it just increases the string length
-     * Column position will be the same as the user sees.
+     * offsetRecord keys are absolute offsets into the pre-replacement SQL,
+     * while the parser reports line-relative columns, so only replacements
+     * on the error's own line (and before the error column) shift it.
+     * Replacements never add or remove newlines, so line numbers match.
      */
-    for (const [position, offset] of Object.entries(this.offsetRecord)) {
-      if (column > parseInt(position, 10)) {
+    const replacements = Object.entries(this.offsetRecord)
+      .map(([position, offset]) => ({ position: parseInt(position, 10), offset }))
+      .sort((a, b) => a.position - b.position);
+    let shift = 0;
+    for (const { position, offset } of replacements) {
+      const replacedPosition = position + shift;
+      shift += offset;
+
+      const beforeReplacement = sql.slice(0, replacedPosition);
+      const replacementLine = (beforeReplacement.match(/\n/g)?.length ?? 0) + 1;
+      const replacementColumn = replacedPosition - beforeReplacement.lastIndexOf("\n");
+
+      if (line === replacementLine && column > replacementColumn) {
         column -= offset;
       }
     }
@@ -209,7 +222,7 @@ export class NodeSqlParser implements SqlParser {
     return {
       message: this.cleanErrorMessage(message),
       line: Math.max(1, line),
-      column: column,
+      column: Math.max(1, column),
       severity: "error" as const,
     };
   }

--- a/src/sql/structure-analyzer.ts
+++ b/src/sql/structure-analyzer.ts
@@ -39,16 +39,15 @@ export class SqlStructureAnalyzer {
    */
   async analyzeDocument(state: EditorState): Promise<SqlStatement[]> {
     const content = state.doc.toString();
-    const cacheKey = this.generateCacheKey(content);
 
     // Check cache
-    const cached = this.cache.get(cacheKey);
+    const cached = this.cache.get(content);
     if (cached) {
       return cached;
     }
 
     const statements = await this.extractStatements(content, state);
-    this.cache.set(cacheKey, statements);
+    this.cache.set(content, statements);
 
     // Keep cache size reasonable
     if (this.cache.size > this.MAX_CACHE_SIZE) {
@@ -308,17 +307,6 @@ export class SqlStructureAnalyzer {
     }
 
     return result;
-  }
-
-  private generateCacheKey(content: string): string {
-    // Simple hash function for caching
-    let hash = 0;
-    for (let i = 0; i < content.length; i++) {
-      const char = content.charCodeAt(i);
-      hash = (hash << 5) - hash + char;
-      hash = hash & hash; // Convert to 32-bit integer
-    }
-    return hash.toString();
   }
 
   /**

--- a/src/sql/structure-extension.ts
+++ b/src/sql/structure-extension.ts
@@ -1,5 +1,5 @@
 import { type Extension, RangeSet, StateEffect, StateField } from "@codemirror/state";
-import { EditorView, GutterMarker, gutter, type ViewUpdate } from "@codemirror/view";
+import { EditorView, GutterMarker, gutter, ViewPlugin, type ViewUpdate } from "@codemirror/view";
 import { NodeSqlParser } from "./parser.js";
 import { type SqlStatement, SqlStructureAnalyzer } from "./structure-analyzer.js";
 import type { SqlParser } from "./types.js";
@@ -86,11 +86,11 @@ class SqlGutterMarker extends GutterMarker {
         opacity = "0";
       } else {
         // Default behavior when not focused - use normal opacity
-        opacity = this.isCurrent ? "1" : (this.config.inactiveOpacity || "0.3").toString();
+        opacity = this.isCurrent ? "1" : (this.config.inactiveOpacity ?? 0.3).toString();
       }
     } else {
       // Normal focused behavior
-      opacity = this.isCurrent ? "1" : (this.config.inactiveOpacity || "0.3").toString();
+      opacity = this.isCurrent ? "1" : (this.config.inactiveOpacity ?? 0.3).toString();
     }
 
     el.style.cssText = `
@@ -183,32 +183,41 @@ function createSqlGutterMarkers(
   return markers;
 }
 
-function createUpdateListener(analyzer: SqlStructureAnalyzer): Extension {
-  return EditorView.updateListener.of(async (update: ViewUpdate) => {
-    // Update on document changes, selection changes, or focus changes
-    if (!update.docChanged && !update.selectionSet && !update.focusChanged) {
-      return;
-    }
+async function analyzeAndDispatch(view: EditorView, analyzer: SqlStructureAnalyzer): Promise<void> {
+  const { state } = view;
+  const cursorPosition = state.selection.main.head;
 
-    const { state } = update.view;
-    const { main } = state.selection;
-    const cursorPosition = main.head;
+  // Analyze the document for SQL statements
+  const allStatements = await analyzer.analyzeDocument(state);
+  const currentStatement = await analyzer.getStatementAtPosition(state, cursorPosition);
 
-    // Analyze the document for SQL statements
-    const allStatements = await analyzer.analyzeDocument(state);
-    const currentStatement = await analyzer.getStatementAtPosition(state, cursorPosition);
+  const newState: SqlGutterState = {
+    currentStatement,
+    allStatements,
+    cursorPosition,
+    isFocused: view.hasFocus,
+  };
 
-    const newState: SqlGutterState = {
-      currentStatement,
-      allStatements,
-      cursorPosition,
-      isFocused: update.view.hasFocus,
+  // Dispatch the update
+  view.dispatch({
+    effects: updateSqlStatementsEffect.of(newState),
+  });
+}
+
+function createStructurePlugin(analyzer: SqlStructureAnalyzer): Extension {
+  return ViewPlugin.define((view: EditorView) => {
+    // Analyze on creation so pre-filled documents get markers immediately
+    void analyzeAndDispatch(view, analyzer);
+
+    return {
+      update(update: ViewUpdate) {
+        // Update on document changes, selection changes, or focus changes
+        if (!update.docChanged && !update.selectionSet && !update.focusChanged) {
+          return;
+        }
+        void analyzeAndDispatch(update.view, analyzer);
+      },
     };
-
-    // Dispatch the update
-    update.view.dispatch({
-      effects: updateSqlStatementsEffect.of(newState),
-    });
   });
 }
 
@@ -256,7 +265,7 @@ export function sqlStructureGutter(config: SqlGutterConfig = {}): Extension[] {
 
   return [
     sqlGutterStateField,
-    createUpdateListener(analyzer),
+    createStructurePlugin(analyzer),
     createGutterTheme(config),
     createSqlGutter(config),
   ];


### PR DESCRIPTION
- structure-analyzer: key the statement cache on document content instead of
  a lossy 32-bit hash that could collide and return another document's statements
- namespace-utils: allow tables literally named "self"; only treat objects with
  a Completion-shaped self tag and children as self-children namespaces
- hover: own-property check so Object.prototype members (constructor, toString)
  don't produce keyword tooltips; don't cache a rejected keywords promise so a
  transient fetch failure no longer permanently disables all hovers
- parser: map error columns back through bracket replacements per-line (parser
  columns are line-relative, offsets were absolute), and clamp columns to >= 1
- structure-extension: analyze on view creation so pre-filled documents show
  gutter markers without needing an edit/selection/focus change; honor an
  explicit inactiveOpacity of 0
- cte-completion-source: scan CTE bodies with balanced parentheses so CTEs
  after function calls or subqueries are completed; support column lists
  (WITH a(x, y) AS ...)
