### PR TITLE
feat: alias resolution for hover and completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A CodeMirror extension for SQL linting and visual gutter indicators. Built by an
 - 🎨 **Visual gutter** - Color-coded statement indicators and error highlighting
 - 💡 **Hover tooltips** - Schema info, keywords, and column details on hover
 - 🔮 **CTE autocomplete** - Auto-complete support for CTEs
+- 🏷️ **Alias resolution** - Hover and completion understand table aliases (`SELECT u.name FROM users u`)
 - 🎯 **Query-aware resolution** - Context-sensitive schema and column suggestions
 - 🔍 **Additional dialects** - DuckDB, BigQuery, Dremio
 - 🛠️ **Custom renderers** - Customizable tooltip rendering for tables, columns, and keywords
@@ -28,7 +29,7 @@ pnpm add @marimo-team/codemirror-sql
 ```ts
 import { sql, StandardSQL } from "@codemirror/lang-sql";
 import { basicSetup, EditorView } from "codemirror";
-import { sqlExtension, cteCompletionSource } from "@marimo-team/codemirror-sql";
+import { sqlExtension, cteCompletionSource, aliasColumnCompletionSource } from "@marimo-team/codemirror-sql";
 
 const schema = {
   users: ["id", "name", "email", "active"],
@@ -46,6 +47,10 @@ const editor = new EditorView({
     }),
     StandardSQL.language.data.of({
       autocomplete: cteCompletionSource,
+    }),
+    StandardSQL.language.data.of({
+      // Complete `u.` -> columns of `users` in `SELECT ... FROM users u`
+      autocomplete: aliasColumnCompletionSource({ schema }),
     }),
     sqlExtension({
       // Shared by hover tooltips and semantic linting

--- a/demo/index.ts
+++ b/demo/index.ts
@@ -4,6 +4,7 @@ import { Compartment, type EditorState, StateEffect, StateField } from "@codemir
 import { keymap } from "@codemirror/view";
 import { basicSetup, EditorView } from "codemirror";
 import {
+  aliasColumnCompletionSource,
   cteCompletionSource,
   DefaultSqlTooltipRenders,
   defaultSqlHoverTheme,
@@ -176,6 +177,10 @@ function initializeEditor() {
     }),
     defaultDialect.language.data.of({
       autocomplete: cteCompletionSource,
+    }),
+    defaultDialect.language.data.of({
+      // Complete `u.` -> columns of `users` in `SELECT ... FROM users u`
+      autocomplete: aliasColumnCompletionSource({ schema, parser }),
     }),
     // Custom theme for better SQL editing
     EditorView.theme({

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -11,7 +11,10 @@ describe("index.ts exports", () => {
       [
         "DefaultSqlTooltipRenders",
         "NodeSqlParser",
+        "QueryContextAnalyzer",
         "SqlStructureAnalyzer",
+        "aliasColumnCompletionSource",
+        "analyzeQueryContext",
         "cteCompletionSource",
         "defaultSqlHoverTheme",
         "resolveSqlSchema",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,7 @@
+export {
+  type AliasCompletionConfig,
+  aliasColumnCompletionSource,
+} from "./sql/alias-completion-source.js";
 export { cteCompletionSource } from "./sql/cte-completion-source.js";
 export { type SqlLinterConfig, sqlLinter } from "./sql/diagnostics.js";
 export { type SqlExtensionConfig, sqlExtension } from "./sql/extension.js";
@@ -15,6 +19,13 @@ export {
   type ParserOption,
   type SupportedDialects,
 } from "./sql/parser.js";
+export {
+  analyzeQueryContext,
+  type QueryContext,
+  QueryContextAnalyzer,
+  type QueryContextCte,
+  type QueryContextTable,
+} from "./sql/query-context.js";
 export { resolveSqlSchema, type SqlSchemaSource, sqlSchemaFacet } from "./sql/schema-facet.js";
 export {
   type SemanticSeverity,

--- a/src/sql/__tests__/alias-completion-source.test.ts
+++ b/src/sql/__tests__/alias-completion-source.test.ts
@@ -1,0 +1,149 @@
+import { CompletionContext, type CompletionResult } from "@codemirror/autocomplete";
+import type { SQLNamespace } from "@codemirror/lang-sql";
+import { EditorState } from "@codemirror/state";
+import { describe, expect, it } from "vitest";
+import { aliasColumnCompletionSource } from "../alias-completion-source.js";
+import { sqlSchemaFacet } from "../schema-facet.js";
+
+const schema: SQLNamespace = {
+  users: ["id", "username", "email"],
+  orders: [
+    { label: "order_id", detail: "Order ID", type: "property" },
+    "total",
+  ],
+};
+
+const nestedSchema: SQLNamespace = {
+  mydb: {
+    users: ["id", "username"],
+  },
+};
+
+async function complete(
+  doc: string,
+  opts: {
+    schema?: SQLNamespace;
+    pos?: number;
+    explicit?: boolean;
+    facetSchema?: SQLNamespace;
+  } = {},
+): Promise<CompletionResult | null> {
+  const source = aliasColumnCompletionSource(
+    opts.schema === undefined && opts.facetSchema !== undefined ? {} : { schema: opts.schema },
+  );
+  const state = EditorState.create({
+    doc,
+    extensions: opts.facetSchema !== undefined ? [sqlSchemaFacet.of(opts.facetSchema)] : [],
+  });
+  const pos = opts.pos ?? doc.length;
+  const context = new CompletionContext(state, pos, opts.explicit ?? false);
+  return (await source(context)) as CompletionResult | null;
+}
+
+function labels(result: CompletionResult | null): string[] {
+  return (result?.options ?? []).map((option) => option.label);
+}
+
+describe("aliasColumnCompletionSource", () => {
+  it("offers the aliased table's columns after `alias.`", async () => {
+    const result = await complete("SELECT u. FROM users u", {
+      schema,
+      pos: "SELECT u.".length,
+    });
+    expect(labels(result)).toEqual(["id", "username", "email"]);
+    expect(result?.from).toBe("SELECT u.".length);
+    expect(result?.options.every((option) => option.type === "property")).toBe(true);
+  });
+
+  it("completes with a typed prefix and keeps `from` after the dot", async () => {
+    const doc = "SELECT u.user FROM users u";
+    const result = await complete(doc, { schema, pos: "SELECT u.user".length });
+    expect(labels(result)).toEqual(["id", "username", "email"]);
+    expect(result?.from).toBe("SELECT u.".length);
+    expect(result?.validFor).toBeTruthy();
+  });
+
+  it("works on explicit completion requests", async () => {
+    const result = await complete("SELECT u. FROM users u", {
+      schema,
+      pos: "SELECT u.".length,
+      explicit: true,
+    });
+    expect(labels(result)).toEqual(["id", "username", "email"]);
+  });
+
+  it("resolves each alias in a join to its own table", async () => {
+    const doc = "SELECT o. FROM users u JOIN orders o ON u.id = o.user_id";
+    const result = await complete(doc, { schema, pos: "SELECT o.".length });
+    expect(labels(result)).toEqual(["order_id", "total"]);
+    // Completion objects from the schema are preserved
+    expect(result?.options.find((option) => option.label === "order_id")?.detail).toBe(
+      "Order ID",
+    );
+  });
+
+  it("resolves aliases of tables nested in the schema", async () => {
+    const result = await complete("SELECT u. FROM mydb.users u", {
+      schema: nestedSchema,
+      pos: "SELECT u.".length,
+    });
+    expect(labels(result)).toEqual(["id", "username"]);
+  });
+
+  it("offers CTE columns for a CTE alias", async () => {
+    const doc = "WITH recent AS (SELECT x, y FROM logs) SELECT r. FROM recent r";
+    const result = await complete(doc, { schema, pos: doc.indexOf("r. FROM") + 2 });
+    expect(labels(result)).toEqual(["x", "y"]);
+  });
+
+  it("falls back to the sqlSchemaFacet when no schema is configured", async () => {
+    const result = await complete("SELECT u. FROM users u", {
+      facetSchema: schema,
+      pos: "SELECT u.".length,
+    });
+    expect(labels(result)).toEqual(["id", "username", "email"]);
+  });
+
+  it("returns null when the qualifier is not an alias", async () => {
+    const result = await complete("SELECT x. FROM users u", {
+      schema,
+      pos: "SELECT x.".length,
+    });
+    expect(result).toBeNull();
+  });
+
+  it("returns null without a dot before the cursor", async () => {
+    const result = await complete("SELECT u FROM users u", {
+      schema,
+      pos: "SELECT u".length,
+    });
+    expect(result).toBeNull();
+  });
+
+  it("ignores multi-segment qualifiers like `db.table.`", async () => {
+    const doc = "SELECT mydb.users. FROM mydb.users u";
+    const result = await complete(doc, { schema: nestedSchema, pos: "SELECT mydb.users.".length });
+    expect(result).toBeNull();
+  });
+
+  it("scopes aliases to the statement containing the cursor", async () => {
+    const doc = "SELECT id FROM users u; SELECT u. FROM orders o";
+    const result = await complete(doc, { schema, pos: doc.indexOf("u. FROM orders") + 2 });
+    // `u` is aliased in statement 1, not statement 2
+    expect(result).toBeNull();
+  });
+
+  it("still completes while the statement is mid-edit (unparseable)", async () => {
+    const doc = "SELECT u. FROM users u WHERE";
+    const result = await complete(doc, { schema, pos: "SELECT u.".length });
+    expect(labels(result)).toEqual(["id", "username", "email"]);
+  });
+
+  it("returns null when the aliased table is not in the schema", async () => {
+    const result = await complete("SELECT m. FROM missing m", {
+      schema,
+      pos: "SELECT m.".length,
+    });
+    expect(result).toBeNull();
+  });
+});

--- a/src/sql/__tests__/alias-completion-source.test.ts
+++ b/src/sql/__tests__/alias-completion-source.test.ts
@@ -133,7 +133,7 @@ describe("aliasColumnCompletionSource", () => {
     expect(result).toBeNull();
   });
 
-  it("still completes while the statement is mid-edit (unparseable)", async () => {
+  it("still completes while the statement is mid-edit (unparsable)", async () => {
     const doc = "SELECT u. FROM users u WHERE";
     const result = await complete(doc, { schema, pos: "SELECT u.".length });
     expect(labels(result)).toEqual(["id", "username", "email"]);

--- a/src/sql/__tests__/alias-completion-source.test.ts
+++ b/src/sql/__tests__/alias-completion-source.test.ts
@@ -139,6 +139,26 @@ describe("aliasColumnCompletionSource", () => {
     expect(labels(result)).toEqual(["id", "username", "email"]);
   });
 
+  it("completes after a quoted alias qualifier", async () => {
+    const quotedSchema: SQLNamespace = { "User Table": ["id", "full_name"] };
+    const doc = 'SELECT "ut". FROM "User Table" ut';
+    const result = await complete(doc, { schema: quotedSchema, pos: 'SELECT "ut".'.length });
+    expect(labels(result)).toEqual(["id", "full_name"]);
+  });
+
+  it("forces the property type but keeps schema-provided details", async () => {
+    const typedSchema: SQLNamespace = {
+      users: [{ label: "id", type: "keyword", detail: "Primary key" }],
+    };
+    const result = await complete("SELECT u. FROM users u", {
+      schema: typedSchema,
+      pos: "SELECT u.".length,
+    });
+    expect(result?.options).toEqual([
+      { label: "id", type: "property", detail: "Primary key" },
+    ]);
+  });
+
   it("returns null when the aliased table is not in the schema", async () => {
     const result = await complete("SELECT m. FROM missing m", {
       schema,

--- a/src/sql/__tests__/hover-integration.test.ts
+++ b/src/sql/__tests__/hover-integration.test.ts
@@ -950,7 +950,7 @@ describe("Query-aware hover behavior - edge cases", () => {
 
       it("still resolves aliases while the statement is mid-edit", async () => {
         const source = createHoverSource({ schema });
-        // Trailing WHERE makes the statement unparseable
+        // Trailing WHERE makes the statement unparsable
         const doc = "SELECT u.name FROM users u WHERE";
         const view = createMockView(doc);
 

--- a/src/sql/__tests__/hover-integration.test.ts
+++ b/src/sql/__tests__/hover-integration.test.ts
@@ -809,6 +809,20 @@ describe("Query-aware hover behavior - edge cases", () => {
       return { state } as unknown as EditorView;
     }
 
+    it("only shows hovers for tables when columns are disabled (and vice versa)", async () => {
+      const schema = { users: ["id", "name"] };
+      const doc = "SELECT name FROM users";
+      const view = createMockView(doc);
+
+      const tablesOnly = createHoverSource({ schema, enableColumns: false });
+      expect(await tablesOnly(view, doc.indexOf("users") + 2, 1)).not.toBeNull();
+      expect(await tablesOnly(view, doc.indexOf("name") + 2, 1)).toBeNull();
+
+      const columnsOnly = createHoverSource({ schema, enableTables: false });
+      expect(await columnsOnly(view, doc.indexOf("users") + 2, 1)).toBeNull();
+      expect(await columnsOnly(view, doc.indexOf("name") + 2, 1)).not.toBeNull();
+    });
+
     it("does not show keyword tooltips for Object.prototype members", async () => {
       const source = createHoverSource({ keywords: {}, schema: {} });
 
@@ -831,6 +845,107 @@ describe("Query-aware hover behavior - edge cases", () => {
 
       const tooltip = await source(view, doc.indexOf("SELECT") + 2, 1);
       expect(tooltip).not.toBeNull();
+    });
+
+    describe("alias-aware resolution", () => {
+      const schema = {
+        users: ["id", "name", "email"],
+        orders: ["order_id", "total"],
+      };
+
+      function renderTooltip(
+        tooltip: Awaited<ReturnType<ReturnType<typeof createHoverSource>>>,
+        view: EditorView,
+      ): string {
+        if (!tooltip) {
+          throw new Error("expected a tooltip");
+        }
+        return tooltip.create(view).dom.innerHTML;
+      }
+
+      it("resolves a bare alias to its table and labels it as an alias", async () => {
+        const source = createHoverSource({ schema });
+        const doc = "SELECT u.name FROM users u";
+        const view = createMockView(doc);
+
+        const tooltip = await source(view, doc.length - 1, 1);
+        const html = renderTooltip(tooltip, view);
+        expect(html).toContain("is an alias for");
+        expect(html).toContain("users");
+        expect(html).toContain("table");
+      });
+
+      it("resolves alias-qualified columns to the aliased table", async () => {
+        const source = createHoverSource({ schema });
+        const doc = "SELECT u.name FROM users u";
+        const view = createMockView(doc);
+
+        const tooltip = await source(view, doc.indexOf("u.name") + 3, 1);
+        const html = renderTooltip(tooltip, view);
+        expect(html).toContain("<strong>name</strong>");
+        expect(html).toContain("column");
+        expect(html).toContain("users");
+      });
+
+      it("supports AS aliases", async () => {
+        const source = createHoverSource({ schema });
+        const doc = "SELECT u.email FROM users AS u";
+        const view = createMockView(doc);
+
+        const tooltip = await source(view, doc.indexOf("u.email") + 3, 1);
+        const html = renderTooltip(tooltip, view);
+        expect(html).toContain("<strong>email</strong>");
+        expect(html).toContain("column");
+      });
+
+      it("resolves each alias in a join to its own table", async () => {
+        const source = createHoverSource({ schema });
+        const doc = "SELECT u.name, o.total FROM users u JOIN orders o ON u.id = o.order_id";
+        const view = createMockView(doc);
+
+        const totalHtml = renderTooltip(await source(view, doc.indexOf("o.total") + 3, 1), view);
+        expect(totalHtml).toContain("<strong>total</strong>");
+        expect(totalHtml).toContain("orders");
+
+        const nameHtml = renderTooltip(await source(view, doc.indexOf("u.name") + 3, 1), view);
+        expect(nameHtml).toContain("<strong>name</strong>");
+        expect(nameHtml).toContain("users");
+      });
+
+      it("lets an alias shadow a real table name within the statement", async () => {
+        const source = createHoverSource({ schema });
+        // `orders` aliases the users table here; `orders.name` must resolve to
+        // users.name (the real orders table has no `name` column)
+        const doc = "SELECT orders.name FROM users orders";
+        const view = createMockView(doc);
+
+        const tooltip = await source(view, doc.indexOf("orders.name") + 8, 1);
+        const html = renderTooltip(tooltip, view);
+        expect(html).toContain("<strong>name</strong>");
+        expect(html).toContain("users");
+      });
+
+      it("does not leak tables across statement boundaries", async () => {
+        const source = createHoverSource({ schema, enableFuzzySearch: true });
+        const doc = "SELECT name FROM users; SELECT name FROM orders";
+        const view = createMockView(doc);
+
+        // In statement 1, `name` resolves in users
+        expect(await source(view, doc.indexOf("name") + 2, 1)).not.toBeNull();
+        // In statement 2, only orders is in scope and it has no `name` column
+        expect(await source(view, doc.lastIndexOf("name") + 2, 1)).toBeNull();
+      });
+
+      it("still resolves aliases while the statement is mid-edit", async () => {
+        const source = createHoverSource({ schema });
+        // Trailing WHERE makes the statement unparseable
+        const doc = "SELECT u.name FROM users u WHERE";
+        const view = createMockView(doc);
+
+        const tooltip = await source(view, doc.indexOf("u.name") + 3, 1);
+        const html = renderTooltip(tooltip, view);
+        expect(html).toContain("<strong>name</strong>");
+      });
     });
 
     it("does not permanently disable hovers when the keywords promise rejects", async () => {

--- a/src/sql/__tests__/hover-integration.test.ts
+++ b/src/sql/__tests__/hover-integration.test.ts
@@ -925,6 +925,18 @@ describe("Query-aware hover behavior - edge cases", () => {
         expect(html).toContain("users");
       });
 
+      it("escapes markup in alias targets before rendering", async () => {
+        const source = createHoverSource({ schema: { "<b>t</b>": ["x"] } });
+        const doc = 'SELECT x FROM "<b>t</b>" a';
+        const view = createMockView(doc);
+
+        const tooltip = await source(view, doc.length - 1, 1);
+        const html = renderTooltip(tooltip, view);
+        expect(html).toContain("is an alias for");
+        expect(html).toContain("&lt;b&gt;t&lt;/b&gt;");
+        expect(html).not.toContain("alias for <code><b>");
+      });
+
       it("does not leak tables across statement boundaries", async () => {
         const source = createHoverSource({ schema, enableFuzzySearch: true });
         const doc = "SELECT name FROM users; SELECT name FROM orders";

--- a/src/sql/__tests__/query-context.test.ts
+++ b/src/sql/__tests__/query-context.test.ts
@@ -1,0 +1,190 @@
+import { EditorState } from "@codemirror/state";
+import { describe, expect, it, vi } from "vitest";
+import { NodeSqlParser } from "../parser.js";
+import {
+  analyzeQueryContext,
+  type QueryContext,
+  QueryContextAnalyzer,
+  stripIdentifierQuotes,
+} from "../query-context.js";
+
+const parser = new NodeSqlParser();
+
+async function analyze(sql: string): Promise<QueryContext> {
+  return analyzeQueryContext(sql, parser, { state: EditorState.create({ doc: sql }) });
+}
+
+describe("analyzeQueryContext", () => {
+  it("returns an empty context for empty input", async () => {
+    const context = await analyze("   ");
+    expect(context.tables).toEqual([]);
+    expect(context.ctes).toEqual([]);
+    expect(context.aliases.size).toBe(0);
+    expect(context.selectAliases).toEqual([]);
+  });
+
+  it("extracts a bare alias (no AS)", async () => {
+    const context = await analyze("SELECT u.name FROM users u");
+    expect(context.tables).toEqual([{ name: "users", path: ["users"], alias: "u" }]);
+    expect(context.aliases.get("u")).toBe("users");
+  });
+
+  it("extracts an AS alias", async () => {
+    const context = await analyze("SELECT u.name FROM users AS u");
+    expect(context.aliases.get("u")).toBe("users");
+  });
+
+  it("records tables without aliases", async () => {
+    const context = await analyze("SELECT name FROM users");
+    expect(context.tables).toEqual([{ name: "users", path: ["users"] }]);
+    expect(context.aliases.size).toBe(0);
+  });
+
+  it("extracts both aliases from a join", async () => {
+    const context = await analyze(
+      "SELECT u.name, o.total FROM users u JOIN orders o ON u.id = o.user_id",
+    );
+    expect(context.aliases.get("u")).toBe("users");
+    expect(context.aliases.get("o")).toBe("orders");
+    expect(context.tables).toHaveLength(2);
+  });
+
+  it("lets an alias shadow a real table name", async () => {
+    // `orders` here is an alias for `users`, not the orders table
+    const context = await analyze("SELECT orders.name FROM users orders");
+    expect(context.aliases.get("orders")).toBe("users");
+  });
+
+  it("keeps qualified paths in the alias target", async () => {
+    const context = await analyze("SELECT u.name FROM mydb.users u");
+    expect(context.tables).toEqual([{ name: "users", path: ["mydb", "users"], alias: "u" }]);
+    expect(context.aliases.get("u")).toBe("mydb.users");
+  });
+
+  it("extracts aliases from subqueries", async () => {
+    const context = await analyze(
+      "SELECT * FROM (SELECT u.id FROM users u) sub WHERE sub.id > 1",
+    );
+    expect(context.aliases.get("u")).toBe("users");
+  });
+
+  it("collects select-list aliases", async () => {
+    const context = await analyze("SELECT count(*) AS total, name AS n FROM users");
+    expect(context.selectAliases).toEqual(["total", "n"]);
+  });
+
+  describe("CTEs", () => {
+    it("extracts a CTE with inferred columns and its alias", async () => {
+      const sql = "WITH recent AS (SELECT x, y FROM logs) SELECT r.x FROM recent r";
+      const context = await analyze(sql);
+
+      expect(context.ctes).toHaveLength(1);
+      const cte = context.ctes[0];
+      expect(cte?.name).toBe("recent");
+      expect(cte?.columns).toEqual(["x", "y"]);
+      expect(cte?.from).toBe(sql.indexOf("recent"));
+      expect(cte?.to).toBe(sql.indexOf("recent") + "recent".length);
+
+      expect(context.aliases.get("r")).toBe("recent");
+      // The CTE body's table is still visible
+      expect(context.tables.some((t) => t.name === "logs")).toBe(true);
+    });
+
+    it("prefers declared CTE column lists", async () => {
+      const context = await analyze(
+        "WITH recent (a, b) AS (SELECT x, y FROM logs) SELECT * FROM recent",
+      );
+      expect(context.ctes[0]?.columns).toEqual(["a", "b"]);
+    });
+
+    it("uses select aliases as CTE output columns", async () => {
+      const context = await analyze(
+        "WITH stats AS (SELECT count(*) AS n FROM logs) SELECT * FROM stats",
+      );
+      expect(context.ctes[0]?.columns).toEqual(["n"]);
+    });
+
+    it("extracts multiple CTEs", async () => {
+      const context = await analyze(
+        "WITH a AS (SELECT id FROM users), b AS (SELECT id FROM orders) SELECT * FROM a JOIN b ON a.id = b.id",
+      );
+      expect(context.ctes.map((c) => c.name)).toEqual(["a", "b"]);
+    });
+  });
+
+  describe("regex fallback for unparseable statements", () => {
+    it("still resolves aliases mid-edit", async () => {
+      // Trailing dot makes this unparseable
+      const context = await analyze("SELECT u. FROM users u");
+      expect(context.aliases.get("u")).toBe("users");
+      expect(context.tables).toEqual([{ name: "users", path: ["users"], alias: "u" }]);
+    });
+
+    it("does not treat keywords after a table as aliases", async () => {
+      const context = await analyze("SELECT u.name, FROM users u JOIN orders WHERE x = 1");
+      expect(context.aliases.get("u")).toBe("users");
+      expect(context.aliases.has("where")).toBe(false);
+      expect(context.tables.some((t) => t.name === "orders" && t.alias)).toBe(false);
+    });
+
+    it("handles AS aliases and qualified paths", async () => {
+      const context = await analyze("SELECT FROM mydb.users AS u WHERE u.");
+      expect(context.aliases.get("u")).toBe("mydb.users");
+    });
+
+    it("strips quotes from quoted identifiers but resolves the alias", async () => {
+      const context = await analyze('SELECT ut. FROM "User Table" ut');
+      expect(context.aliases.get("ut")).toBe("User Table");
+      expect(context.tables[0]?.name).toBe("User Table");
+    });
+
+    it("extracts CTEs with declared columns", async () => {
+      const sql = "WITH recent (a, b) AS (SELECT x FROM logs WHERE ) SELECT r. FROM recent r";
+      const context = await analyze(sql);
+      expect(context.ctes[0]?.name).toBe("recent");
+      expect(context.ctes[0]?.columns).toEqual(["a", "b"]);
+      expect(context.ctes[0]?.from).toBe(sql.indexOf("recent"));
+      expect(context.aliases.get("r")).toBe("recent");
+    });
+  });
+});
+
+describe("QueryContextAnalyzer", () => {
+  it("caches by statement text", async () => {
+    const spy = vi.spyOn(parser, "parse");
+    const analyzer = new QueryContextAnalyzer(parser);
+    const sql = "SELECT u.name FROM users u";
+    const state = EditorState.create({ doc: sql });
+
+    const first = await analyzer.getContext(sql, { state });
+    const second = await analyzer.getContext(sql, { state });
+    expect(second).toBe(first);
+    expect(spy).toHaveBeenCalledTimes(1);
+    spy.mockRestore();
+  });
+
+  it("clears its cache", async () => {
+    const analyzer = new QueryContextAnalyzer(parser);
+    const sql = "SELECT u.name FROM users u";
+    const state = EditorState.create({ doc: sql });
+
+    const first = await analyzer.getContext(sql, { state });
+    analyzer.clearCache();
+    const second = await analyzer.getContext(sql, { state });
+    expect(second).not.toBe(first);
+    expect(second).toEqual(first);
+  });
+});
+
+describe("stripIdentifierQuotes", () => {
+  it.each([
+    ['"User Table"', "User Table"],
+    ["`users`", "users"],
+    ["[users]", "users"],
+    ["'users'", "users"],
+    ["users", "users"],
+    ['"', '"'],
+  ])("strips %s to %s", (input, expected) => {
+    expect(stripIdentifierQuotes(input)).toBe(expected);
+  });
+});

--- a/src/sql/__tests__/query-context.test.ts
+++ b/src/sql/__tests__/query-context.test.ts
@@ -127,6 +127,32 @@ describe("analyzeQueryContext", () => {
       expect(context.tables.some((t) => t.name === "orders" && t.alias)).toBe(false);
     });
 
+    it("still records a joined table when the previous table has no alias", async () => {
+      const context = await analyze("SELECT FROM users JOIN orders o ON ");
+      expect(context.tables.map((t) => t.name)).toEqual(["users", "orders"]);
+      expect(context.aliases.get("o")).toBe("orders");
+    });
+
+    it("ignores FROM/JOIN inside string literals", async () => {
+      const context = await analyze("SELECT u. FROM users u WHERE name = 'from phantom p'");
+      expect(context.tables.map((t) => t.name)).toEqual(["users"]);
+      expect(context.aliases.has("p")).toBe(false);
+    });
+
+    it("ignores FROM/JOIN inside comments", async () => {
+      const context = await analyze(
+        "SELECT u. -- join phantom ph\n/* from ghost g */ FROM users u",
+      );
+      expect(context.tables.map((t) => t.name)).toEqual(["users"]);
+      expect(context.aliases.has("ph")).toBe(false);
+      expect(context.aliases.has("g")).toBe(false);
+    });
+
+    it("does not let a quote inside a quoted identifier start a string", async () => {
+      const context = await analyze(`SELECT x. FROM "it's" x`);
+      expect(context.aliases.get("x")).toBe("it's");
+    });
+
     it("handles AS aliases and qualified paths", async () => {
       const context = await analyze("SELECT FROM mydb.users AS u WHERE u.");
       expect(context.aliases.get("u")).toBe("mydb.users");

--- a/src/sql/__tests__/query-context.test.ts
+++ b/src/sql/__tests__/query-context.test.ts
@@ -112,9 +112,9 @@ describe("analyzeQueryContext", () => {
     });
   });
 
-  describe("regex fallback for unparseable statements", () => {
+  describe("regex fallback for unparsable statements", () => {
     it("still resolves aliases mid-edit", async () => {
-      // Trailing dot makes this unparseable
+      // Trailing dot makes this unparsable
       const context = await analyze("SELECT u. FROM users u");
       expect(context.aliases.get("u")).toBe("users");
       expect(context.tables).toEqual([{ name: "users", path: ["users"], alias: "u" }]);

--- a/src/sql/alias-completion-source.ts
+++ b/src/sql/alias-completion-source.ts
@@ -1,0 +1,176 @@
+import type { Completion, CompletionContext, CompletionSource } from "@codemirror/autocomplete";
+import type { SQLNamespace } from "@codemirror/lang-sql";
+import {
+  findNamespaceItemByEndMatch,
+  isArrayNamespace,
+  isSelfChildrenNamespace,
+  type ResolvedNamespaceItem,
+  traverseNamespacePath,
+} from "./namespace-utils.js";
+import { NodeSqlParser } from "./parser.js";
+import { type QueryContext, QueryContextAnalyzer } from "./query-context.js";
+import { type SqlSchemaSource, sqlSchemaFacet } from "./schema-facet.js";
+import { SqlStructureAnalyzer } from "./structure-analyzer.js";
+import type { SqlParser } from "./types.js";
+
+/**
+ * Configuration for the alias-aware column completion source
+ */
+export interface AliasCompletionConfig {
+  /**
+   * Database schema to complete columns from. Falls back to the shared
+   * `sqlSchemaFacet` when not provided.
+   */
+  schema?: SqlSchemaSource;
+  /** Custom SQL parser instance to use for query analysis */
+  parser?: SqlParser;
+  /**
+   * Query-context analyzer to reuse (e.g. the one backing hover), so the
+   * statement is only analyzed once per edit.
+   */
+  contextAnalyzer?: QueryContextAnalyzer;
+}
+
+function resolveSchema(
+  explicit: SqlSchemaSource | undefined,
+  context: CompletionContext,
+): SQLNamespace | null {
+  const source = explicit ?? context.state.facet(sqlSchemaFacet);
+  if (source == null) {
+    return null;
+  }
+  if (typeof source === "function") {
+    // Function sources need a view; contexts created without one (e.g. tests)
+    // simply get no schema
+    return context.view ? source(context.view) : null;
+  }
+  return source;
+}
+
+/** Column list of a namespace node, when it is (or wraps) a column array */
+function columnsOf(namespace: SQLNamespace | undefined): readonly (Completion | string)[] | null {
+  if (namespace == null) {
+    return null;
+  }
+  const resolved = isSelfChildrenNamespace(namespace) ? namespace.children : namespace;
+  return isArrayNamespace(resolved) ? resolved : null;
+}
+
+/**
+ * Resolves a (possibly qualified) table path to its column list,
+ * case-insensitively. An under-qualified name also matches a table nested
+ * deeper in the namespace (e.g. `users` matches `mydb.users`).
+ */
+function findTableColumns(
+  schema: SQLNamespace,
+  tablePath: string,
+): readonly (Completion | string)[] | null {
+  const exact = traverseNamespacePath(schema, tablePath, { caseSensitive: false });
+  const exactColumns = columnsOf(exact?.namespace);
+  if (exactColumns) {
+    return exactColumns;
+  }
+
+  const segments = tablePath.split(".").map((segment) => segment.toLowerCase());
+  const lastSegment = segments[segments.length - 1];
+  if (!lastSegment) {
+    return null;
+  }
+
+  const matches = findNamespaceItemByEndMatch(schema, lastSegment).filter(
+    (item: ResolvedNamespaceItem) => {
+      if (columnsOf(item.namespace) === null) {
+        return false;
+      }
+      if (item.path.length < segments.length) {
+        return false;
+      }
+      const suffix = item.path.slice(-segments.length).map((segment) => segment.toLowerCase());
+      return segments.every((segment, i) => suffix[i] === segment);
+    },
+  );
+
+  // Only trust the column list when the match is unambiguous
+  return matches.length === 1 ? columnsOf(matches[0]?.namespace) : null;
+}
+
+function toCompletion(column: Completion | string, detail: string): Completion {
+  if (typeof column === "string") {
+    return { label: column, type: "property", detail };
+  }
+  return { type: "property", detail, ...column };
+}
+
+/**
+ * Creates a completion source that offers a table's columns after an alias
+ * qualifier: with `SELECT ... FROM users u`, typing `u.` completes the columns
+ * of `users`. Aliases of CTEs complete the CTE's declared/inferred columns.
+ *
+ * @example
+ * ```ts
+ * import { aliasColumnCompletionSource } from '@marimo-team/codemirror-sql';
+ * import { StandardSQL } from '@codemirror/lang-sql';
+ *
+ * StandardSQL.language.data.of({
+ *   autocomplete: aliasColumnCompletionSource({ schema: { users: ['id', 'name'] } }),
+ * })
+ * ```
+ */
+export function aliasColumnCompletionSource(config: AliasCompletionConfig = {}): CompletionSource {
+  const parser = config.parser ?? new NodeSqlParser();
+  const contextAnalyzer = config.contextAnalyzer ?? new QueryContextAnalyzer(parser);
+  const structureAnalyzer = new SqlStructureAnalyzer(parser);
+
+  return async (context: CompletionContext) => {
+    // Match `<alias>.<partial>` immediately before the cursor
+    const match = context.matchBefore(/[\w$]+\.[\w$]*/);
+    if (!match) {
+      return null;
+    }
+    // Skip multi-segment paths like `db.table.` — only bare qualifiers can be
+    // aliases
+    if (context.state.sliceDoc(Math.max(0, match.from - 1), match.from) === ".") {
+      return null;
+    }
+
+    const dotIndex = match.text.indexOf(".");
+    const qualifier = match.text.slice(0, dotIndex);
+
+    const statement = await structureAnalyzer.getStatementAtPosition(context.state, context.pos);
+    const statementSql = statement
+      ? context.state.sliceDoc(statement.from, statement.to)
+      : context.state.doc.toString();
+    const queryContext: QueryContext = await contextAnalyzer.getContext(statementSql, {
+      state: context.state,
+    });
+
+    const target = queryContext.aliases.get(qualifier.toLowerCase());
+    if (!target) {
+      return null;
+    }
+
+    let columns: readonly (Completion | string)[] | null = null;
+
+    // Alias of a CTE: use the CTE's declared/inferred output columns
+    const cte = queryContext.ctes.find((c) => c.name.toLowerCase() === target.toLowerCase());
+    if (cte && cte.columns.length > 0) {
+      columns = cte.columns;
+    } else if (!cte) {
+      const schema = resolveSchema(config.schema, context);
+      if (schema != null) {
+        columns = findTableColumns(schema, target);
+      }
+    }
+
+    if (!columns || columns.length === 0) {
+      return null;
+    }
+
+    const detail = `column of ${target}`;
+    return {
+      from: match.from + dotIndex + 1,
+      options: columns.map((column) => toCompletion(column, detail)),
+      validFor: /^[\w$]*$/,
+    };
+  };
+}

--- a/src/sql/alias-completion-source.ts
+++ b/src/sql/alias-completion-source.ts
@@ -8,7 +8,11 @@ import {
   traverseNamespacePath,
 } from "./namespace-utils.js";
 import { NodeSqlParser } from "./parser.js";
-import { type QueryContext, QueryContextAnalyzer } from "./query-context.js";
+import {
+  type QueryContext,
+  QueryContextAnalyzer,
+  stripIdentifierQuotes,
+} from "./query-context.js";
 import { type SqlSchemaSource, sqlSchemaFacet } from "./schema-facet.js";
 import { SqlStructureAnalyzer } from "./structure-analyzer.js";
 import type { SqlParser } from "./types.js";
@@ -98,7 +102,7 @@ function toCompletion(column: Completion | string, detail: string): Completion {
   if (typeof column === "string") {
     return { label: column, type: "property", detail };
   }
-  return { type: "property", detail, ...column };
+  return { ...column, type: "property", detail: column.detail ?? detail };
 }
 
 /**
@@ -122,8 +126,9 @@ export function aliasColumnCompletionSource(config: AliasCompletionConfig = {}):
   const structureAnalyzer = new SqlStructureAnalyzer(parser);
 
   return async (context: CompletionContext) => {
-    // Match `<alias>.<partial>` immediately before the cursor
-    const match = context.matchBefore(/[\w$]+\.[\w$]*/);
+    // Match `<alias>.<partial>` immediately before the cursor; the alias may
+    // be a quoted identifier ("ut"., `ut`., [ut].)
+    const match = context.matchBefore(/(?:[\w$]+|"[^"]+"|`[^`]+`|\[[^\]]+\])\.[\w$]*/);
     if (!match) {
       return null;
     }
