### PR TITLE
feat: schema-aware semantic diagnostics (unknown tables/columns, ambiguous columns)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A CodeMirror extension for SQL linting and visual gutter indicators. Built by an
 ## Features
 
 - ⚡ **Real-time validation** - Per-statement SQL syntax checking as you type, with detailed error messages for every broken statement
+- 🧠 **Schema-aware linting** - Warns about unknown tables, unknown columns, and ambiguous column references based on your schema
 - 🎨 **Visual gutter** - Color-coded statement indicators and error highlighting
 - 💡 **Hover tooltips** - Schema info, keywords, and column details on hover
 - 🔮 **CTE autocomplete** - Auto-complete support for CTEs
@@ -47,6 +48,8 @@ const editor = new EditorView({
       autocomplete: cteCompletionSource,
     }),
     sqlExtension({
+      // Shared by hover tooltips and semantic linting
+      schema: schema,
       linterConfig: {
         delay: 250, // Validation delay in ms
       },
@@ -57,7 +60,6 @@ const editor = new EditorView({
       },
       enableHover: true,
       hoverConfig: {
-        schema: schema,
         hoverTime: 300,
         enableKeywords: true,
         enableTables: true,
@@ -68,6 +70,34 @@ const editor = new EditorView({
   parent: document.querySelector("#editor"),
 });
 ```
+
+### Schema-aware semantic linting
+
+When a schema is provided (via the top-level `schema` option, the
+`sqlSchemaFacet`, or `semanticLinterConfig.schema`), queries are validated
+against it: unknown tables, unknown columns, and ambiguous column references
+are reported as warnings (configurable per check). Without a schema the
+semantic linter is inert.
+
+```ts
+import { sqlSemanticLinter } from "@marimo-team/codemirror-sql";
+
+sqlSemanticLinter({
+  schema: { users: ["id", "name"], posts: ["id", "user_id"] },
+  severity: {
+    unknownTable: "error", // "error" | "warning" | "off" (default: "warning")
+    unknownColumn: "warning",
+    ambiguousColumn: "warning",
+  },
+});
+```
+
+Checks only run on statements that parse cleanly, and skip anything that
+can't be confidently resolved (CTE outputs, subquery results, aliases from
+outer scopes), preferring under-reporting over false positives. Semantic
+diagnostics carry `source: "sql-schema"`; syntax diagnostics use
+`source: "sql-parser"`. If the schema is provided as a function, it is called
+on every lint pass and should be cheap/memoized.
 
 ## Additional Dialects
 

--- a/README.md
+++ b/README.md
@@ -80,15 +80,21 @@ are reported as warnings (configurable per check). Without a schema the
 semantic linter is inert.
 
 ```ts
+import { EditorView } from "codemirror";
 import { sqlSemanticLinter } from "@marimo-team/codemirror-sql";
 
-sqlSemanticLinter({
-  schema: { users: ["id", "name"], posts: ["id", "user_id"] },
-  severity: {
-    unknownTable: "error", // "error" | "warning" | "off" (default: "warning")
-    unknownColumn: "warning",
-    ambiguousColumn: "warning",
-  },
+const editor = new EditorView({
+  extensions: [
+    sqlSemanticLinter({
+      schema: { users: ["id", "name"], posts: ["id", "user_id"] },
+      severity: {
+        unknownTable: "error", // "error" | "warning" | "off" (default: "warning")
+        unknownColumn: "warning",
+        ambiguousColumn: "warning",
+      },
+    }),
+  ],
+  parent: document.querySelector("#editor"),
 });
 ```
 

--- a/_typos.toml
+++ b/_typos.toml
@@ -7,4 +7,6 @@ extend-exclude = [
   "src/data/duckdb-keywords.json",
   # Contains intentionally misspelled SQL (e.g. SELCT) to trigger parse errors
   "src/sql/__tests__/diagnostics.test.ts",
+  # Contains intentionally misspelled identifiers (e.g. usres) to trigger schema diagnostics
+  "src/sql/__tests__/semantic-diagnostics.test.ts",
 ]

--- a/demo/index.ts
+++ b/demo/index.ts
@@ -134,9 +134,16 @@ function initializeEditor() {
     databaseField,
     baseSqlCompartment.of(baseSqlExtension(defaultDialect)),
     sqlExtension({
+      // Shared schema for hover tooltips and schema-aware linting
+      schema: schema,
       // Linter extension configuration
       linterConfig: {
         delay: 250, // Delay before running validation
+        parser,
+      },
+      // Schema-aware linting (unknown tables/columns, ambiguous columns)
+      semanticLinterConfig: {
+        delay: 250,
         parser,
       },
 

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -14,9 +14,12 @@ describe("index.ts exports", () => {
         "SqlStructureAnalyzer",
         "cteCompletionSource",
         "defaultSqlHoverTheme",
+        "resolveSqlSchema",
         "sqlExtension",
         "sqlHover",
         "sqlLinter",
+        "sqlSchemaFacet",
+        "sqlSemanticLinter",
         "sqlStructureGutter",
       ]
     `);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 export { cteCompletionSource } from "./sql/cte-completion-source.js";
 export { type SqlLinterConfig, sqlLinter } from "./sql/diagnostics.js";
-export { sqlExtension } from "./sql/extension.js";
+export { type SqlExtensionConfig, sqlExtension } from "./sql/extension.js";
 export type {
   KeywordTooltipData,
   NamespaceTooltipData,
@@ -15,6 +15,12 @@ export {
   type ParserOption,
   type SupportedDialects,
 } from "./sql/parser.js";
+export { resolveSqlSchema, type SqlSchemaSource, sqlSchemaFacet } from "./sql/schema-facet.js";
+export {
+  type SemanticSeverity,
+  type SqlSemanticLinterConfig,
+  sqlSemanticLinter,
+} from "./sql/semantic-diagnostics.js";
 export type { SqlStatement } from "./sql/structure-analyzer.js";
 export { SqlStructureAnalyzer } from "./sql/structure-analyzer.js";
 export type { SqlGutterConfig } from "./sql/structure-extension.js";

--- a/src/sql/__tests__/extension.test.ts
+++ b/src/sql/__tests__/extension.test.ts
@@ -35,10 +35,22 @@ describe("sqlExtension", () => {
   it("should handle all features disabled", () => {
     const extensions = sqlExtension({
       enableLinting: false,
+      enableSemanticLinting: false,
       enableGutterMarkers: false,
       enableHover: false,
     });
     expect(extensions).toEqual([]);
+  });
+
+  it("should register the shared schema facet when a schema is provided", () => {
+    const withSchema = sqlExtension({
+      schema: { users: ["id"] },
+      enableLinting: false,
+      enableSemanticLinting: false,
+      enableGutterMarkers: false,
+      enableHover: false,
+    });
+    expect(withSchema).toHaveLength(1);
   });
 
   it("should pass config objects to individual extensions", () => {

--- a/src/sql/__tests__/extension.test.ts
+++ b/src/sql/__tests__/extension.test.ts
@@ -1,5 +1,7 @@
+import { EditorState } from "@codemirror/state";
 import { describe, expect, it } from "vitest";
 import { sqlExtension } from "../extension.js";
+import { sqlSchemaFacet } from "../schema-facet.js";
 
 describe("sqlExtension", () => {
   it("should return an array of extensions with default config", () => {
@@ -43,14 +45,27 @@ describe("sqlExtension", () => {
   });
 
   it("should register the shared schema facet when a schema is provided", () => {
+    const schema = { users: ["id"] };
     const withSchema = sqlExtension({
-      schema: { users: ["id"] },
+      schema,
       enableLinting: false,
       enableSemanticLinting: false,
       enableGutterMarkers: false,
       enableHover: false,
     });
     expect(withSchema).toHaveLength(1);
+
+    const state = EditorState.create({ extensions: withSchema });
+    expect(state.facet(sqlSchemaFacet)).toBe(schema);
+
+    const withoutSchema = sqlExtension({
+      enableLinting: false,
+      enableSemanticLinting: false,
+      enableGutterMarkers: false,
+      enableHover: false,
+    });
+    const emptyState = EditorState.create({ extensions: withoutSchema });
+    expect(emptyState.facet(sqlSchemaFacet)).toBeNull();
   });
 
   it("should pass config objects to individual extensions", () => {

--- a/src/sql/__tests__/semantic-diagnostics.test.ts
+++ b/src/sql/__tests__/semantic-diagnostics.test.ts
@@ -1,0 +1,333 @@
+import { EditorState, type Extension } from "@codemirror/state";
+import type { EditorView } from "@codemirror/view";
+import { describe, expect, it, vi } from "vitest";
+import { sqlSchemaFacet } from "../schema-facet.js";
+import {
+  exportedForTesting,
+  type SqlSemanticLinterConfig,
+  sqlSemanticLinter,
+} from "../semantic-diagnostics.js";
+import type { SqlParser } from "../types.js";
+
+const { createSemanticLintSource } = exportedForTesting;
+
+const SCHEMA = {
+  users: ["id", "name", "email"],
+  posts: ["id", "user_id", "title"],
+};
+
+const createMockView = (content: string, extensions: Extension[] = []) => {
+  return {
+    state: EditorState.create({ doc: content, extensions }),
+  } as EditorView;
+};
+
+const lint = (content: string, config: SqlSemanticLinterConfig = {}, extensions: Extension[] = []) => {
+  return createSemanticLintSource(config)(createMockView(content, extensions));
+};
+
+describe("sqlSemanticLinter", () => {
+  it("should create a linter extension", () => {
+    expect(sqlSemanticLinter()).toBeDefined();
+    expect(sqlSemanticLinter({ schema: SCHEMA, delay: 100 })).toBeDefined();
+  });
+});
+
+describe("unknown tables", () => {
+  it("flags a table missing from the schema", async () => {
+    const doc = "SELECT * FROM usres";
+    const diagnostics = await lint(doc, { schema: SCHEMA });
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].message).toContain("usres");
+    expect(diagnostics[0].severity).toBe("warning");
+    expect(diagnostics[0].source).toBe("sql-schema");
+    // Positioned on the identifier itself
+    expect(doc.slice(diagnostics[0].from, diagnostics[0].to)).toBe("usres");
+  });
+
+  it("does not flag known tables", async () => {
+    expect(await lint("SELECT * FROM users", { schema: SCHEMA })).toEqual([]);
+  });
+
+  it("is case-insensitive", async () => {
+    expect(await lint("SELECT * FROM USERS", { schema: SCHEMA })).toEqual([]);
+  });
+
+  it("resolves qualified names through nested namespaces", async () => {
+    const nested = { mydb: { users: ["id", "name"] } };
+    expect(await lint("SELECT * FROM mydb.users", { schema: nested })).toEqual([]);
+
+    const diagnostics = await lint("SELECT * FROM mydb.usres", { schema: nested });
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].message).toContain("mydb.usres");
+  });
+
+  it("does not flag unqualified references to tables nested deeper in the schema", async () => {
+    const nested = { mydb: { users: ["id", "name"] } };
+    expect(await lint("SELECT * FROM users", { schema: nested })).toEqual([]);
+  });
+
+  it("does not flag CTE names", async () => {
+    const doc = "WITH t AS (SELECT id FROM users) SELECT * FROM t";
+    expect(await lint(doc, { schema: SCHEMA })).toEqual([]);
+  });
+
+  it("flags unknown tables inside CTE bodies", async () => {
+    const doc = "WITH t AS (SELECT id FROM usres) SELECT * FROM t";
+    const diagnostics = await lint(doc, { schema: SCHEMA });
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].message).toContain("usres");
+  });
+
+  it("does not flag CREATE TABLE targets but flags their source tables", async () => {
+    expect(await lint("CREATE TABLE newtbl (id int)", { schema: SCHEMA })).toEqual([]);
+
+    const diagnostics = await lint("CREATE TABLE newtbl AS SELECT * FROM usres", {
+      schema: SCHEMA,
+    });
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].message).toContain("usres");
+  });
+
+  it("flags unknown DML targets", async () => {
+    expect(
+      await lint("INSERT INTO usres (id) VALUES (1)", { schema: SCHEMA }),
+    ).toHaveLength(1);
+    expect(await lint("UPDATE usres SET id = 1", { schema: SCHEMA })).toHaveLength(1);
+    expect(await lint("DELETE FROM usres WHERE id = 1", { schema: SCHEMA })).toHaveLength(1);
+    expect(await lint("INSERT INTO users (id) VALUES (1)", { schema: SCHEMA })).toEqual([]);
+  });
+
+  it("flags unknown tables in subqueries", async () => {
+    const diagnostics = await lint("SELECT * FROM users WHERE id IN (SELECT user_id FROM psts)", {
+      schema: SCHEMA,
+    });
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].message).toContain("psts");
+  });
+});
+
+describe("unknown columns", () => {
+  it("flags a column missing from the referenced table", async () => {
+    const doc = "SELECT nme FROM users";
+    const diagnostics = await lint(doc, { schema: SCHEMA });
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].message).toContain("nme");
+    expect(diagnostics[0].message).toContain("users");
+    expect(doc.slice(diagnostics[0].from, diagnostics[0].to)).toBe("nme");
+  });
+
+  it("does not flag known columns, *, or case variants", async () => {
+    expect(await lint("SELECT id, NAME, * FROM users", { schema: SCHEMA })).toEqual([]);
+  });
+
+  it("resolves alias-qualified references", async () => {
+    expect(await lint("SELECT u.name FROM users u", { schema: SCHEMA })).toEqual([]);
+
+    const diagnostics = await lint("SELECT u.nme FROM users u", { schema: SCHEMA });
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].message).toContain("nme");
+  });
+
+  it("checks table-qualified references across joins", async () => {
+    const doc = "SELECT users.name, posts.title FROM users JOIN posts ON posts.user_id = users.id";
+    expect(await lint(doc, { schema: SCHEMA })).toEqual([]);
+
+    const bad = "SELECT users.nme FROM users JOIN posts ON posts.user_id = users.id";
+    expect(await lint(bad, { schema: SCHEMA })).toHaveLength(1);
+  });
+
+  it("skips qualifiers that do not resolve to a scope source", async () => {
+    // `x` might be an outer alias or something we can't resolve — never guess
+    expect(await lint("SELECT x.nme FROM users u", { schema: SCHEMA })).toEqual([]);
+  });
+
+  it("skips unqualified columns when multiple tables are referenced", async () => {
+    // `title` only exists in posts, but we only check unqualified columns
+    // against single-table statements
+    expect(await lint("SELECT missing_col FROM users, posts", { schema: SCHEMA })).toEqual([]);
+  });
+
+  it("is CTE and alias aware", async () => {
+    expect(
+      await lint("WITH t AS (SELECT 1 AS x) SELECT x FROM t", { schema: SCHEMA }),
+    ).toEqual([]);
+  });
+
+  it("skips SELECT-list aliases referenced in ORDER BY / GROUP BY", async () => {
+    const doc = "SELECT name AS display_name FROM users ORDER BY display_name";
+    expect(await lint(doc, { schema: SCHEMA })).toEqual([]);
+  });
+
+  it("checks columns inside FROM subqueries", async () => {
+    const diagnostics = await lint("SELECT * FROM (SELECT nme FROM users) sub", {
+      schema: SCHEMA,
+    });
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].message).toContain("nme");
+  });
+
+  it("skips unqualified columns in correlated subqueries", async () => {
+    // `email` is not in posts, but unqualified names in a correlated subquery
+    // may resolve to the outer scope, so it must not be flagged
+    const doc = "SELECT * FROM users WHERE EXISTS (SELECT 1 FROM posts WHERE user_id = id)";
+    expect(await lint(doc, { schema: SCHEMA })).toEqual([]);
+  });
+
+  it("flags unknown columns in UPDATE statements", async () => {
+    const diagnostics = await lint("UPDATE users SET nme = 'x' WHERE id = 1", {
+      schema: SCHEMA,
+    });
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].message).toContain("nme");
+  });
+
+  it("checks columns referenced inside function calls", async () => {
+    expect(await lint("SELECT count(*) FROM users", { schema: SCHEMA })).toEqual([]);
+    expect(await lint("SELECT count(nme) FROM users", { schema: SCHEMA })).toHaveLength(1);
+  });
+
+  it("supports self/children namespaces", async () => {
+    const schema = {
+      users: { self: { label: "users" }, children: ["id", "name"] },
+    };
+    expect(await lint("SELECT name FROM users", { schema })).toEqual([]);
+    expect(await lint("SELECT nme FROM users", { schema })).toHaveLength(1);
+  });
+
+  it("positions diagnostics correctly with inline comments", async () => {
+    const doc = "SELECT -- comment\n  nme\nFROM users";
+    const diagnostics = await lint(doc, { schema: SCHEMA });
+    expect(diagnostics).toHaveLength(1);
+    expect(doc.slice(diagnostics[0].from, diagnostics[0].to)).toBe("nme");
+  });
+
+  it("supports Completion objects as columns", async () => {
+    const schema = {
+      users: [{ label: "id", detail: "int" }, { label: "name", detail: "text" }],
+    };
+    expect(await lint("SELECT name FROM users", { schema })).toEqual([]);
+    expect(await lint("SELECT nme FROM users", { schema })).toHaveLength(1);
+  });
+});
+
+describe("ambiguous columns", () => {
+  it("flags an unqualified column that exists in multiple referenced tables", async () => {
+    const doc = "SELECT id FROM users, posts";
+    const diagnostics = await lint(doc, { schema: SCHEMA });
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].message).toContain("ambiguous");
+    expect(diagnostics[0].message).toContain("users");
+    expect(diagnostics[0].message).toContain("posts");
+    expect(doc.slice(diagnostics[0].from, diagnostics[0].to)).toBe("id");
+  });
+
+  it("does not flag qualified references or single-table columns", async () => {
+    expect(
+      await lint("SELECT users.id, title FROM users JOIN posts ON posts.user_id = users.id", {
+        schema: SCHEMA,
+      }),
+    ).toEqual([]);
+  });
+
+  it("does not flag columns joined with USING", async () => {
+    expect(await lint("SELECT id FROM users JOIN posts USING (id)", { schema: SCHEMA })).toEqual(
+      [],
+    );
+  });
+});
+
+describe("inertness and gating", () => {
+  it("returns no diagnostics and never parses when no schema is configured", async () => {
+    const parser = {
+      parse: vi.fn(),
+      validateSql: vi.fn(),
+      extractTableReferences: vi.fn(),
+      extractColumnReferences: vi.fn(),
+    } as unknown as SqlParser;
+
+    expect(await lint("SELECT * FROM usres", { parser })).toEqual([]);
+    expect(parser.parse).not.toHaveBeenCalled();
+  });
+
+  it("treats an empty schema as no schema (lazy loading upstream)", async () => {
+    expect(await lint("SELECT * FROM usres", { schema: {} })).toEqual([]);
+    expect(await lint("SELECT * FROM usres", { schema: [] })).toEqual([]);
+  });
+
+  it("returns no diagnostics for empty documents", async () => {
+    expect(await lint("", { schema: SCHEMA })).toEqual([]);
+    expect(await lint("   \n  ", { schema: SCHEMA })).toEqual([]);
+  });
+
+  it("skips statements with syntax errors", async () => {
+    // Broken statement: no semantic noise on top of the syntax error;
+    // the valid statement is still checked
+    const diagnostics = await lint("SELCT * FROM usres;\nSELECT * FROM usres;", {
+      schema: SCHEMA,
+    });
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].source).toBe("sql-schema");
+  });
+
+  it("reads the schema from sqlSchemaFacet when not configured directly", async () => {
+    const diagnostics = await lint("SELECT * FROM usres", {}, [sqlSchemaFacet.of(SCHEMA)]);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].message).toContain("usres");
+  });
+
+  it("prefers the explicit schema over the facet", async () => {
+    const diagnostics = await lint("SELECT * FROM other_table", { schema: SCHEMA }, [
+      sqlSchemaFacet.of({ other_table: ["id"] }),
+    ]);
+    expect(diagnostics).toHaveLength(1);
+  });
+
+  it("supports function schema sources", async () => {
+    const schema = vi.fn(() => SCHEMA);
+    const diagnostics = await lint("SELECT * FROM usres", { schema });
+    expect(diagnostics).toHaveLength(1);
+    expect(schema).toHaveBeenCalled();
+  });
+});
+
+describe("severity configuration", () => {
+  it("supports severity overrides", async () => {
+    const diagnostics = await lint("SELECT * FROM usres", {
+      schema: SCHEMA,
+      severity: { unknownTable: "error" },
+    });
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].severity).toBe("error");
+  });
+
+  it("supports turning checks off", async () => {
+    expect(
+      await lint("SELECT * FROM usres", {
+        schema: SCHEMA,
+        severity: { unknownTable: "off" },
+      }),
+    ).toEqual([]);
+
+    expect(
+      await lint("SELECT id FROM users, posts", {
+        schema: SCHEMA,
+        severity: { ambiguousColumn: "off" },
+      }),
+    ).toEqual([]);
+  });
+});
+
+describe("multiple statements", () => {
+  it("reports findings per statement with document-relative positions", async () => {
+    const doc = "SELECT * FROM users;\nSELECT nme FROM users;\nSELECT * FROM usres;";
+    const diagnostics = await lint(doc, { schema: SCHEMA });
+
+    expect(diagnostics).toHaveLength(2);
+    const spans = diagnostics.map((d) => doc.slice(d.from, d.to)).sort();
+    expect(spans).toEqual(["nme", "usres"]);
+  });
+});

