### PR TITLE
test: improve coverage for hover, gutter, parser, and namespace utils

### DIFF
--- a/src/sql/__tests__/hover-render.test.ts
+++ b/src/sql/__tests__/hover-render.test.ts
@@ -1,0 +1,414 @@
+import type { SQLNamespace } from "@codemirror/lang-sql";
+import { EditorState } from "@codemirror/state";
+import type { EditorView } from "@codemirror/view";
+import { describe, expect, it, vi } from "vitest";
+import { DefaultSqlTooltipRenders, defaultSqlHoverTheme, exportedForTesting } from "../hover.js";
+import type { ResolvedNamespaceItem } from "../namespace-utils.js";
+
+const { createHoverSource } = exportedForTesting;
+
+// ---------------------------------------------------------------------------
+// Pure tooltip HTML builders (exposed via DefaultSqlTooltipRenders)
+// ---------------------------------------------------------------------------
+
+describe("DefaultSqlTooltipRenders.keyword", () => {
+  const render = DefaultSqlTooltipRenders.keyword;
+
+  it("renders an uppercased keyword header and description", () => {
+    const html = render({ keyword: "select", info: { description: "Selects rows" } });
+    expect(html).toContain("<strong>SELECT</strong>");
+    expect(html).toContain("keyword");
+    expect(html).toContain("Selects rows");
+  });
+
+  it("renders syntax, example, and metadata tags when present", () => {
+    const html = render({
+      keyword: "join",
+      info: {
+        description: "Combines rows",
+        syntax: "A JOIN B ON ...",
+        example: "SELECT * FROM a JOIN b",
+        metadata: { since: "SQL-92", category: "clause" },
+      },
+    });
+    expect(html).toContain("Syntax:");
+    expect(html).toContain("A JOIN B ON ...");
+    expect(html).toContain("Example:");
+    expect(html).toContain("SELECT * FROM a JOIN b");
+    expect(html).toContain('title="since"');
+    expect(html).toContain("SQL-92");
+    expect(html).toContain('title="category"');
+  });
+
+  it("omits the metadata block for empty metadata", () => {
+    const html = render({ keyword: "where", info: { description: "Filters", metadata: {} } });
+    expect(html).not.toContain("sql-hover-metadata");
+  });
+});
+
+describe("DefaultSqlTooltipRenders.table", () => {
+  const render = DefaultSqlTooltipRenders.table;
+
+  it("pluralizes the column count and lists columns", () => {
+    const html = render({ tableName: "users", columns: ["id", "name"] });
+    expect(html).toContain("<strong>users</strong>");
+    expect(html).toContain("2 columns");
+    expect(html).toContain("<code>id</code>");
+    expect(html).toContain("<code>name</code>");
+  });
+
+  it("uses singular wording for exactly one column", () => {
+    const html = render({ tableName: "t", columns: ["only"] });
+    expect(html).toContain("1 column");
+    expect(html).not.toContain("1 columns");
+  });
+
+  it("renders no column list when there are no columns", () => {
+    const html = render({ tableName: "empty", columns: [] });
+    expect(html).toContain("0 columns");
+    expect(html).not.toContain("sql-hover-columns");
+  });
+
+  it("truncates when there are more than 10 columns", () => {
+    const columns = Array.from({ length: 13 }, (_, i) => `c${i}`);
+    const html = render({ tableName: "wide", columns });
+    expect(html).toContain("and 3 more");
+    expect(html).toContain("<code>c9</code>");
+    expect(html).not.toContain("<code>c10</code>");
+  });
+
+  it("renders metadata tags", () => {
+    const html = render({ tableName: "t", columns: ["a"], metadata: { rows: "100" } });
+    expect(html).toContain('title="rows"');
+    expect(html).toContain("100");
+  });
+});
+
+describe("DefaultSqlTooltipRenders.column", () => {
+  const render = DefaultSqlTooltipRenders.column;
+
+  it("lists other columns in the same table", () => {
+    const html = render({
+      tableName: "users",
+      columnName: "id",
+      schema: { users: ["id", "name", "email"] },
+    });
+    expect(html).toContain("<strong>id</strong>");
+    expect(html).toContain("Column in table <code>users</code>");
+    expect(html).toContain("Other columns in users");
+    expect(html).toContain("<code>name</code>");
+    expect(html).toContain("<code>email</code>");
+    // "id" itself is filtered from the related list (it only appears in the header)
+    expect(html).not.toContain("<code>id</code>");
+  });
+
+  it("truncates the related columns list beyond 8", () => {
+    const cols = ["target", ...Array.from({ length: 12 }, (_, i) => `o${i}`)];
+    const html = render({ tableName: "t", columnName: "target", schema: { t: cols } });
+    expect(html).toContain("and 4 more");
+  });
+
+  it("omits the related section when the table is unknown", () => {
+    const html = render({ tableName: "ghost", columnName: "x", schema: {} });
+    expect(html).not.toContain("Other columns");
+  });
+
+  it("omits the related section when the table has a single column", () => {
+    const html = render({ tableName: "t", columnName: "only", schema: { t: ["only"] } });
+    expect(html).not.toContain("Other columns");
+  });
+
+  it("renders metadata tags", () => {
+    const html = render({
+      tableName: "t",
+      columnName: "a",
+      schema: { t: ["a", "b"] },
+      metadata: { type: "int" },
+    });
+    expect(html).toContain('title="type"');
+    expect(html).toContain("int");
+  });
+});
+
+describe("DefaultSqlTooltipRenders.namespace", () => {
+  const render = DefaultSqlTooltipRenders.namespace;
+
+  it("renders a database with schema count and detail", () => {
+    const item: ResolvedNamespaceItem = {
+      path: ["mydb"],
+      type: "completion",
+      semanticType: "database",
+      completion: { label: "mydb", detail: "primary db" },
+      namespace: { public: { users: ["id"] }, private: { secrets: ["k"] } },
+    };
+    const html = render(item);
+    expect(html).toContain("<strong>mydb</strong>");
+    expect(html).toContain("database");
+    expect(html).toContain("Database: primary db");
+    expect(html).toContain("Contains 2 schemas");
+  });
+
+  it("uses singular schema wording and no detail when absent", () => {
+    const item: ResolvedNamespaceItem = {
+      path: ["db"],
+      type: "namespace",
+      semanticType: "database",
+      namespace: { public: { users: ["id"] } },
+    };
+    const html = render(item);
+    expect(html).toContain("Contains 1 schema");
+    expect(html).not.toContain("1 schemas");
+    expect(html).toContain("Database</div>");
+  });
+
+  it("counts self/children namespaces as children", () => {
+    const item: ResolvedNamespaceItem = {
+      path: ["db"],
+      type: "namespace",
+      semanticType: "database",
+      // self/children counts as 1 + children length (2) = 3
+      namespace: { self: { label: "t" }, children: ["a", "b"] } as SQLNamespace,
+    };
+    const html = render(item);
+    expect(html).toContain("Contains 3 schemas");
+  });
+
+  it("renders a schema with path and table count", () => {
+    const item: ResolvedNamespaceItem = {
+      path: ["mydb", "public"],
+      type: "namespace",
+      semanticType: "schema",
+      namespace: { users: ["id"], orders: ["id"] },
+    };
+    const html = render(item);
+    expect(html).toContain("Schema");
+    expect(html).toContain("<code>mydb.public</code>");
+    expect(html).toContain("Contains 2 tables");
+  });
+
+  it("renders a table with columns, truncation, and schema path", () => {
+    const columns = [{ label: "id" }, "name", ...Array.from({ length: 8 }, (_, i) => `c${i}`)];
+    const item: ResolvedNamespaceItem = {
+      path: ["mydb", "public", "users"],
+      type: "namespace",
+      semanticType: "table",
+      namespace: columns as SQLNamespace,
+    };
+    const html = render(item);
+    expect(html).toContain("<strong>users</strong>"); // name falls back to last path segment
+    expect(html).toContain("Columns (10)");
+    expect(html).toContain("<code>id</code>");
+    expect(html).toContain("and 2 more");
+    expect(html).toContain("Schema:</strong> <code>mydb.public</code>");
+  });
+
+  it("renders a column with its table path and completion info", () => {
+    const item: ResolvedNamespaceItem = {
+      path: ["users", "email"],
+      type: "completion",
+      semanticType: "column",
+      completion: { label: "email", detail: "user email", info: "the primary contact" },
+    };
+    const html = render(item);
+    expect(html).toContain("<strong>email</strong>");
+    expect(html).toContain("Column: user email");
+    expect(html).toContain("Table:</strong> <code>users</code>");
+    expect(html).toContain("the primary contact");
+  });
+
+  it("falls back to the string value for the name when no completion", () => {
+    const item: ResolvedNamespaceItem = {
+      path: ["users", "created_at"],
+      type: "string",
+      semanticType: "column",
+      value: "created_at",
+    };
+    const html = render(item);
+    expect(html).toContain("<strong>created_at</strong>");
+  });
+
+  it("renders the default namespace branch with an item count", () => {
+    const item: ResolvedNamespaceItem = {
+      path: ["misc"],
+      type: "namespace",
+      semanticType: "namespace",
+      namespace: ["a", "b", "c"] as SQLNamespace,
+    };
+    const html = render(item);
+    expect(html).toContain("Namespace");
+    expect(html).toContain("Contains 3 items");
+  });
+
+  it("falls back to 'unknown' when there is no name source", () => {
+    const item: ResolvedNamespaceItem = {
+      path: [],
+      type: "namespace",
+      semanticType: "namespace",
+    };
+    const html = render(item);
+    expect(html).toContain("<strong>unknown</strong>");
+  });
+});
+
+describe("defaultSqlHoverTheme", () => {
+  it("builds a light theme by default", () => {
+    expect(defaultSqlHoverTheme()).toBeDefined();
+    expect(defaultSqlHoverTheme("light")).toBeDefined();
+  });
+
+  it("builds a dark theme when requested", () => {
+    expect(defaultSqlHoverTheme("dark")).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Hover source `create` path (produces the tooltip DOM)
+// ---------------------------------------------------------------------------
+
+describe("hover source tooltip DOM creation", () => {
+  function mockView(doc: string): EditorView {
+    const state = EditorState.create({ doc });
+    return { state } as unknown as EditorView;
+  }
+
+  const schema: SQLNamespace = {
+    users: ["id", "username", "email"],
+    orders: ["id", "total"],
+  };
+
+  async function hoverWord(
+    doc: string,
+    word: string,
+    config: Parameters<typeof createHoverSource>[0] = {},
+    side = 1,
+  ) {
+    const source = createHoverSource({ schema, ...config });
+    const view = mockView(doc);
+    const pos = doc.indexOf(word) + 2;
+    const tooltip = await source(view, pos, side);
+    return { tooltip, view };
+  }
+
+  it("renders a default table tooltip DOM when hovering a table", async () => {
+    const { tooltip, view } = await hoverWord("SELECT id FROM users", "users");
+    expect(tooltip).not.toBeNull();
+    const { dom } = tooltip!.create(view);
+    expect(dom.className).toBe("cm-sql-hover-tooltip");
+    expect(dom.innerHTML).toContain("users");
+    expect(dom.innerHTML).toContain("table");
+  });
+
+  it("renders a default column tooltip DOM when hovering a column", async () => {
+    const { tooltip, view } = await hoverWord("SELECT username FROM users", "username");
+    expect(tooltip).not.toBeNull();
+    const { dom } = tooltip!.create(view);
+    expect(dom.innerHTML).toContain("username");
+    expect(dom.innerHTML).toContain("column");
+  });
+
+  it("renders a default keyword tooltip DOM", async () => {
+    const { tooltip, view } = await hoverWord("SELECT id FROM users", "SELECT", {
+      keywords: { select: { description: "Selects rows" } },
+    });
+    expect(tooltip).not.toBeNull();
+    const { dom } = tooltip!.create(view);
+    expect(dom.innerHTML).toContain("SELECT");
+    expect(dom.innerHTML).toContain("Selects rows");
+  });
+
+  it("uses a custom tooltipRender when it returns an element", async () => {
+    const custom = document.createElement("span");
+    custom.textContent = "custom!";
+    const { tooltip, view } = await hoverWord("SELECT id FROM users", "users", {
+      tooltipRender: () => custom,
+    });
+    const { dom } = tooltip!.create(view);
+    expect(dom).toBe(custom);
+  });
+
+  it("falls back to the default renderer when tooltipRender returns null", async () => {
+    const { tooltip, view } = await hoverWord("SELECT id FROM users", "users", {
+      tooltipRender: () => null,
+    });
+    const { dom } = tooltip!.create(view);
+    expect(dom.className).toBe("cm-sql-hover-tooltip");
+    expect(dom.innerHTML).toContain("users");
+  });
+
+  it("uses a custom table renderer for table items", async () => {
+    const table = vi.fn().mockReturnValue("<div>custom table</div>");
+    const { tooltip, view } = await hoverWord("SELECT id FROM users", "users", {
+      tooltipRenderers: { table },
+    });
+    const { dom } = tooltip!.create(view);
+    expect(table).toHaveBeenCalledOnce();
+    expect(dom.innerHTML).toContain("custom table");
+  });
+
+  it("uses a custom column renderer for column items", async () => {
+    const column = vi.fn().mockReturnValue("<div>custom column</div>");
+    const { tooltip, view } = await hoverWord("SELECT username FROM users", "username", {
+      tooltipRenderers: { column },
+    });
+    const { dom } = tooltip!.create(view);
+    expect(column).toHaveBeenCalledOnce();
+    expect(dom.innerHTML).toContain("custom column");
+  });
+
+  it("uses a custom keyword renderer for keyword items", async () => {
+    const keyword = vi.fn().mockReturnValue("<div>custom keyword</div>");
+    const { tooltip, view } = await hoverWord("SELECT id FROM users", "SELECT", {
+      keywords: { select: { description: "Selects rows" } },
+      tooltipRenderers: { keyword },
+    });
+    const { dom } = tooltip!.create(view);
+    expect(keyword).toHaveBeenCalledOnce();
+    expect(dom.innerHTML).toContain("custom keyword");
+  });
+
+  it("returns an empty div when a custom renderer yields no content", async () => {
+    const { tooltip, view } = await hoverWord("SELECT id FROM users", "users", {
+      tooltipRenderers: { table: () => "" },
+    });
+    const { dom } = tooltip!.create(view);
+    expect(dom.className).toBe("");
+    expect(dom.innerHTML).toBe("");
+  });
+
+  it("returns null when the pointer sits just before a word (side < 0)", async () => {
+    const source = createHoverSource({ schema });
+    const doc = "SELECT id FROM users";
+    const view = mockView(doc);
+    const tooltip = await source(view, doc.indexOf("users"), -1);
+    expect(tooltip).toBeNull();
+  });
+
+  it("falls back to the full schema when the query has no parseable tables", async () => {
+    // "users" alone is not a valid query, so no table refs are extracted;
+    // the resolver must fall back to the full schema to still show the table.
+    const { tooltip, view } = await hoverWord("users", "users");
+    expect(tooltip).not.toBeNull();
+    const { dom } = tooltip!.create(view);
+    expect(dom.innerHTML).toContain("users");
+  });
+
+  it("returns null when nothing matches", async () => {
+    const source = createHoverSource({ schema, keywords: {} });
+    const doc = "SELECT zzz FROM users";
+    const view = mockView(doc);
+    const tooltip = await source(view, doc.indexOf("zzz") + 1, 1);
+    expect(tooltip).toBeNull();
+  });
+
+  it("respects enableKeywords: false", async () => {
+    const source = createHoverSource({
+      schema: {},
+      keywords: { select: { description: "Selects rows" } },
+      enableKeywords: false,
+    });
+    const doc = "SELECT id FROM users";
+    const view = mockView(doc);
+    const tooltip = await source(view, doc.indexOf("SELECT") + 2, 1);
+    expect(tooltip).toBeNull();
+  });
+});

--- a/src/sql/__tests__/namespace-utils.test.ts
+++ b/src/sql/__tests__/namespace-utils.test.ts
@@ -266,6 +266,23 @@ describe("findNamespaceCompletions", () => {
     });
   });
 
+  describe("self label matching at the root", () => {
+    it("should match the self completion of a root self/children namespace by prefix", () => {
+      // "database" is the self label of the selfChildren namespace.
+      const results = findNamespaceCompletions(mockNamespaces.selfChildren, "data");
+      const selfMatch = results.find((r) => r.completion?.label === "database");
+      expect(selfMatch).toBeTruthy();
+      expect(selfMatch?.type).toBe("completion");
+    });
+
+    it("should match the self completion exactly when partial matching is disabled", () => {
+      const results = findNamespaceCompletions(mockNamespaces.selfChildren, "database", {
+        allowPartialMatch: false,
+      });
+      expect(results.some((r) => r.completion?.label === "database")).toBe(true);
+    });
+  });
+
   describe("array namespace completions", () => {
     it("should find string completions in arrays", () => {
       const results = findNamespaceCompletions(mockNamespaces.arrayNamespace, "");
@@ -353,6 +370,28 @@ describe("findNamespaceItemByEndMatch", () => {
 
   it("should return empty array for non-existent identifiers", () => {
     const results = findNamespaceItemByEndMatch(mockNamespaces.complexNested, "nonexistent");
+    expect(results).toEqual([]);
+  });
+
+  it("should collect items from a root-level self/children namespace", () => {
+    // The root of selfChildren is itself a { self, children } node, exercising the
+    // self/children branch of collectAllItems.
+    const results = findNamespaceItemByEndMatch(mockNamespaces.selfChildren, "public");
+    expect(results.length).toBeGreaterThanOrEqual(1);
+    expect(results.some((r) => r.path[r.path.length - 1] === "public")).toBe(true);
+  });
+
+  it("should find array columns nested under a root self/children namespace", () => {
+    const results = findNamespaceItemByEndMatch(mockNamespaces.selfChildren, "api_key");
+    expect(results.some((r) => r.value === "api_key")).toBe(true);
+  });
+
+  it("should stop collecting once maxDepth is reached", () => {
+    // With maxDepth 1, only depth-0 keys (postgres, mysql) are collected, so a deep
+    // column like "id" is never reached.
+    const results = findNamespaceItemByEndMatch(mockNamespaces.complexNested, "id", {
+      maxDepth: 1,
+    });
     expect(results).toEqual([]);
   });
 });

--- a/src/sql/__tests__/parser.test.ts
+++ b/src/sql/__tests__/parser.test.ts
@@ -91,6 +91,37 @@ describe("SqlParser", () => {
     });
   });
 
+  describe("extractColumnReferences", () => {
+    it("extracts column references from a SELECT query", async () => {
+      const columns = await parser.extractColumnReferences("SELECT id, name FROM users");
+      expect(columns).toContain("id");
+      expect(columns).toContain("name");
+    });
+
+    it("strips the node-sql-parser prefixes from column names", async () => {
+      const columns = await parser.extractColumnReferences(
+        "SELECT u.email FROM users u WHERE u.active = true",
+      );
+      // Names are cleaned of the "type::table::column" prefixing
+      expect(columns.every((col) => !col.includes("::"))).toBe(true);
+      expect(columns).toContain("email");
+    });
+
+    it("returns an empty array for invalid SQL", async () => {
+      const columns = await parser.extractColumnReferences("NOT VALID SQL");
+      expect(columns).toEqual([]);
+    });
+
+    it("passes parser options through when a state is provided", async () => {
+      const getParserOptions = vi.fn().mockReturnValue({ database: "PostgreSQL" });
+      const customParser = new NodeSqlParser({ getParserOptions });
+      const columnState = EditorState.create({ doc: "SELECT id FROM users" });
+
+      await customParser.extractColumnReferences("SELECT id FROM users", { state: columnState });
+      expect(getParserOptions).toHaveBeenCalledWith(columnState);
+    });
+  });
+
   describe("validateSql", () => {
     it("should return empty array for valid SQL", async () => {
       const sql = "SELECT 1";

--- a/src/sql/__tests__/structure-extension.test.ts
+++ b/src/sql/__tests__/structure-extension.test.ts
@@ -1,7 +1,7 @@
 import { EditorState, Text } from "@codemirror/state";
 import { EditorView } from "@codemirror/view";
 import { describe, expect, it } from "vitest";
-import { sqlStructureGutter } from "../structure-extension.js";
+import { computeMarkerStyle, sqlStructureGutter } from "../structure-extension.js";
 
 async function waitFor(condition: () => boolean, timeoutMs = 3000): Promise<void> {
   const start = Date.now();
@@ -32,6 +32,95 @@ const _createMockView = (content: string, hasFocus = true) => {
     dispatch: () => {},
   } as EditorView;
 };
+
+describe("computeMarkerStyle", () => {
+  const focused = { isCurrent: false, isValid: true, isFocused: true };
+
+  describe("background color", () => {
+    it("uses the default blue for valid statements", () => {
+      expect(computeMarkerStyle({}, focused).backgroundColor).toBe("#3b82f6");
+    });
+
+    it("honors a custom backgroundColor", () => {
+      expect(computeMarkerStyle({ backgroundColor: "#123456" }, focused).backgroundColor).toBe(
+        "#123456",
+      );
+    });
+
+    it("uses the default red for invalid statements", () => {
+      expect(
+        computeMarkerStyle({}, { isCurrent: false, isValid: false, isFocused: true })
+          .backgroundColor,
+      ).toBe("#ef4444");
+    });
+
+    it("honors a custom errorBackgroundColor for invalid statements", () => {
+      expect(
+        computeMarkerStyle(
+          { errorBackgroundColor: "#abcdef" },
+          { isCurrent: false, isValid: false, isFocused: true },
+        ).backgroundColor,
+      ).toBe("#abcdef");
+    });
+
+    it("does not use the error color when showInvalid is false", () => {
+      expect(
+        computeMarkerStyle(
+          { showInvalid: false },
+          { isCurrent: false, isValid: false, isFocused: true },
+        ).backgroundColor,
+      ).toBe("#3b82f6");
+    });
+  });
+
+  describe("opacity when focused", () => {
+    it("is fully opaque for the current statement", () => {
+      expect(
+        computeMarkerStyle({}, { isCurrent: true, isValid: true, isFocused: true }).opacity,
+      ).toBe("1");
+    });
+
+    it("defaults to 0.3 for non-current statements", () => {
+      expect(computeMarkerStyle({}, focused).opacity).toBe("0.3");
+    });
+
+    it("honors a custom inactiveOpacity", () => {
+      expect(computeMarkerStyle({ inactiveOpacity: 0.5 }, focused).opacity).toBe("0.5");
+    });
+
+    it("honors an explicit inactiveOpacity of 0", () => {
+      expect(computeMarkerStyle({ inactiveOpacity: 0 }, focused).opacity).toBe("0");
+    });
+  });
+
+  describe("opacity when not focused", () => {
+    const unfocused = { isCurrent: false, isValid: true, isFocused: false };
+
+    it("uses unfocusedOpacity when provided", () => {
+      expect(computeMarkerStyle({ unfocusedOpacity: 0.2 }, unfocused).opacity).toBe("0.2");
+    });
+
+    it("prefers unfocusedOpacity over hideWhenNotFocused", () => {
+      expect(
+        computeMarkerStyle(
+          { unfocusedOpacity: 0.4, hideWhenNotFocused: true },
+          unfocused,
+        ).opacity,
+      ).toBe("0.4");
+    });
+
+    it("hides the marker when hideWhenNotFocused is set", () => {
+      expect(computeMarkerStyle({ hideWhenNotFocused: true }, unfocused).opacity).toBe("0");
+    });
+
+    it("falls back to normal opacity when neither unfocused option is set", () => {
+      expect(computeMarkerStyle({}, unfocused).opacity).toBe("0.3");
+      expect(
+        computeMarkerStyle({}, { isCurrent: true, isValid: true, isFocused: false }).opacity,
+      ).toBe("1");
+    });
+  });
+});
 
 describe("sqlStructureGutter", () => {
   it("should create a gutter extension with default config", () => {

--- a/src/sql/structure-extension.ts
+++ b/src/sql/structure-extension.ts
@@ -57,6 +57,45 @@ const sqlGutterStateField = StateField.define<SqlGutterState>({
   },
 });
 
+/**
+ * Computes the background color and opacity for a gutter marker based on its
+ * state and config. Extracted as a pure function so the (many) branches can be
+ * unit-tested without constructing an EditorView.
+ */
+export function computeMarkerStyle(
+  config: SqlGutterConfig,
+  state: { isCurrent: boolean; isValid: boolean; isFocused: boolean },
+): { backgroundColor: string; opacity: string } {
+  const { isCurrent, isValid, isFocused } = state;
+
+  // Set background color based on state
+  let backgroundColor = config.backgroundColor || "#3b82f6";
+  if (!isValid && config.showInvalid !== false) {
+    backgroundColor = config.errorBackgroundColor || "#ef4444";
+  }
+
+  // Opacity for the "normal" (focused, or focus-agnostic) case
+  const normalOpacity = isCurrent ? "1" : (config.inactiveOpacity ?? 0.3).toString();
+
+  // Calculate opacity based on focus state
+  let opacity: string;
+  if (!isFocused) {
+    if (config.unfocusedOpacity !== undefined) {
+      opacity = config.unfocusedOpacity.toString();
+    } else if (config.hideWhenNotFocused) {
+      opacity = "0";
+    } else {
+      // Default behavior when not focused - use normal opacity
+      opacity = normalOpacity;
+    }
+  } else {
+    // Normal focused behavior
+    opacity = normalOpacity;
+  }
+
+  return { backgroundColor, opacity };
+}
+
 class SqlGutterMarker extends GutterMarker {
   constructor(
     private config: SqlGutterConfig,
@@ -71,27 +110,11 @@ class SqlGutterMarker extends GutterMarker {
     const el = document.createElement("div");
     el.className = "cm-sql-gutter-marker";
 
-    // Set background color based on state
-    let backgroundColor = this.config.backgroundColor || "#3b82f6";
-    if (!this.isValid && this.config.showInvalid !== false) {
-      backgroundColor = this.config.errorBackgroundColor || "#ef4444";
-    }
-
-    // Calculate opacity based on focus state
-    let opacity: string;
-    if (!this.isFocused) {
-      if (this.config.unfocusedOpacity !== undefined) {
-        opacity = this.config.unfocusedOpacity.toString();
-      } else if (this.config.hideWhenNotFocused) {
-        opacity = "0";
-      } else {
-        // Default behavior when not focused - use normal opacity
-        opacity = this.isCurrent ? "1" : (this.config.inactiveOpacity ?? 0.3).toString();
-      }
-    } else {
-      // Normal focused behavior
-      opacity = this.isCurrent ? "1" : (this.config.inactiveOpacity ?? 0.3).toString();
-    }
+    const { backgroundColor, opacity } = computeMarkerStyle(this.config, {
+      isCurrent: this.isCurrent,
+      isValid: this.isValid,
+      isFocused: this.isFocused,
+    });
 
     el.style.cssText = `
       background: ${backgroundColor};


### PR DESCRIPTION
Raise line coverage 73% -> 93% and branch coverage 63% -> 83%.

- Extract computeMarkerStyle from SqlGutterMarker.toDOM so the marker
  color/opacity branches can be unit-tested without an EditorView
- Add hover-render tests covering the tooltip HTML builders and the
  tooltip create() path (hover.ts 30% -> 97%)
- Add extractColumnReferences tests for the parser
- Cover remaining namespace-utils branches (root self/children
  traversal, maxDepth cutoff, self-label matching)