@@ -133,8 +138,10 @@ export function aliasColumnCompletionSource(config: AliasCompletionConfig = {}):
       return null;
     }
 
-    const dotIndex = match.text.indexOf(".");
-    const qualifier = match.text.slice(0, dotIndex);
+    // The partial after the dot contains no dots, so the last dot is the
+    // qualifier separator even for quoted qualifiers like `"a.b".`
+    const dotIndex = match.text.lastIndexOf(".");
+    const qualifier = stripIdentifierQuotes(match.text.slice(0, dotIndex));
 
     const statement = await structureAnalyzer.getStatementAtPosition(context.state, context.pos);
     const statementSql = statement

--- a/src/sql/hover.ts
+++ b/src/sql/hover.ts
@@ -9,7 +9,9 @@ import {
   resolveNamespaceItem,
 } from "./namespace-utils.js";
 import { NodeSqlParser } from "./parser.js";
+import { QueryContextAnalyzer } from "./query-context.js";
 import { resolveSqlSchema } from "./schema-facet.js";
+import { SqlStructureAnalyzer } from "./structure-analyzer.js";
 import type { SqlParser } from "./types.js";
 
 /**
@@ -89,6 +91,11 @@ export interface NamespaceTooltipData {
   word: string;
   /** The resolved schema context */
   resolvedSchema: SQLNamespace;