--- a/src/sql/__tests__/semantic-diagnostics.test.ts
+++ b/src/sql/__tests__/semantic-diagnostics.test.ts
@@ -1,5 +1,6 @@
+import { type Diagnostic, forceLinting, forEachDiagnostic } from "@codemirror/lint";
 import { EditorState, type Extension } from "@codemirror/state";
-import type { EditorView } from "@codemirror/view";
+import { EditorView } from "@codemirror/view";
 import { describe, expect, it, vi } from "vitest";
 import { sqlSchemaFacet } from "../schema-facet.js";
 import {
@@ -30,6 +31,37 @@ describe("sqlSemanticLinter", () => {
   it("should create a linter extension", () => {
     expect(sqlSemanticLinter()).toBeDefined();
     expect(sqlSemanticLinter({ schema: SCHEMA, delay: 100 })).toBeDefined();
+  });
+
+  it("produces diagnostics through the installed extension", async () => {
+    const view = new EditorView({
+      doc: "SELECT * FROM usres",
+      extensions: [
+        sqlSemanticLinter({
+          schema: SCHEMA,
+          delay: 0,
+          severity: { unknownTable: "error" },
+        }),
+      ],
+      parent: document.body,
+    });
+
+    try {
+      forceLinting(view);
+      const diagnostics = await vi.waitFor(() => {
+        const found: Diagnostic[] = [];
+        forEachDiagnostic(view.state, (d) => found.push(d));
+        expect(found).toHaveLength(1);
+        return found;
+      });
+
+      expect(diagnostics[0].message).toContain("usres");
+      expect(diagnostics[0].source).toBe("sql-schema");
+      // Option forwarding: severity override applied
+      expect(diagnostics[0].severity).toBe("error");
+    } finally {
+      view.destroy();
+    }
   });
 });
 
@@ -266,11 +298,12 @@ describe("inertness and gating", () => {
   it("skips statements with syntax errors", async () => {
     // Broken statement: no semantic noise on top of the syntax error;
     // the valid statement is still checked
-    const diagnostics = await lint("SELCT * FROM usres;\nSELECT * FROM usres;", {
-      schema: SCHEMA,
-    });
+    const doc = "SELCT * FROM tbl_broken;\nSELECT * FROM tbl_missing;";
+    const diagnostics = await lint(doc, { schema: SCHEMA });
     expect(diagnostics).toHaveLength(1);
     expect(diagnostics[0].source).toBe("sql-schema");
+    expect(diagnostics[0].message).toContain("tbl_missing");
+    expect(doc.slice(diagnostics[0].from, diagnostics[0].to)).toBe("tbl_missing");
   });
 
   it("reads the schema from sqlSchemaFacet when not configured directly", async () => {

--- a/src/sql/extension.ts
+++ b/src/sql/extension.ts
@@ -93,7 +93,17 @@ export function sqlExtension(config: SqlExtensionConfig = {}): Extension[] {
   }
 
   if (enableSemanticLinting) {
-    extensions.push(sqlSemanticLinter(semanticLinterConfig));
+    // Reuse the syntax linter's parser/analyzer so dialect-specific setups
+    // don't have to configure them twice (and semantic checks don't disagree
+    // with the syntax linter about what parses)
+    extensions.push(
+      sqlSemanticLinter({
+        ...semanticLinterConfig,
+        parser: semanticLinterConfig?.parser ?? linterConfig?.parser,
+        structureAnalyzer:
+          semanticLinterConfig?.structureAnalyzer ?? linterConfig?.structureAnalyzer,
+      }),
+    );
   }
 
   if (enableGutterMarkers) {

--- a/src/sql/extension.ts
+++ b/src/sql/extension.ts
@@ -95,13 +95,19 @@ export function sqlExtension(config: SqlExtensionConfig = {}): Extension[] {
   if (enableSemanticLinting) {
     // Reuse the syntax linter's parser/analyzer so dialect-specific setups
     // don't have to configure them twice (and semantic checks don't disagree
-    // with the syntax linter about what parses)
+    // with the syntax linter about what parses). The linter's analyzer is
+    // only inherited when its parser is too — an analyzer is bound to the
+    // parser it was built with, and mixing it with a different semantic
+    // parser would gate statements with the wrong dialect.
+    const semanticParser = semanticLinterConfig?.parser ?? linterConfig?.parser;
+    const semanticAnalyzer =
+      semanticLinterConfig?.structureAnalyzer ??
+      (semanticLinterConfig?.parser == null ? linterConfig?.structureAnalyzer : undefined);
     extensions.push(
       sqlSemanticLinter({
         ...semanticLinterConfig,
-        parser: semanticLinterConfig?.parser ?? linterConfig?.parser,
-        structureAnalyzer:
-          semanticLinterConfig?.structureAnalyzer ?? linterConfig?.structureAnalyzer,
+        parser: semanticParser,
+        structureAnalyzer: semanticAnalyzer,
       }),
     );
   }

--- a/src/sql/extension.ts
+++ b/src/sql/extension.ts
@@ -1,16 +1,37 @@
 import type { Extension } from "@codemirror/state";
 import { type SqlLinterConfig, sqlLinter } from "./diagnostics.js";
 import { defaultSqlHoverTheme, type SqlHoverConfig, sqlHover } from "./hover.js";
+import { type SqlSchemaSource, sqlSchemaFacet } from "./schema-facet.js";
+import { type SqlSemanticLinterConfig, sqlSemanticLinter } from "./semantic-diagnostics.js";
 import { type SqlGutterConfig, sqlStructureGutter } from "./structure-extension.js";
 
 /**
  * Configuration options for the SQL extension
  */
 export interface SqlExtensionConfig {
+  /**
+   * Database schema shared by all schema-aware features (hover tooltips and
+   * semantic linting), registered via `sqlSchemaFacet`. Per-feature `schema`
+   * options in `hoverConfig`/`semanticLinterConfig` take precedence.
+   *
+   * Function sources are called on every lint/hover pass and should be
+   * cheap/memoized.
+   */
+  schema?: SqlSchemaSource;
+
   /** Whether to enable SQL linting (default: true) */
   enableLinting?: boolean;
   /** Configuration for the SQL linter */
   linterConfig?: SqlLinterConfig;
+
+  /**
+   * Whether to enable schema-aware semantic linting — unknown tables, unknown
+   * columns, ambiguous columns (default: true). Inert unless a schema is
+   * provided (via `schema` or `semanticLinterConfig.schema`).
+   */
+  enableSemanticLinting?: boolean;
+  /** Configuration for the semantic linter */
+  semanticLinterConfig?: SqlSemanticLinterConfig;
 
   /** Whether to enable gutter markers for SQL statements (default: true) */
   enableGutterMarkers?: boolean;
@@ -26,6 +47,7 @@ export interface SqlExtensionConfig {
 /**
  * Creates a comprehensive SQL extension for CodeMirror that includes:
  * - SQL syntax validation and linting
+ * - Schema-aware semantic linting (unknown tables/columns, ambiguous columns)
  * - Visual gutter indicators for SQL statements
  * - Hover tooltips for keywords, tables, and columns
  *
@@ -39,6 +61,7 @@ export interface SqlExtensionConfig {
  * const editor = new EditorView({
  *   extensions: [
  *     sqlExtension({
+ *       schema: { users: ['id', 'name'] },
  *       linterConfig: { delay: 500 },
  *       gutterConfig: { backgroundColor: '#3b82f6' },
  *       hoverConfig: { hoverTime: 300 }
@@ -50,16 +73,27 @@ export interface SqlExtensionConfig {
 export function sqlExtension(config: SqlExtensionConfig = {}): Extension[] {
   const extensions: Extension[] = [];
   const {
+    schema,
     enableLinting = true,
+    enableSemanticLinting = true,
     enableGutterMarkers = true,
     enableHover = true,
     linterConfig,
+    semanticLinterConfig,
     gutterConfig,
     hoverConfig,
   } = config;
 
+  if (schema != null) {
+    extensions.push(sqlSchemaFacet.of(schema));
+  }
+
   if (enableLinting) {
     extensions.push(sqlLinter(linterConfig));
+  }
+
+  if (enableSemanticLinting) {
+    extensions.push(sqlSemanticLinter(semanticLinterConfig));
   }
 
   if (enableGutterMarkers) {
@@ -68,9 +102,7 @@ export function sqlExtension(config: SqlExtensionConfig = {}): Extension[] {
 
   if (enableHover) {
     extensions.push(sqlHover(hoverConfig));
-    hoverConfig?.theme
-      ? extensions.push(hoverConfig.theme)
-      : extensions.push(defaultSqlHoverTheme());
+    extensions.push(hoverConfig?.theme ?? defaultSqlHoverTheme());
   }
 
   return extensions;

--- a/src/sql/hover.ts
+++ b/src/sql/hover.ts
@@ -9,6 +9,7 @@ import {
   resolveNamespaceItem,
 } from "./namespace-utils.js";
 import { NodeSqlParser } from "./parser.js";
+import { resolveSqlSchema } from "./schema-facet.js";
 import type { SqlParser } from "./types.js";
 
 /**
@@ -106,7 +107,10 @@ interface TooltipCreateData {
  * Configuration for SQL hover tooltips
  */
 export interface SqlHoverConfig {
-  /** Database schema for table and column information */
+  /**
+   * Database schema for table and column information.
+   * Falls back to the shared `sqlSchemaFacet` when not provided.
+   */
   schema?: SQLNamespace | ((view: EditorView) => SQLNamespace);
   /** SQL dialect for keyword information */
   dialect?: SQLDialect | ((view: EditorView) => SQLDialect);
@@ -150,7 +154,7 @@ function createHoverSource(
   config: SqlHoverConfig = {},
 ): (view: EditorView, pos: number, side: number) => Promise<Tooltip | null> {
   const {
-    schema = {},
+    schema,
     keywords = {},
     enableKeywords = true,
     enableTables = true,
@@ -197,7 +201,7 @@ function createHoverSource(
       return null;
     }
 
-    const resolvedSchema = typeof schema === "function" ? schema(view) : schema;
+    const resolvedSchema = resolveSqlSchema(schema, view) ?? {};
 
     let createData: TooltipCreateData | null = null;
 

--- a/src/sql/schema-facet.ts
+++ b/src/sql/schema-facet.ts
@@ -1,0 +1,44 @@
+import type { SQLNamespace } from "@codemirror/lang-sql";
+import { Facet } from "@codemirror/state";
+import type { EditorView } from "@codemirror/view";
+
+/**
+ * A schema source: either a namespace object or a function that resolves one
+ * from the current view.
+ *
+ * When a function is provided it is called on every lint/hover pass, so it
+ * should be cheap (return a cached/memoized namespace rather than rebuilding it).
+ */
+export type SqlSchemaSource = SQLNamespace | ((view: EditorView) => SQLNamespace);
+
+/**
+ * Facet holding the SQL schema shared by schema-aware features (hover tooltips,
+ * semantic linting). Register it once instead of passing the same schema to
+ * each sub-extension:
+ *
+ * ```ts
+ * import { sqlSchemaFacet } from "@marimo-team/codemirror-sql";
+ *
+ * const extensions = [sqlSchemaFacet.of({ users: ["id", "name"] })];
+ * ```
+ *
+ * Per-extension `schema` config options take precedence over this facet.
+ */
+export const sqlSchemaFacet = Facet.define<SqlSchemaSource, SqlSchemaSource | null>({
+  combine: (values) => values[0] ?? null,
+});
+
+/**
+ * Resolves a schema for the given view, preferring an explicitly configured
+ * source over the {@link sqlSchemaFacet} value.
+ */
+export function resolveSqlSchema(
+  explicit: SqlSchemaSource | undefined,
+  view: EditorView,
+): SQLNamespace | null {
+  const source = explicit ?? view.state.facet(sqlSchemaFacet);
+  if (source == null) {
+    return null;
+  }
+  return typeof source === "function" ? source(view) : source;
+}

--- a/src/sql/semantic-diagnostics.ts
+++ b/src/sql/semantic-diagnostics.ts
@@ -1,0 +1,705 @@
+import type { SQLNamespace } from "@codemirror/lang-sql";
+import { type Diagnostic, linter } from "@codemirror/lint";
+import type { Extension, Text } from "@codemirror/state";
+import type { EditorView } from "@codemirror/view";
+import {
+  findNamespaceItemByEndMatch,
+  isArrayNamespace,
+  isObjectNamespace,
+  isSelfChildrenNamespace,
+  traverseNamespacePath,
+} from "./namespace-utils.js";
+import { NodeSqlParser } from "./parser.js";
+import { resolveSqlSchema, type SqlSchemaSource } from "./schema-facet.js";
+import { type SqlStatement, SqlStructureAnalyzer } from "./structure-analyzer.js";
+import type { SqlParser } from "./types.js";
+
+const DEFAULT_DELAY = 750;
+
+/** Severity for a semantic check; "off" disables the check entirely */
+export type SemanticSeverity = "error" | "warning" | "off";
+
+/**
+ * Configuration options for the semantic (schema-aware) SQL linter
+ */
+export interface SqlSemanticLinterConfig {
+  /**
+   * Database schema to validate queries against. Falls back to the shared
+   * `sqlSchemaFacet` when not provided. Without a schema (or with an empty
+   * one) the linter is inert.
+   *
+   * Function sources are invoked on every lint pass and should be
+   * cheap/memoized.
+   */
+  schema?: SqlSchemaSource;
+  /** Custom SQL parser instance to use for analysis */
+  parser?: SqlParser;
+  /**
+   * Structure analyzer used to split the document into statements.
+   * Pass a shared instance (e.g. the one used by the gutter) to reuse its cache.
+   */
+  structureAnalyzer?: SqlStructureAnalyzer;
+  /** Delay in milliseconds before running validation (default: 750) */
+  delay?: number;
+  /** Per-check severity overrides (default: "warning" for every check) */
+  severity?: {
+    /** A referenced table is not present in the schema */
+    unknownTable?: SemanticSeverity;
+    /** A column is not present in its resolved table */
+    unknownColumn?: SemanticSeverity;
+    /** An unqualified column exists in two or more referenced tables */
+    ambiguousColumn?: SemanticSeverity;
+  };
+}
+
+type FindingKind = "unknownTable" | "unknownColumn" | "ambiguousColumn";
+
+interface SemanticFinding {
+  kind: FindingKind;
+  /** Identifier to highlight in the statement text */
+  identifier: string;
+  message: string;
+}
+
+/** Loosely-typed node-sql-parser AST node */
+interface AstNode {
+  [key: string]: unknown;
+}
+
+/** A table-like source in a query scope (FROM entry, DML target, CTE, subquery) */
+interface TableSource {
+  /** Full dotted path as written, e.g. "mydb.users" (empty for subqueries) */
+  path: string;
+  /** Unqualified table name */
+  name: string;
+  alias: string | null;
+  /** References a CTE defined in the statement */
+  isCte: boolean;
+  /** Subquery/table-function source whose columns we cannot know */
+  opaque: boolean;
+}
+
+/**
+ * A single query scope (a SELECT, or the target/WHERE portion of a DML
+ * statement). Column references are checked against the scope's sources.
+ */
+interface QueryScope {
+  sources: TableSource[];
+  columnRefs: AstNode[];
+  /** Lowercased SELECT-list aliases, referable from GROUP BY/ORDER BY etc. */
+  selectAliases: Set<string>;
+  /**
+   * Whether unqualified column refs may be checked. Disabled for scopes that
+   * can see an outer scope (correlated subqueries), where an unqualified name
+   * may legally resolve to an outer table.
+   */
+  checkUnqualified: boolean;
+  /** A USING/NATURAL join makes shared columns unambiguous; skip that check */
+  hasUsingJoin: boolean;
+}
+
+function isSelectNode(node: unknown): node is AstNode & { type: "select" } {
+  return (
+    typeof node === "object" &&
+    node !== null &&
+    !Array.isArray(node) &&
+    (node as AstNode).type === "select"
+  );
+}
+
+function asArray(value: unknown): AstNode[] {
+  return Array.isArray(value) ? (value as AstNode[]) : [];
+}
+
+function newScope(checkUnqualified: boolean): QueryScope {
+  return {
+    sources: [],
+    columnRefs: [],
+    selectAliases: new Set(),
+    checkUnqualified,
+    hasUsingJoin: false,
+  };
+}
+
+/**
+ * Registers CTE names defined on a statement node and collects scopes from
+ * their bodies. Names are registered before bodies are walked so a CTE
+ * referencing another (or itself, when recursive) is never flagged.
+ */
+function registerCtes(node: AstNode, ctes: Set<string>, scopes: QueryScope[]): void {
+  const withList = asArray(node.with);
+  for (const cte of withList) {
+    const name = cte.name as AstNode | string | undefined;
+    const value = typeof name === "string" ? name : name?.value;
+    if (typeof value === "string") {
+      ctes.add(value.toLowerCase());
+    }
+  }
+  for (const cte of withList) {
+    const stmt = cte.stmt as AstNode | undefined;
+    const body = stmt?.ast ?? stmt;
+    if (isSelectNode(body)) {
+      collectSelect(body, ctes, scopes, false);
+    }
+  }
+}
+
+/**
+ * Adds a FROM/target entry to the scope. Entries are either named tables
+ * (`{db, schema, table, as}`) or expression sources (subqueries, table
+ * functions), which are treated as opaque.
+ */
+function addTableEntry(
+  entry: AstNode,
+  scope: QueryScope,
+  ctes: Set<string>,
+  scopes: QueryScope[],
+): void {
+  if (entry.using != null) {
+    scope.hasUsingJoin = true;
+  }
+  if (typeof entry.join === "string" && entry.join.toLowerCase().includes("natural")) {
+    scope.hasUsingJoin = true;
+  }
+  if (entry.on != null) {
+    walkExpr(entry.on, scope, ctes, scopes);
+  }
+
+  const expr = entry.expr as AstNode | undefined;
+  if (expr != null) {
+    const sub = expr.ast ?? expr;
+    if (isSelectNode(sub)) {
+      collectSelect(sub, ctes, scopes, false);
+    }
+    scope.sources.push({
+      path: "",
+      name: "",
+      alias: typeof entry.as === "string" ? entry.as : null,
+      isCte: false,
+      opaque: true,
+    });
+    return;
+  }
+
+  if (typeof entry.table === "string") {
+    const qualifier = entry.db ?? entry.catalog;
+    const parts = [qualifier, entry.schema, entry.table].filter(
+      (part): part is string => typeof part === "string" && part.length > 0,
+    );
+    scope.sources.push({
+      path: parts.join("."),
+      name: entry.table,
+      alias: typeof entry.as === "string" ? entry.as : null,
+      isCte: parts.length === 1 && ctes.has(entry.table.toLowerCase()),
+      opaque: false,
+    });
+  }
+}
+
+/**
+ * Generic walk collecting column refs into the current scope and opening a
+ * new (correlated) scope for any nested SELECT.
+ */
+function walkExpr(value: unknown, scope: QueryScope, ctes: Set<string>, scopes: QueryScope[]): void {
+  if (value == null || typeof value !== "object") {
+    return;
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      walkExpr(item, scope, ctes, scopes);
+    }
+    return;
+  }
+  const node = value as AstNode;
+  if (node.type === "column_ref") {
+    scope.columnRefs.push(node);
+    return;
+  }
+  if (isSelectNode(node)) {
+    collectSelect(node, ctes, scopes, true);
+    return;
+  }
+  if (isSelectNode(node.ast)) {
+    collectSelect(node.ast, ctes, scopes, true);
+    return;
+  }
+  for (const [key, child] of Object.entries(node)) {
+    if (key === "loc" || key === "tableList" || key === "columnList") {
+      continue;
+    }
+    walkExpr(child, scope, ctes, scopes);
+  }
+}
+
+function collectSelect(
+  node: AstNode,
+  inheritedCtes: Set<string>,
+  scopes: QueryScope[],
+  correlated: boolean,
+): void {
+  const ctes = new Set(inheritedCtes);
+  registerCtes(node, ctes, scopes);
+
+  const scope = newScope(!correlated);
+  scopes.push(scope);
+
+  for (const entry of asArray(node.from)) {
+    addTableEntry(entry, scope, ctes, scopes);
+  }
+
+  for (const col of asArray(node.columns)) {
+    if (typeof col.as === "string") {
+      scope.selectAliases.add(col.as.toLowerCase());
+    }
+  }
+
+  for (const [key, child] of Object.entries(node)) {
+    // `with` and `from` were handled above; walking them again would create
+    // duplicate scopes (and `on` clauses are walked by addTableEntry)
+    if (key === "with" || key === "from" || key === "loc") {
+      continue;
+    }
+    walkExpr(child, scope, ctes, scopes);
+  }
+}
+
+/**
+ * Collects query scopes from a single parsed statement. DDL targets (CREATE
+ * TABLE x) define tables rather than read them, so they are never added as
+ * sources; DML targets (INSERT/UPDATE/DELETE) must exist and are.
+ */
+function collectStatement(node: AstNode, scopes: QueryScope[]): void {
+  const ctes = new Set<string>();
+
+  switch (node.type) {
+    case "select": {
+      collectSelect(node, ctes, scopes, false);
+      return;
+    }
+    case "update": {
+      registerCtes(node, ctes, scopes);
+      const scope = newScope(true);
+      scopes.push(scope);
+      for (const entry of asArray(node.table)) {
+        addTableEntry(entry, scope, ctes, scopes);
+      }
+      for (const entry of asArray(node.from)) {
+        addTableEntry(entry, scope, ctes, scopes);
+      }
+      // SET entries are `{column, table, value}` where `column` is a plain
+      // string in some dialect grammars (no column_ref type), so the generic
+      // walk would miss them
+      for (const entry of asArray(node.set)) {
+        if (entry.column != null) {
+          scope.columnRefs.push({
+            type: "column_ref",
+            table: entry.table ?? null,
+            column: entry.column,
+          });
+        }
+        walkExpr(entry.value, scope, ctes, scopes);
+      }
+      for (const [key, child] of Object.entries(node)) {
+        if (
+          key === "with" ||
+          key === "table" ||
+          key === "from" ||
+          key === "set" ||
+          key === "loc"
+        ) {
+          continue;
+        }
+        walkExpr(child, scope, ctes, scopes);
+      }
+      return;
+    }
+    case "delete": {
+      registerCtes(node, ctes, scopes);
+      const scope = newScope(true);
+      scopes.push(scope);
+      // node.table duplicates node.from entries (with `addition: true`), so
+      // only FROM is used as the source list
+      for (const entry of asArray(node.from)) {
+        addTableEntry(entry, scope, ctes, scopes);
+      }
+      for (const [key, child] of Object.entries(node)) {
+        if (key === "with" || key === "table" || key === "from" || key === "loc") {
+          continue;
+        }
+        walkExpr(child, scope, ctes, scopes);
+      }
+      return;
+    }
+    case "insert":
+    case "replace": {
+      registerCtes(node, ctes, scopes);
+      // The insert target must exist, but its scope has no readable columns
+      // context, so unqualified column checks stay off
+      const scope = newScope(false);
+      scopes.push(scope);
+      for (const entry of asArray(node.table)) {
+        addTableEntry(entry, scope, ctes, scopes);
+      }
+      for (const [key, child] of Object.entries(node)) {
+        // `columns` holds the target column names as plain strings
+        if (key === "with" || key === "table" || key === "columns" || key === "loc") {
+          continue;
+        }
+        if (isSelectNode(child)) {
+          // INSERT INTO t SELECT ... — the select is a top-level query
+          collectSelect(child, ctes, scopes, false);
+        } else {
+          walkExpr(child, scope, ctes, scopes);
+        }
+      }
+      return;
+    }
+    case "create":
+    case "alter":
+    case "drop": {
+      const scope = newScope(false);
+      scopes.push(scope);
+      for (const [key, child] of Object.entries(node)) {
+        if (key === "table" || key === "loc") {
+          continue;
+        }
+        if (isSelectNode(child)) {
+          // CREATE TABLE/VIEW ... AS SELECT — top-level query, not correlated
+          collectSelect(child, ctes, scopes, false);
+        } else {
+          walkExpr(child, scope, ctes, scopes);
+        }
+      }
+      return;
+    }
+    default: {
+      const scope = newScope(false);
+      scopes.push(scope);
+      for (const [key, child] of Object.entries(node)) {
+        if (key === "loc") {
+          continue;
+        }
+        walkExpr(child, scope, ctes, scopes);
+      }
+    }
+  }
+}
+
+/**
+ * Extracts the column name from a column_ref node. Depending on the dialect
+ * grammar the column is either a plain string or `{expr: {value}}`.
+ */
+function getColumnName(ref: AstNode): string | null {
+  const column = ref.column;
+  if (typeof column === "string") {
+    return column;
+  }
+  if (typeof column === "object" && column !== null) {
+    const expr = (column as AstNode).expr as AstNode | undefined;
+    const value = expr?.value ?? (column as AstNode).value;
+    if (typeof value === "string") {
+      return value;
+    }
+  }
+  return null;
+}
+
+function getColumnQualifier(ref: AstNode): string | null {
+  if (typeof ref.table !== "string" || ref.table.length === 0) {
+    return null;
+  }
+  if (typeof ref.db === "string" && ref.db.length > 0) {
+    return `${ref.db}.${ref.table}`;
+  }
+  return ref.table;
+}
+
+/** Extracts column names when the namespace node is a column array */
+function columnsOf(namespace: SQLNamespace | undefined): string[] | null {
+  if (namespace == null) {
+    return null;
+  }
+  const resolved = isSelfChildrenNamespace(namespace) ? namespace.children : namespace;
+  if (isArrayNamespace(resolved)) {
+    return resolved.map((col) => (typeof col === "string" ? col : col.label));
+  }
+  return null;
+}
+
+interface ResolvedTable {
+  exists: boolean;
+  /** Column names when the table resolves to a column array; null otherwise */
+  columns: string[] | null;
+}
+
+/**
+ * Resolves a (possibly qualified) table path against the schema,
+ * case-insensitively. An unqualified or partially-qualified name also matches
+ * a table nested deeper in the namespace (e.g. `users` matches `mydb.users`)
+ * so that under-qualified references are never flagged.
+ */
+function resolveTable(schema: SQLNamespace, path: string): ResolvedTable {
+  const exact = traverseNamespacePath(schema, path, { caseSensitive: false });
+  if (exact) {
+    return { exists: true, columns: columnsOf(exact.namespace) };
+  }
+
+  const segments = path.split(".").map((segment) => segment.toLowerCase());
+  const lastSegment = segments[segments.length - 1];
+  if (!lastSegment) {
+    return { exists: false, columns: null };
+  }
+
+  const matches = findNamespaceItemByEndMatch(schema, lastSegment).filter((item) => {
+    if (columnsOf(item.namespace) === null) {
+      return false; // only table-like matches (nodes holding a column array)
+    }
+    if (item.path.length < segments.length) {
+      return false;
+    }
+    const suffix = item.path.slice(-segments.length).map((segment) => segment.toLowerCase());
+    return segments.every((segment, i) => suffix[i] === segment);
+  });
+
+  if (matches.length === 0) {
+    return { exists: false, columns: null };
+  }
+  // Only trust the column list when the match is unambiguous
+  return {
+    exists: true,
+    columns: matches.length === 1 ? columnsOf(matches[0]?.namespace) : null,
+  };
+}
+
+function includesIgnoreCase(haystack: string[], needle: string): boolean {
+  const lower = needle.toLowerCase();
+  return haystack.some((item) => item.toLowerCase() === lower);
+}
+
+/**
+ * Runs the semantic checks for one parsed statement and returns findings,
+ * deduplicated by kind + identifier.
+ */
+function analyzeStatementAst(ast: AstNode, schema: SQLNamespace): SemanticFinding[] {
+  const scopes: QueryScope[] = [];
+  collectStatement(ast, scopes);
+
+  const findings = new Map<string, SemanticFinding>();
+  const addFinding = (finding: SemanticFinding) => {
+    const key = `${finding.kind}::${finding.identifier.toLowerCase()}`;
+    if (!findings.has(key)) {
+      findings.set(key, finding);
+    }
+  };
+
+  for (const scope of scopes) {
+    const resolved = scope.sources.map((source) => {
+      if (source.opaque || source.isCte) {
+        return { source, exists: true, columns: null };
+      }
+      const table = resolveTable(schema, source.path);
+      return { source, exists: table.exists, columns: table.columns };
+    });
+
+    for (const { source, exists } of resolved) {
+      if (!source.opaque && !source.isCte && !exists) {
+        addFinding({
+          kind: "unknownTable",
+          identifier: source.name,
+          message: `Unknown table '${source.path}'`,
+        });
+      }
+    }
+
+    for (const ref of scope.columnRefs) {
+      const name = getColumnName(ref);
+      if (!name || name === "*") {
+        continue;
+      }
+
+      const qualifier = getColumnQualifier(ref);
+      if (qualifier) {
+        const lowerQualifier = qualifier.toLowerCase();
+        const match =
+          resolved.find((entry) => entry.source.alias?.toLowerCase() === lowerQualifier) ??
+          resolved.find(
+            (entry) =>
+              entry.source.name.toLowerCase() === lowerQualifier ||
+              entry.source.path.toLowerCase() === lowerQualifier,
+          );
+        // An unresolved qualifier may be an outer-scope alias; skip it
+        if (match?.columns && !includesIgnoreCase(match.columns, name)) {
+          addFinding({
+            kind: "unknownColumn",
+            identifier: name,
+            message: `Column '${name}' not found in table '${match.source.path || qualifier}'`,
+          });
+        }
+        continue;
+      }
+
+      if (!scope.checkUnqualified || scope.selectAliases.has(name.toLowerCase())) {
+        continue;
+      }
+
+      const containing = resolved.filter(
+        (entry) => entry.columns !== null && includesIgnoreCase(entry.columns, name),
+      );
+      if (containing.length >= 2 && !scope.hasUsingJoin) {
+        addFinding({
+          kind: "ambiguousColumn",
+          identifier: name,
+          message: `Column '${name}' is ambiguous; it exists in ${containing
+            .map((entry) => entry.source.name)
+            .join(", ")}`,
+        });
+        continue;
+      }
+      // Only flag unknown columns when the scope reads exactly one table
+      // whose columns are fully known — anything else is not confidently
+      // resolvable and false positives are worse than under-reporting
+      const only = resolved.length === 1 ? resolved[0] : undefined;
+      if (only && only.columns !== null && containing.length === 0) {
+        addFinding({
+          kind: "unknownColumn",
+          identifier: name,
+          message: `Column '${name}' not found in table '${only.source.path}'`,
+        });
+      }
+    }
+  }
+
+  return [...findings.values()];
+}
+
+/**
+ * Finds an identifier occurrence (word-bounded, case-insensitive) in text.
+ * Used to position diagnostics, since node-sql-parser's name lists and AST
+ * nodes for tables/columns carry no location information.
+ */
+function findIdentifier(text: string, name: string): number {
+  const lowerText = text.toLowerCase();
+  const needle = name.toLowerCase();
+  let index = lowerText.indexOf(needle);
+  while (index !== -1) {
+    const before = index > 0 ? (lowerText[index - 1] ?? "") : "";
+    const after = lowerText[index + needle.length] ?? "";
+    if (!/[\w$]/.test(before) && !/[\w$]/.test(after)) {
+      return index;
+    }
+    index = lowerText.indexOf(needle, index + 1);
+  }
+  return -1;
+}
+
+function findingToDiagnostic(
+  finding: SemanticFinding,
+  stmt: SqlStatement,
+  doc: Text,
+  severity: "error" | "warning",
+): Diagnostic {
+  const statementText = doc.sliceString(stmt.from, stmt.to);
+  const offset = findIdentifier(statementText, finding.identifier);
+  const from = offset === -1 ? stmt.from : stmt.from + offset;
+  const to =
+    offset === -1
+      ? Math.min(stmt.from + (statementText.match(/^[\w"'`.]+/)?.[0].length ?? 1), stmt.to)
+      : Math.min(from + finding.identifier.length, stmt.to);
+
+  return {
+    from,
+    to,
+    severity,
+    message: finding.message,
+    source: "sql-schema",
+  };
+}
+
+/** True when the schema has nothing to validate against */
+function isEmptySchema(schema: SQLNamespace): boolean {
+  if (isArrayNamespace(schema)) {
+    return schema.length === 0;
+  }
+  if (isObjectNamespace(schema)) {
+    return Object.keys(schema).length === 0;
+  }
+  return false;
+}
+
+function createSemanticLintSource(config: SqlSemanticLinterConfig = {}) {
+  const parser = config.parser || new NodeSqlParser();
+  const analyzer = config.structureAnalyzer || new SqlStructureAnalyzer(parser);
+  const severities = {
+    unknownTable: config.severity?.unknownTable ?? "warning",
+    unknownColumn: config.severity?.unknownColumn ?? "warning",
+    ambiguousColumn: config.severity?.ambiguousColumn ?? "warning",
+  } as const;
+
+  return async (view: EditorView): Promise<Diagnostic[]> => {
+    const schema = resolveSqlSchema(config.schema, view);
+    // No schema (or an empty placeholder while it loads) → stay inert rather
+    // than flagging every table as unknown
+    if (schema == null || isEmptySchema(schema)) {
+      return [];
+    }
+
+    const doc = view.state.doc;
+    if (!doc.toString().trim()) {
+      return [];
+    }
+
+    const diagnostics: Diagnostic[] = [];
+    const statements = await analyzer.analyzeDocument(view.state);
+    for (const stmt of statements) {
+      // Never stack semantic noise on top of syntax errors
+      if (!stmt.isValid) {
+        continue;
+      }
+      const result = await parser.parse(stmt.content, { state: view.state });
+      if (!result.success || result.ast == null) {
+        continue;
+      }
+      const asts = Array.isArray(result.ast) ? result.ast : [result.ast];
+      for (const ast of asts) {
+        for (const finding of analyzeStatementAst(ast as AstNode, schema)) {
+          const severity = severities[finding.kind];
+          if (severity === "off") {
+            continue;
+          }
+          diagnostics.push(findingToDiagnostic(finding, stmt, doc, severity));
+        }
+      }
+    }
+    return diagnostics;
+  };
+}
+
+/**
+ * Creates a schema-aware SQL linter extension that validates queries against
+ * a database schema, reporting unknown tables, unknown columns, and ambiguous
+ * column references.
+ *
+ * Checks only run on statements that parse cleanly, and skip anything that is
+ * not confidently resolvable (CTEs, subquery outputs, aliases from outer
+ * scopes, expressions), preferring under-reporting over false positives.
+ *
+ * @param config Configuration options for the semantic linter
+ * @returns A CodeMirror linter extension
+ *
+ * @example
+ * ```ts
+ * import { sqlSemanticLinter } from '@marimo-team/codemirror-sql';
+ *
+ * const linter = sqlSemanticLinter({
+ *   schema: { users: ['id', 'name'], posts: ['id', 'user_id'] },
+ *   severity: { unknownTable: 'error' },
+ * });
+ * ```
+ */
+export function sqlSemanticLinter(config: SqlSemanticLinterConfig = {}): Extension {
+  return linter(createSemanticLintSource(config), {
+    delay: config.delay || DEFAULT_DELAY,
+  });
+}
+
+export const exportedForTesting = { createSemanticLintSource };


### PR DESCRIPTION
## Summary

Linting was syntax-only, even though the extension already accepts a full `SQLNamespace` schema (used by hover). This adds **`sqlSemanticLinter`**, a schema-aware linter that reports the highest-value SQL diagnostics:

- **Unknown table** — `FROM`/`JOIN` references and DML targets (`INSERT`/`UPDATE`/`DELETE`) resolved against the namespace. Case-insensitive; qualified paths like `mydb.users` traverse nested namespaces; CTE names and DDL targets (`CREATE TABLE x` defines `x`) are skipped.
- **Unknown column** — qualified refs (`u.name`, `users.name`) resolved through a per-scope alias map; unqualified refs checked only when the statement reads exactly one known table.
- **Ambiguous column** — unqualified refs that exist in 2+ referenced tables (suppressed for `USING`/`NATURAL` joins).

Severities are configurable per check (`"error" | "warning" | "off"`, default `"warning"`), and semantic diagnostics carry `source: "sql-schema"` vs. `"sql-parser"` for syntax errors.

## False positives are fatal to trust

The analyzer builds proper query scopes from the AST and skips anything not confidently resolvable, preferring under-reporting:

- checks only run on statements that parse cleanly (no semantic noise on top of syntax errors)
- CTE outputs, FROM-subquery results, and table functions are opaque — their columns are never guessed
- unqualified columns are never checked inside correlated subqueries (they may legally resolve to the outer scope)
- SELECT-list aliases referenced in `ORDER BY`/`GROUP BY` are skipped
- unresolved qualifiers (possible outer-scope aliases) are skipped
- under-qualified names match tables nested deeper in the schema, so `FROM users` with schema `{mydb: {users}}` never flags
- without a schema (or with an empty placeholder while it lazily loads upstream) the linter is fully inert — zero parser calls

## Shared schema facet

Also introduces **`sqlSchemaFacet`** so the schema is defined once for hover + semantic linting (and future completion) instead of per sub-extension. `sqlExtension` gains top-level `schema`, `enableSemanticLinting` (default true; inert without a schema), and `semanticLinterConfig`. Per-extension `schema` config still overrides for back-compat.

## Implementation note on positions

The plan called for `parseOptions: { includeLocations: true }`, but node-sql-parser does not attach `loc` to `column_ref`/table nodes even with it enabled (verified empirically; only some expression wrappers get it). Diagnostics are instead positioned by word-bounded, case-insensitive text search within the statement's document range — searching the original doc text keeps positions exact even around inline comments (covered by a test).

## Testing

- 24 new tests in `src/sql/__tests__/semantic-diagnostics.test.ts` covering all checks, CTE/alias/subquery/correlation scoping, nested namespaces, `self/children` namespaces, Completion-object columns, severity overrides, facet fallback/precedence, inertness gating, and diagnostic positioning
- `pnpm test`: 334 passed | 1 expected fail (pre-existing)
- `pnpm run typecheck` and `pnpm exec oxlint`: clean (also fixed the one pre-existing oxlint warning in `extension.ts`)
- demo updated to exercise semantic linting (`pnpm run demo` builds)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add schema-aware SQL linting that flags unknown tables/columns and ambiguous columns, shared with hover via a new schema facet. Introduces `sqlSemanticLinter` and `sqlSchemaFacet`, and adds top-level `schema` and `enableSemanticLinting` options to `sqlExtension`; also refines parser/analyzer inheritance to avoid dialect mismatches.

- **New Features**
  - `sqlSemanticLinter`: reports unknown tables, unknown columns, and ambiguous unqualified columns; per-check severity (`error` | `warning` | `off`, default `warning`); diagnostics use `source: "sql-schema"`; skips unresolvable cases to avoid false positives.
  - `sqlSchemaFacet`: shared schema for hover and semantic lint; supports function sources; per-feature `schema` still overrides; exported `resolveSqlSchema`.
  - `sqlExtension`: new `schema`, `enableSemanticLinting` (default true; inert without a schema), and `semanticLinterConfig`; hover falls back to the shared schema; semantic linter reuses `linterConfig.parser` and inherits `linterConfig.structureAnalyzer` only when the linter parser is inherited, preventing analyzer/dialect mismatches.

- **Migration**
  - If you already pass a schema to hover, move it to `sqlExtension({ schema })` to share across features.
  - To enable semantic linting, supply a schema and optionally set severities via `semanticLinterConfig.severity`.
  - To disable, set `enableSemanticLinting: false`.

<sup>Written for commit fb7ca9e396a621c22681625bdc1eb859d4e85522. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marimo-team/codemirror-sql/pull/163?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