+  /**
+   * When the hovered word was an alias (or alias-qualified), the dotted table
+   * path the alias resolves to, e.g. `users` for `SELECT u.name FROM users u`.
+   */
+  aliasFor?: string;
 }
 
 /**
@@ -130,6 +137,11 @@ export interface SqlHoverConfig {
   enableFuzzySearch?: boolean;
   /** Custom SQL parser instance to use for query analysis */
   parser?: SqlParser;
+  /**
+   * Query-context analyzer to reuse (e.g. shared with
+   * `aliasColumnCompletionSource`), so each statement is only analyzed once.
+   */
+  contextAnalyzer?: QueryContextAnalyzer;
   /** Custom tooltip render function - highest priority, returns HTMLElement or null for fallback */
   tooltipRender?: (word: string, view: EditorView, pos: number) => HTMLElement | null;
   /** Custom tooltip renderers for different item types */
@@ -164,6 +176,9 @@ function createHoverSource(
     tooltipRender,
     tooltipRenderers = {},
   } = config;
+
+  const structureAnalyzer = new SqlStructureAnalyzer(parser);
+  const contextAnalyzer = config.contextAnalyzer ?? new QueryContextAnalyzer(parser);
 
   let keywordsPromise: Promise<Record<string, SqlKeywordInfo>> | null = null;
 
@@ -231,25 +246,52 @@ function createHoverSource(
 
     // Step 2: Try to resolve directly in SQLNamespace (query-aware)
     if (!createData && (enableTables || enableColumns) && resolvedSchema) {
-      // Get the current SQL query to filter schema by referenced tables
-      const currentQuery = view.state.doc.toString();
-      const tableList = await parser.extractTableReferences(currentQuery);
-      const tableRefs = new Set(tableList.map((table: string) => table.toLowerCase()));
+      // Scope the analysis to the statement containing the hover position, so
+      // tables from other statements in a multi-statement doc don't leak in
+      const statement = await structureAnalyzer.getStatementAtPosition(view.state, pos);
+      const statementSql = statement
+        ? view.state.doc.sliceString(statement.from, statement.to)
+        : view.state.doc.toString();
+      const queryContext = await contextAnalyzer.getContext(statementSql, {
+        state: view.state,
+      });
 
-      // Filter schema to only include tables referenced in the current query
+      // Rewrite alias-qualified words through the statement's alias map:
+      // `u` -> `users`, `u.name` -> `users.name`
+      const [firstSegment = "", ...restSegments] = word.split(".");
+      const aliasTarget = queryContext.aliases.get(firstSegment);
+      const lookupWord = aliasTarget
+        ? [aliasTarget, ...restSegments].join(".").toLowerCase()
+        : word;
+
+      const tableRefs = new Set(queryContext.tables.map((table) => table.name.toLowerCase()));
+
+      // Filter schema to only include tables referenced in the current statement
       const filteredSchema = filterSchemaByTableRefs(resolvedSchema, tableRefs);
 
       // Try to resolve in the filtered schema first (query-aware)
-      let namespaceResult = resolveNamespaceItem(filteredSchema, word, {
+      let namespaceResult = resolveNamespaceItem(filteredSchema, lookupWord, {
         enableFuzzySearch,
       });
 
-      // If no result in filtered schema and no tables were found in query,
-      // fall back to the full schema to show any relevant information
+      // If no result in filtered schema and no tables were found in the
+      // statement, fall back to the full schema to show any relevant information
       if (!namespaceResult && tableRefs.size === 0) {
-        namespaceResult = resolveNamespaceItem(resolvedSchema, word, {
+        namespaceResult = resolveNamespaceItem(resolvedSchema, lookupWord, {
           enableFuzzySearch,
         });
+      }
+
+      // Gate by the resolved semantic type so disabling only tables (or only
+      // columns) actually disables that kind of tooltip
+      if (namespaceResult) {
+        const { semanticType } = namespaceResult;
+        if (
+          (semanticType === "table" && !enableTables) ||
+          (semanticType === "column" && !enableColumns)
+        ) {
+          namespaceResult = null;
+        }
       }
 
       if (namespaceResult) {
@@ -264,6 +306,7 @@ function createHoverSource(
           item: namespaceResult,
           word,
           resolvedSchema: tableRefs.size > 0 ? filteredSchema : resolvedSchema,
+          ...(aliasTarget ? { aliasFor: aliasTarget } : {}),
         };
 
         createData = {
@@ -324,6 +367,12 @@ function createHoverSource(
           } else {
             // Fallback to default renderer
             tooltipContent = createNamespaceTooltip(namespaceData.item);
+            if (namespaceData.aliasFor) {
+              const aliasName = namespaceData.word.split(".")[0];
+              tooltipContent =
+                `<div class="sql-hover-alias"><code>${aliasName}</code> is an alias for <code>${namespaceData.aliasFor}</code></div>` +
+                tooltipContent;
+            }
           }
         }
 
@@ -680,6 +729,11 @@ export const defaultSqlHoverTheme = (theme: "light" | "dark" = "light"): Extensi
     ".cm-sql-hover-tooltip .sql-hover-info": {
       marginBottom: "4px",
       color: colors.info,
+    },
+    ".cm-sql-hover-tooltip .sql-hover-alias": {
+      marginBottom: "6px",
+      color: colors.tooltipChildren,
+      fontSize: "12px",
     },
     ".cm-sql-hover-tooltip .sql-hover-children": {
       marginBottom: "4px",

--- a/src/sql/hover.ts
+++ b/src/sql/hover.ts
@@ -368,9 +368,10 @@ function createHoverSource(
             // Fallback to default renderer
             tooltipContent = createNamespaceTooltip(namespaceData.item);
             if (namespaceData.aliasFor) {
-              const aliasName = namespaceData.word.split(".")[0];
+              // Alias targets come from document text, so escape them
+              const aliasName = escapeHtml(namespaceData.word.split(".")[0] ?? "");
               tooltipContent =
-                `<div class="sql-hover-alias"><code>${aliasName}</code> is an alias for <code>${namespaceData.aliasFor}</code></div>` +
+                `<div class="sql-hover-alias"><code>${aliasName}</code> is an alias for <code>${escapeHtml(namespaceData.aliasFor)}</code></div>` +
                 tooltipContent;
             }
           }
@@ -398,6 +399,14 @@ export function sqlHover(config: SqlHoverConfig = {}): Extension {
 }
 
 export const exportedForTesting = { createHoverSource };
+
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
 
 /**
  * Creates HTML content for namespace-resolved items

--- a/src/sql/parser.ts
+++ b/src/sql/parser.ts
@@ -338,8 +338,10 @@ function replaceBracketsWithQuotes(sql: string): {
 } {
   const offsetRecord: Record<number, number> = {};
 
+  // Quote bodies use the unrolled-loop form (`[^"\\]*(?:\\.[^"\\]*)*`) instead
+  // of `(?:[^"\\]|\\.)*` to avoid polynomial backtracking on unclosed strings
   const replacedSql = sql.replace(
-    /("(?:[^"\\]|\\.)*")|('(?:[^'\\]|\\.)*')|(\{[^}]*\})/g,
+    /("[^"\\]*(?:\\.[^"\\]*)*")|('[^'\\]*(?:\\.[^'\\]*)*')|(\{[^}]*\})/g,
     (match, doubleQuoted, singleQuoted, bracket, offset) => {
       // If it's a quoted string, return it as-is
       if (doubleQuoted || singleQuoted) {

--- a/src/sql/query-context.ts
+++ b/src/sql/query-context.ts
@@ -1,0 +1,547 @@
+import type { EditorState } from "@codemirror/state";
+import { debug } from "../debug.js";
+import { NodeSqlParser } from "./parser.js";
+import type { SqlParser } from "./types.js";
+
+/**
+ * A table-like source referenced by a statement (FROM/JOIN entries and
+ * INSERT/UPDATE/DELETE targets).
+ */
+export interface QueryContextTable {
+  /** Unqualified table name (quotes stripped) */
+  name: string;
+  /** Full dotted path as written, e.g. ["mydb", "users"] (quotes stripped) */
+  path: string[];
+  /** Alias as written (quotes stripped), if any */
+  alias?: string;
+}
+
+/**
+ * A CTE declared in the statement's WITH clause
+ */
+export interface QueryContextCte {
+  name: string;
+  /** Declared or inferred output columns (empty when unknown) */
+  columns: string[];
+  /** Start of the CTE name in the statement text (-1 when not found) */
+  from: number;
+  /** End of the CTE name in the statement text (-1 when not found) */
+  to: number;
+}
+
+/**
+ * Statement-scoped analysis of table references, aliases, and CTEs, used to
+ * resolve alias-qualified identifiers in hover tooltips and completions.
+ */
+export interface QueryContext {
+  tables: QueryContextTable[];
+  ctes: QueryContextCte[];
+  /** alias (lowercase) -> dotted table path / CTE name as written */
+  aliases: Map<string, string>;
+  /** AS aliases in the top-level select list */
+  selectAliases: string[];
+}
+
+function emptyContext(): QueryContext {
+  return { tables: [], ctes: [], aliases: new Map(), selectAliases: [] };
+}
+
+/** Loosely-typed node-sql-parser AST node */
+interface AstNode {
+  [key: string]: unknown;
+}
+
+function isRecord(value: unknown): value is AstNode {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function asArray(value: unknown): AstNode[] {
+  return Array.isArray(value) ? (value as AstNode[]) : [];
+}
+
+/**
+ * Strips one layer of identifier quoting: "x", 'x', `x`, [x]
+ */
+export function stripIdentifierQuotes(identifier: string): string {
+  const first = identifier[0];
+  const last = identifier[identifier.length - 1];
+  if (
+    identifier.length >= 2 &&
+    ((first === '"' && last === '"') ||
+      (first === "'" && last === "'") ||
+      (first === "`" && last === "`") ||
+      (first === "[" && last === "]"))
+  ) {
+    return identifier.slice(1, -1);
+  }
+  return identifier;
+}
+
+/** Extracts a name that may be a plain string or a `{value}` wrapper node */
+function nameValue(value: unknown): string | null {
+  if (typeof value === "string") {
+    return value;
+  }
+  if (isRecord(value) && typeof value.value === "string") {
+    return value.value;
+  }
+  return null;
+}
+
+/** Extracts the column name from a column_ref-like node */
+function columnRefName(expr: unknown): string | null {
+  if (!isRecord(expr) || expr.type !== "column_ref") {
+    return null;
+  }
+  const column = expr.column;
+  if (typeof column === "string") {
+    return column;
+  }
+  if (isRecord(column)) {
+    const inner = column.expr;
+    const value = isRecord(inner) ? inner.value : column.value;
+    if (typeof value === "string") {
+      return value;
+    }
+  }
+  return null;
+}
+
+/** Output columns of a CTE: the declared list, else its SELECT list */
+function cteColumns(cte: AstNode): string[] {
+  const declared = asArray(cte.columns)
+    .map((col) => nameValue(col) ?? columnRefName(col) ?? nameValue((col as AstNode).column))
+    .filter((name): name is string => typeof name === "string");
+  if (declared.length > 0) {
+    return declared;
+  }
+
+  const stmt = cte.stmt;
+  const body = isRecord(stmt) ? ((stmt.ast ?? stmt) as AstNode) : null;
+  if (!isRecord(body) || body.type !== "select") {
+    return [];
+  }
+  const columns: string[] = [];
+  for (const col of asArray(body.columns)) {
+    if (typeof col.as === "string") {
+      columns.push(col.as);
+    } else {
+      const name = columnRefName(col.expr);
+      if (name) {
+        columns.push(name);
+      }
+    }
+  }
+  return columns;
+}
+
+interface MutableContext {
+  tables: QueryContextTable[];
+  ctes: QueryContextCte[];
+  selectAliases: string[];
+  seenTables: Set<string>;
+  seenCtes: Set<string>;
+}
+
+/**
+ * Records a FROM/target entry of shape `{db?, catalog?, schema?, table, as?}`.
+ * Expression sources (subqueries, table functions) carry no `table` string and
+ * are skipped; their inner SELECTs are reached by the generic walk.
+ */
+function recordTableEntry(entry: AstNode, ctx: MutableContext): void {
+  if (typeof entry.table !== "string" || entry.table.length === 0) {
+    return;
+  }
+  const qualifier = entry.db ?? entry.catalog;
+  const path = [qualifier, entry.schema, entry.table]
+    .filter((part): part is string => typeof part === "string" && part.length > 0)
+    .map(stripIdentifierQuotes);
+  const alias = typeof entry.as === "string" ? stripIdentifierQuotes(entry.as) : undefined;
+
+  const key = `${path.join(".").toLowerCase()}::${alias?.toLowerCase() ?? ""}`;
+  if (ctx.seenTables.has(key)) {
+    return;
+  }
+  ctx.seenTables.add(key);
+  ctx.tables.push({
+    name: stripIdentifierQuotes(entry.table),
+    path,
+    ...(alias ? { alias } : {}),
+  });
+}
+
+/**
+ * Defensive recursive walk over a node-sql-parser AST. Shapes vary by
+ * statement type and dialect, so unknown structures are skipped, never thrown
+ * on.
+ */
+function walkAst(value: unknown, ctx: MutableContext, seen: Set<unknown>): void {
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      walkAst(item, ctx, seen);
+    }
+    return;
+  }
+  if (!isRecord(value) || seen.has(value)) {
+    return;
+  }
+  seen.add(value);
+
+  // WITH clauses: register CTE names and output columns
+  for (const cte of asArray(value.with)) {
+    const name = nameValue(cte.name);
+    if (name && !ctx.seenCtes.has(name.toLowerCase())) {
+      ctx.seenCtes.add(name.toLowerCase());
+      ctx.ctes.push({
+        name: stripIdentifierQuotes(name),
+        columns: cteColumns(cte).map(stripIdentifierQuotes),
+        from: -1,
+        to: -1,
+      });
+    }
+  }
+
+  // Table sources: FROM lists and DML/DDL targets
+  for (const key of ["from", "table"]) {
+    for (const entry of asArray(value[key])) {
+      recordTableEntry(entry, ctx);
+    }
+  }
+
+  for (const [key, child] of Object.entries(value)) {
+    if (key === "loc" || key === "tableList" || key === "columnList") {
+      continue;
+    }
+    walkAst(child, ctx, seen);
+  }
+}
+
+/** Collects `SELECT expr AS alias` names from the statement's own select list */
+function collectSelectAliases(ast: AstNode, ctx: MutableContext): void {
+  if (ast.type !== "select") {
+    return;
+  }
+  for (const col of asArray(ast.columns)) {
+    if (typeof col.as === "string") {
+      ctx.selectAliases.push(stripIdentifierQuotes(col.as));
+    }
+  }
+}
+
+/**
+ * Locates CTE name definitions (`name [(cols)] AS (`) in the statement text so
+ * `QueryContextCte.from/to` can point at the declaration.
+ */
+function findCteSpan(sql: string, name: string): { from: number; to: number } {
+  const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const pattern = new RegExp(`\\b(${escaped})\\s*(?:\\([^)]*\\)\\s*)?AS\\s*\\(`, "i");
+  const match = pattern.exec(sql);
+  if (!match || match.index < 0) {
+    return { from: -1, to: -1 };
+  }
+  return { from: match.index, to: match.index + name.length };
+}
+
+/** Keywords that can directly follow a table reference and are never aliases */
+const NON_ALIAS_KEYWORDS = new Set([
+  "as",
+  "on",
+  "using",
+  "where",
+  "join",
+  "inner",
+  "left",
+  "right",
+  "full",
+  "cross",
+  "outer",
+  "natural",
+  "lateral",
+  "group",
+  "order",
+  "limit",
+  "offset",
+  "having",
+  "union",
+  "intersect",
+  "except",
+  "select",
+  "set",
+  "values",
+  "when",
+  "then",
+  "and",
+  "or",
+  "not",
+  "in",
+  "is",
+  "asc",
+  "desc",
+  "fetch",
+  "window",
+  "qualify",
+  "returning",
+  "with",
+]);
+
+const IDENT = String.raw`(?:[\w$]+|"[^"]+"|\`[^\`]+\`|\[[^\]]+\])`;
+const TABLE_REF_PATTERN = new RegExp(
+  String.raw`\b(?:from|join)\s+(${IDENT}(?:\.${IDENT})*)(?:\s+(?:as\s+)?(${IDENT}))?`,
+  "gi",
+);
+
+/**
+ * Regex-based fallback used when the statement doesn't parse (e.g. mid-edit),
+ * so aliases still resolve. Matches `FROM|JOIN <table> [AS] <alias>` forms.
+ */
+function buildContextByRegex(sql: string): QueryContext {
+  const ctx: MutableContext = {
+    tables: [],
+    ctes: [],
+    selectAliases: [],
+    seenTables: new Set(),
+    seenCtes: new Set(),
+  };
+
+  extractCtesByRegex(sql, ctx);
+
+  TABLE_REF_PATTERN.lastIndex = 0;
+  let match = TABLE_REF_PATTERN.exec(sql);
+  while (match !== null) {
+    const rawPath = match[1];
+    const rawAlias = match[2];
+    if (rawPath) {
+      const path = rawPath.split(".").map(stripIdentifierQuotes);
+      const name = path[path.length - 1] ?? "";
+      const alias =
+        rawAlias && !NON_ALIAS_KEYWORDS.has(rawAlias.toLowerCase())
+          ? stripIdentifierQuotes(rawAlias)
+          : undefined;
+      const key = `${path.join(".").toLowerCase()}::${alias?.toLowerCase() ?? ""}`;
+      if (name && !ctx.seenTables.has(key)) {
+        ctx.seenTables.add(key);
+        ctx.tables.push({ name, path, ...(alias ? { alias } : {}) });
+      }
+    }
+    match = TABLE_REF_PATTERN.exec(sql);
+  }
+
+  return finalizeContext(ctx);
+}
+
+/**
+ * Extracts CTE declarations (name, declared column list, position) with the
+ * same paren-tracking approach as the CTE completion source.
+ */
+function extractCtesByRegex(sql: string, ctx: MutableContext): void {
+  const withPattern = /\bWITH\s+(?:RECURSIVE\s+)?/gi;
+  const ctePattern = /^([a-zA-Z_][a-zA-Z0-9_]*)\s*(?:\(([^)]*)\)\s*)?AS\s*\(/i;
+
+  let withMatch = withPattern.exec(sql);
+  while (withMatch !== null) {
+    let pos = withMatch.index + withMatch[0].length;
+
+    for (;;) {
+      const cteMatch = ctePattern.exec(sql.slice(pos));
+      const cteName = cteMatch?.[1];
+      if (!cteMatch || !cteName) {
+        break;
+      }
+      // Skip past the CTE body, tracking nested parentheses
+      const bodyStart = pos + cteMatch[0].length;
+      let i = bodyStart;
+      let depth = 1;
+      while (i < sql.length && depth > 0) {
+        if (sql[i] === "(") depth++;
+        else if (sql[i] === ")") depth--;
+        i++;
+      }
+
+      if (!ctx.seenCtes.has(cteName.toLowerCase())) {
+        ctx.seenCtes.add(cteName.toLowerCase());
+        const declared = (cteMatch[2] ?? "")
+          .split(",")
+          .map((col) => stripIdentifierQuotes(col.trim()))
+          .filter((col) => col.length > 0);
+        ctx.ctes.push({
+          name: cteName,
+          columns:
+            declared.length > 0
+              ? declared
+              : inferColumnsFromSelectBody(sql.slice(bodyStart, Math.max(bodyStart, i - 1))),
+          from: pos,
+          to: pos + cteName.length,
+        });
+      }
+
+      const separator = /^\s*,\s*/.exec(sql.slice(i));
+      if (!separator) {
+        break;
+      }
+      pos = i + separator[0].length;
+    }
+
+    withMatch = withPattern.exec(sql);
+  }
+}
+
+function splitTopLevelCommas(text: string): string[] {
+  const parts: string[] = [];
+  let depth = 0;
+  let current = "";
+  for (const char of text) {
+    if (char === "(") depth++;
+    else if (char === ")") depth = Math.max(0, depth - 1);
+    if (char === "," && depth === 0) {
+      parts.push(current);
+      current = "";
+    } else {
+      current += char;
+    }
+  }
+  parts.push(current);
+  return parts;
+}
+
+/**
+ * Best-effort inference of a CTE's output columns from its body's select list
+ * (used by the regex fallback): `AS` aliases and simple identifiers only.
+ */
+function inferColumnsFromSelectBody(body: string): string[] {
+  const selectMatch = /^\s*SELECT\s+(?:DISTINCT\s+)?([\s\S]*?)\s+FROM\s/i.exec(body);
+  if (!selectMatch || !selectMatch[1]) {
+    return [];
+  }
+  const columns: string[] = [];
+  for (const item of splitTopLevelCommas(selectMatch[1])) {
+    const trimmed = item.trim();
+    const asMatch = new RegExp(String.raw`\s+AS\s+(${IDENT})$`, "i").exec(trimmed);
+    if (asMatch?.[1]) {
+      columns.push(stripIdentifierQuotes(asMatch[1]));
+      continue;
+    }
+    if (/^(?:[\w$]+\.)*[\w$]+$/.test(trimmed)) {
+      const segments = trimmed.split(".");
+      const last = segments[segments.length - 1];
+      if (last && last !== "*") {
+        columns.push(last);
+      }
+    }
+  }
+  return columns;
+}
+
+/**
+ * Builds the alias map from collected tables. Earlier (outer) entries win, so
+ * a top-level alias shadows a same-named alias in a subquery.
+ */
+function finalizeContext(ctx: MutableContext): QueryContext {
+  const aliases = new Map<string, string>();
+  for (const table of ctx.tables) {
+    if (table.alias) {
+      const key = table.alias.toLowerCase();
+      if (!aliases.has(key)) {
+        aliases.set(key, table.path.join("."));
+      }
+    }
+  }
+  return {
+    tables: ctx.tables,
+    ctes: ctx.ctes,
+    aliases,
+    selectAliases: ctx.selectAliases,
+  };
+}
+
+/**
+ * Analyzes a single SQL statement, extracting referenced tables, aliases,
+ * CTEs, and select-list aliases. Prefers the parsed AST and falls back to a
+ * regex scan when the statement doesn't parse (e.g. mid-edit).
+ */
+export async function analyzeQueryContext(
+  sql: string,
+  parser: SqlParser,
+  opts: { state: EditorState },
+): Promise<QueryContext> {
+  if (!sql.trim()) {
+    return emptyContext();
+  }
+
+  let ast: unknown = null;
+  try {
+    const result = await parser.parse(sql, opts);
+    if (result.success && result.ast != null) {
+      ast = result.ast;
+    }
+  } catch (error) {
+    debug("query-context parse failed", error);
+  }
+
+  if (ast == null) {
+    return buildContextByRegex(sql);
+  }
+
+  try {
+    const ctx: MutableContext = {
+      tables: [],
+      ctes: [],
+      selectAliases: [],
+      seenTables: new Set(),
+      seenCtes: new Set(),
+    };
+    const asts = Array.isArray(ast) ? ast : [ast];
+    for (const node of asts) {
+      if (isRecord(node)) {
+        collectSelectAliases(node, ctx);
+      }
+    }
+    walkAst(ast, ctx, new Set());
+    for (const cte of ctx.ctes) {
+      const span = findCteSpan(sql, cte.name);
+      cte.from = span.from;
+      cte.to = span.to;
+    }
+    return finalizeContext(ctx);
+  } catch (error) {
+    debug("query-context AST walk failed", error);
+    return buildContextByRegex(sql);
+  }
+}
+
+/**
+ * Caching wrapper around {@link analyzeQueryContext}, keyed on statement text.
+ * Share one instance between hover/completion sources to avoid re-parsing the
+ * same statement.
+ */
+export class QueryContextAnalyzer {
+  private parser: SqlParser;
+  private cache = new Map<string, QueryContext>();
+  private readonly MAX_CACHE_SIZE = 20;
+
+  constructor(parser: SqlParser = new NodeSqlParser()) {
+    this.parser = parser;
+  }
+
+  async getContext(sql: string, opts: { state: EditorState }): Promise<QueryContext> {
+    const cached = this.cache.get(sql);
+    if (cached) {
+      return cached;
+    }
+
+    const context = await analyzeQueryContext(sql, this.parser, opts);
+    this.cache.set(sql, context);
+
+    if (this.cache.size > this.MAX_CACHE_SIZE) {
+      const firstKey = this.cache.keys().next().value;
+      if (firstKey !== undefined) {
+        this.cache.delete(firstKey);
+      }
+    }
+
+    return context;
+  }
+
+  clearCache(): void {
+    this.cache.clear();
+  }
+}

--- a/src/sql/query-context.ts
+++ b/src/sql/query-context.ts
@@ -146,7 +146,7 @@ interface MutableContext {
 /**
  * Records a FROM/target entry of shape `{db?, catalog?, schema?, table, as?}`.
  * Expression sources (subqueries, table functions) carry no `table` string and
- * are skipped; their inner SELECTs are reached by the generic walk.
+ * are skipped; their inner SELECT nodes are reached by the generic walk.
  */
 function recordTableEntry(entry: AstNode, ctx: MutableContext): void {
   if (typeof entry.table !== "string" || entry.table.length === 0) {

--- a/src/sql/query-context.ts
+++ b/src/sql/query-context.ts
@@ -285,16 +285,93 @@ const NON_ALIAS_KEYWORDS = new Set([
 ]);
 
 const IDENT = String.raw`(?:[\w$]+|"[^"]+"|\`[^\`]+\`|\[[^\]]+\])`;
+// A keyword after a table reference is never its alias; without this guard the
+// match would consume e.g. `JOIN` and skip right past the joined table
+const NON_ALIAS_GUARD = `(?!(?:${[...NON_ALIAS_KEYWORDS].join("|")})\\b)`;
 const TABLE_REF_PATTERN = new RegExp(
-  String.raw`\b(?:from|join)\s+(${IDENT}(?:\.${IDENT})*)(?:\s+(?:as\s+)?(${IDENT}))?`,
+  String.raw`\b(?:from|join)\s+(${IDENT}(?:\.${IDENT})*)(?:\s+(?:as\s+)?${NON_ALIAS_GUARD}(${IDENT}))?`,
   "gi",
 );
+
+/**
+ * Blanks out single-quoted string literals and comments (preserving offsets)
+ * so the regex fallback doesn't read `FROM`/`JOIN` inside them as table
+ * references. Double-quoted/backtick/bracket identifiers are left intact.
+ */
+function maskLiteralsAndComments(sql: string): string {
+  const chars = sql.split("");
+  let i = 0;
+  while (i < sql.length) {
+    const char = sql[i];
+    const next = sql[i + 1];
+
+    if (char === "-" && next === "-") {
+      while (i < sql.length && sql[i] !== "\n") {
+        chars[i] = " ";
+        i++;
+      }
+      continue;
+    }
+
+    if (char === "/" && next === "*") {
+      chars[i] = " ";
+      chars[i + 1] = " ";
+      i += 2;
+      while (i < sql.length && !(sql[i] === "*" && sql[i + 1] === "/")) {
+        chars[i] = " ";
+        i++;
+      }
+      if (i < sql.length) {
+        chars[i] = " ";
+        chars[i + 1] = " ";
+        i += 2;
+      }
+      continue;
+    }
+
+    // Quoted identifiers pass through untouched (a ' inside them must not
+    // start a string literal)
+    if (char === '"' || char === "`" || char === "[") {
+      const close = char === "[" ? "]" : char;
+      i++;
+      while (i < sql.length && sql[i] !== close) {
+        i++;
+      }
+      i++;
+      continue;
+    }
+
+    if (char === "'") {
+      chars[i] = " ";
+      i++;
+      while (i < sql.length) {
+        if (sql[i] === "'") {
+          chars[i] = " ";
+          if (sql[i + 1] === "'") {
+            // Escaped quote ('') stays inside the literal
+            chars[i + 1] = " ";
+            i += 2;
+            continue;
+          }
+          i++;
+          break;
+        }
+        chars[i] = " ";
+        i++;
+      }
+      continue;
+    }
+
+    i++;
+  }
+  return chars.join("");
+}
 
 /**
  * Regex-based fallback used when the statement doesn't parse (e.g. mid-edit),
  * so aliases still resolve. Matches `FROM|JOIN <table> [AS] <alias>` forms.
  */
-function buildContextByRegex(sql: string): QueryContext {
+function buildContextByRegex(rawSql: string): QueryContext {
   const ctx: MutableContext = {
     tables: [],
     ctes: [],
@@ -302,6 +379,9 @@ function buildContextByRegex(sql: string): QueryContext {
     seenTables: new Set(),
     seenCtes: new Set(),
   };
+
+  // Masking preserves offsets, so CTE spans remain valid in the original text
+  const sql = maskLiteralsAndComments(rawSql);
 
   extractCtesByRegex(sql, ctx);
 


### PR DESCRIPTION
## Summary

Nothing in the extension previously understood table aliases: in `SELECT u.name FROM users u`, hovering `u` or `u.name` found nothing, and there was no alias-qualified column completion. This PR adds a shared, statement-scoped alias/CTE analysis and uses it in hover and a new completion source.

### New `src/sql/query-context.ts`

- `analyzeQueryContext(sql, parser, {state})` returns a `QueryContext`: referenced `tables` (name / dotted path / alias), `ctes` (name, declared-or-inferred output columns, name span), an `aliases` map (lowercased alias → dotted table path or CTE name), and top-level `selectAliases`.
- Walks the node-sql-parser AST defensively (unknown node shapes are skipped, never thrown on), including joins, subqueries, and `WITH` clauses.
- Falls back to a small `FROM|JOIN <table> [AS] <alias>` regex (with keyword filtering and quote stripping) when the statement doesn't parse, so aliases still resolve mid-edit; the fallback also infers CTE output columns from the CTE body's select list.
- `QueryContextAnalyzer` adds a cache keyed on statement text (same pattern as `SqlStructureAnalyzer`), shareable between hover and completion via the new `contextAnalyzer` config options.

### Hover (`src/sql/hover.ts`)

- Analysis is now scoped to the statement containing the hover position (previously the whole doc), so tables from other statements in a multi-statement doc no longer leak into resolution.
- Alias-qualified words are rewritten through the alias map before namespace resolution: `u` resolves as table `users` (tooltip shows "`u` is an alias for `users`"), `u.name` resolves as column `users.name`. Alias wins over a same-named real table within the statement. Custom renderers receive the new `aliasFor` field on `NamespaceTooltipData`.
- Fixed the `enableTables`/`enableColumns` gating bug: both flags previously gated the same block, so disabling one without the other did nothing. Gating now filters on the resolved item's `semanticType`.

### Completion (`src/sql/alias-completion-source.ts`)

- New `aliasColumnCompletionSource({ schema?, parser?, contextAnalyzer? })`: typing `u.` offers the columns of `users` (`type: "property"`; schema `Completion` objects preserved). Handles nested schemas (`FROM mydb.users u`), CTE aliases (declared/inferred CTE columns), falls back to `sqlSchemaFacet`, ignores multi-segment qualifiers like `db.table.`, and scopes strictly to the statement containing the cursor.
- Registered in the demo and documented in the README alongside `cteCompletionSource`.

Semantic diagnostics needed no change — the scope collector from #163 already resolves alias-qualified column refs.

## Test plan

- 40 new tests: `query-context.test.ts` (aliases with/without `AS`, joins, alias shadowing, qualified paths, subqueries, CTE columns/spans, regex fallback, caching), `alias-completion-source.test.ts` (explicit/typed-prefix, joins, CTE aliases, facet fallback, statement scoping, mid-edit), and hover-integration additions (alias hover, gating fix, multi-statement isolation, mid-edit fallback).
- `pnpm vitest run`: 386 passed, 1 pre-existing expected fail; `pnpm vitest run --project browser`: passing; `tsc --noEmit` and `oxlint` clean; demo builds.

Note: `pnpm run test:browser` is broken independently of this PR — it references a `vitest.browser.config.ts` that doesn't exist; the browser project runs via `pnpm vitest run --project browser`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds statement-scoped SQL alias resolution for hover and a new alias-aware column completion, so `u` and `u.name` resolve and `u.` completes columns (even mid-edit). Also fixes hover gating, prevents cross-statement leakage, hardens alias parsing, and rewrites a parser regex to avoid backtracking flagged by CodeQL.

- New Features
  - Added `analyzeQueryContext` and cached `QueryContextAnalyzer` to extract tables, CTEs (columns/spans), aliases, and select aliases via an AST walk with a regex fallback.
  - Hover uses per-statement context, resolves aliases (`u` → `users`, `u.name` → `users.name`), shows an “alias for” note, and supports CTE aliases via `aliasFor` on `NamespaceTooltipData`.
  - Added `aliasColumnCompletionSource({ schema?, parser?, contextAnalyzer? })`: typing `alias.` completes columns for the aliased table/CTE; supports nested schemas and quoted qualifiers, ignores `db.table.`, scopes to the current statement, and falls back to `sqlSchemaFacet`. Exported `aliasColumnCompletionSource`, `analyzeQueryContext`, and `QueryContextAnalyzer`; demo and README updated.

- Bug Fixes
  - Fixed `enableTables`/`enableColumns` gating to filter by resolved `semanticType` and stopped resolution leaking across statements.
  - Hardened fallback: masks single-quoted strings and comments to avoid phantom tables and guards against keywords being treated as aliases.
  - Escaped alias names/targets in hover HTML; completion forces option type `"property"` while preserving schema-provided details.
  - Rewrote the string-literal matcher in `replaceBracketsWithQuotes` to an unrolled-loop regex to prevent polynomial backtracking on unclosed strings (CodeQL).

<sup>Written for commit 84a0dfca19f6d0ca7b673982231c76969ce9a783. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marimo-team/codemirror-sql/pull/164?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

