### PR TITLE
test: expand edge-case coverage and DRY up test helpers

### DIFF
--- a/src/sql/__tests__/alias-completion-source.test.ts
+++ b/src/sql/__tests__/alias-completion-source.test.ts
@@ -1,48 +1,12 @@
-import { CompletionContext, type CompletionResult } from "@codemirror/autocomplete";
 import type { SQLNamespace } from "@codemirror/lang-sql";
-import { EditorState } from "@codemirror/state";
 import { describe, expect, it } from "vitest";
 import { aliasColumnCompletionSource } from "../alias-completion-source.js";
-import { sqlSchemaFacet } from "../schema-facet.js";
+import { completeWith, labels, NESTED_SCHEMA, TEST_SCHEMA } from "./test-utils.js";
 
-const schema: SQLNamespace = {
-  users: ["id", "username", "email"],
-  orders: [
-    { label: "order_id", detail: "Order ID", type: "property" },
-    "total",
-  ],
-};
+const schema = TEST_SCHEMA;
+const nestedSchema = NESTED_SCHEMA;
 
-const nestedSchema: SQLNamespace = {
-  mydb: {
-    users: ["id", "username"],
-  },
-};
-
-async function complete(
-  doc: string,
-  opts: {
-    schema?: SQLNamespace;
-    pos?: number;
-    explicit?: boolean;
-    facetSchema?: SQLNamespace;
-  } = {},
-): Promise<CompletionResult | null> {
-  const source = aliasColumnCompletionSource(
-    opts.schema === undefined && opts.facetSchema !== undefined ? {} : { schema: opts.schema },
-  );
-  const state = EditorState.create({
-    doc,
-    extensions: opts.facetSchema !== undefined ? [sqlSchemaFacet.of(opts.facetSchema)] : [],
-  });
-  const pos = opts.pos ?? doc.length;
-  const context = new CompletionContext(state, pos, opts.explicit ?? false);
-  return (await source(context)) as CompletionResult | null;
-}
-
-function labels(result: CompletionResult | null): string[] {
-  return (result?.options ?? []).map((option) => option.label);
-}
+const complete = completeWith(aliasColumnCompletionSource);
 
 describe("aliasColumnCompletionSource", () => {
   it("offers the aliased table's columns after `alias.`", async () => {

--- a/src/sql/__tests__/column-completion-source.test.ts
+++ b/src/sql/__tests__/column-completion-source.test.ts
@@ -1,48 +1,12 @@
-import { CompletionContext, type CompletionResult } from "@codemirror/autocomplete";
 import type { SQLNamespace } from "@codemirror/lang-sql";
-import { EditorState } from "@codemirror/state";
 import { describe, expect, it } from "vitest";
 import { unqualifiedColumnCompletionSource } from "../column-completion-source.js";
-import { sqlSchemaFacet } from "../schema-facet.js";
+import { completeWith, labels, NESTED_SCHEMA, TEST_SCHEMA } from "./test-utils.js";
 
-const schema: SQLNamespace = {
-  users: ["id", "username", "email"],
-  orders: [
-    { label: "order_id", detail: "Order ID", type: "property" },
-    "total",
-  ],
-};
+const schema = TEST_SCHEMA;
+const nestedSchema = NESTED_SCHEMA;
 
-const nestedSchema: SQLNamespace = {
-  mydb: {
-    users: ["id", "username"],
-  },
-};
-
-async function complete(
-  doc: string,
-  opts: {
-    schema?: SQLNamespace;
-    pos?: number;
-    explicit?: boolean;
-    facetSchema?: SQLNamespace;
-  } = {},
-): Promise<CompletionResult | null> {
-  const source = unqualifiedColumnCompletionSource(
-    opts.schema === undefined && opts.facetSchema !== undefined ? {} : { schema: opts.schema },
-  );
-  const state = EditorState.create({
-    doc,
-    extensions: opts.facetSchema !== undefined ? [sqlSchemaFacet.of(opts.facetSchema)] : [],
-  });
-  const pos = opts.pos ?? doc.length;
-  const context = new CompletionContext(state, pos, opts.explicit ?? false);
-  return (await source(context)) as CompletionResult | null;
-}
-
-function labels(result: CompletionResult | null): string[] {
-  return (result?.options ?? []).map((option) => option.label);
-}
+const complete = completeWith(unqualifiedColumnCompletionSource);
 
 describe("unqualifiedColumnCompletionSource", () => {
   it("offers the FROM table's columns for a bare prefix", async () => {

--- a/src/sql/__tests__/completion-utils.test.ts
+++ b/src/sql/__tests__/completion-utils.test.ts
@@ -1,0 +1,170 @@
+import type { Completion, CompletionContext } from "@codemirror/autocomplete";
+import type { SQLNamespace } from "@codemirror/lang-sql";
+import type { EditorView } from "@codemirror/view";
+import { describe, expect, it, vi } from "vitest";
+import { columnsOf, findTableColumns, resolveSchema, toCompletion } from "../completion-utils.js";
+import { sqlSchemaFacet } from "../schema-facet.js";
+import { createCompletionContext, createState } from "./test-utils.js";
+
+describe("resolveSchema", () => {
+  it("returns an explicitly provided namespace as-is", () => {
+    const schema: SQLNamespace = { users: ["id"] };
+    const context = createCompletionContext("SELECT ");
+    expect(resolveSchema(schema, context)).toBe(schema);
+  });
+
+  it("falls back to the schema facet when no explicit source is given", () => {
+    const schema: SQLNamespace = { users: ["id"] };
+    const context = createCompletionContext("SELECT ", {
+      extensions: [sqlSchemaFacet.of(schema)],
+    });
+    expect(resolveSchema(undefined, context)).toBe(schema);
+  });
+
+  it("returns null when neither an explicit source nor a facet is present", () => {
+    const context = createCompletionContext("SELECT ");
+    expect(resolveSchema(undefined, context)).toBeNull();
+  });
+
+  it("returns null for a function source when the context has no view", () => {
+    // Contexts created without an editor (as in unit tests) get no schema
+    const source = vi.fn(() => ({ users: ["id"] }) as SQLNamespace);
+    const context = createCompletionContext("SELECT ");
+    expect(resolveSchema(source, context)).toBeNull();
+    expect(source).not.toHaveBeenCalled();
+  });
+
+  it("invokes a function source with the view when one is present", () => {
+    const schema: SQLNamespace = { users: ["id"] };
+    const view = {} as EditorView;
+    const source = vi.fn(() => schema);
+    // Minimal context carrying a view — resolveSchema only reads `state`/`view`
+    const context = { state: createState("SELECT "), view } as unknown as CompletionContext;
+
+    expect(resolveSchema(source, context)).toBe(schema);
+    expect(source).toHaveBeenCalledWith(view);
+  });
+});
+
+describe("columnsOf", () => {
+  it("returns null for a nullish namespace", () => {
+    expect(columnsOf(undefined)).toBeNull();
+  });
+
+  it("returns the array itself for an array namespace", () => {
+    const columns = ["id", "name"];
+    expect(columnsOf(columns)).toBe(columns);
+  });
+
+  it("unwraps the children of a self/children namespace", () => {
+    const children = ["id", "name"];
+    const namespace = { self: { label: "users" }, children } as unknown as SQLNamespace;
+    expect(columnsOf(namespace)).toBe(children);
+  });
+
+  it("returns null for an object (non-column) namespace", () => {
+    expect(columnsOf({ users: ["id"] } as SQLNamespace)).toBeNull();
+  });
+
+  it("returns null when a self/children node wraps a non-array child", () => {
+    const namespace = {
+      self: { label: "db" },
+      children: { users: ["id"] },
+    } as unknown as SQLNamespace;
+    expect(columnsOf(namespace)).toBeNull();
+  });
+});
+
+describe("findTableColumns", () => {
+  const schema: SQLNamespace = {
+    users: ["id", "username", "email"],
+    orders: ["order_id", "total"],
+  };
+
+  it("resolves a simple table name (case-insensitively)", () => {
+    expect(findTableColumns(schema, "users")).toEqual(["id", "username", "email"]);
+    expect(findTableColumns(schema, "USERS")).toEqual(["id", "username", "email"]);
+  });
+
+  it("resolves a fully-qualified path", () => {
+    const nested: SQLNamespace = { mydb: { users: ["id", "name"] } };
+    expect(findTableColumns(nested, "mydb.users")).toEqual(["id", "name"]);
+  });
+
+  it("resolves an under-qualified name to a table nested deeper", () => {
+    const nested: SQLNamespace = { mydb: { users: ["id", "name"] } };
+    expect(findTableColumns(nested, "users")).toEqual(["id", "name"]);
+  });
+
+  it("resolves via pre-split segments (preserving dotted identifiers)", () => {
+    const nested: SQLNamespace = { "my.db": { users: ["id"] } };
+    expect(findTableColumns(nested, ["my.db", "users"])).toEqual(["id"]);
+  });
+
+  it("returns null for an unknown table", () => {
+    expect(findTableColumns(schema, "missing")).toBeNull();
+  });
+
+  it("returns null when the last segment is empty", () => {
+    // A path that reduces to no final segment cannot resolve
+    expect(findTableColumns(schema, [])).toBeNull();
+    expect(findTableColumns(schema, "")).toBeNull();
+  });
+
+  it("returns null when an under-qualified name is ambiguous", () => {
+    const ambiguous: SQLNamespace = {
+      db1: { users: ["id", "a"] },
+      db2: { users: ["id", "b"] },
+    };
+    // `users` exists under two catalogs — refuse to guess
+    expect(findTableColumns(ambiguous, "users")).toBeNull();
+  });
+
+  it("returns null when the qualified path is longer than any match", () => {
+    const nested: SQLNamespace = { mydb: { users: ["id"] } };
+    // `other.users` — the suffix does not match the `mydb.users` path
+    expect(findTableColumns(nested, "other.users")).toBeNull();
+  });
+});
+
+describe("toCompletion", () => {
+  it("wraps a string column with the property type and detail", () => {
+    expect(toCompletion("id", "column")).toEqual({
+      label: "id",
+      type: "property",
+      detail: "column",
+    });
+  });
+
+  it("adds a boost to a string column when provided", () => {
+    expect(toCompletion("id", "column", 5)).toEqual({
+      label: "id",
+      type: "property",
+      detail: "column",
+      boost: 5,
+    });
+  });
+
+  it("preserves an existing Completion detail and forces the property type", () => {
+    const column: Completion = { label: "id", type: "keyword", detail: "Primary key" };
+    expect(toCompletion(column, "fallback")).toEqual({
+      label: "id",
+      type: "property",
+      detail: "Primary key",
+    });
+  });
+
+  it("uses the fallback detail when the Completion has none", () => {
+    const column: Completion = { label: "id" };
+    expect(toCompletion(column, "fallback")).toMatchObject({
+      label: "id",
+      type: "property",
+      detail: "fallback",
+    });
+  });
+
+  it("applies a boost to a Completion only when it has none of its own", () => {
+    expect(toCompletion({ label: "id" }, "d", 3).boost).toBe(3);
+    expect(toCompletion({ label: "id", boost: 9 }, "d", 3).boost).toBe(9);
+  });
+});

--- a/src/sql/__tests__/diagnostics.test.ts
+++ b/src/sql/__tests__/diagnostics.test.ts
@@ -232,4 +232,84 @@ describe("lint source", () => {
     expect(diagnostics).toHaveLength(2);
     expect(validateSpy).not.toHaveBeenCalled();
   });
+
+  it("should clamp the diagnostic span to the document end when the error column runs past it", async () => {
+    // A parser whose reported column points beyond the end of the document
+    // exercises the `from >= doc.length` branch in tokenEndAt, which clamps
+    // the span end to `doc.length`.
+    const doc = "SELECT 1";
+    const parser = {
+      validateSql: vi.fn(async () => [
+        { message: "unexpected end of input", line: 1, column: 999, severity: "error" as const },
+      ]),
+      parse: vi.fn(async () => ({ success: false, errors: [] })),
+      extractTableReferences: vi.fn(async () => []),
+      extractColumnReferences: vi.fn(async () => []),
+    } as unknown as SqlParser;
+
+    const diagnostics = await lint(doc, { parser, perStatement: false });
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].from).toBe(doc.length);
+    expect(diagnostics[0].to).toBe(doc.length);
+  });
+
+  it("should preserve warning severity from the parser", async () => {
+    const parser = {
+      validateSql: vi.fn(async () => [
+        { message: "deprecated syntax", line: 1, column: 1, severity: "warning" as const },
+      ]),
+      parse: vi.fn(async () => ({ success: false, errors: [] })),
+      extractTableReferences: vi.fn(async () => []),
+      extractColumnReferences: vi.fn(async () => []),
+    } as unknown as SqlParser;
+
+    const diagnostics = await lint("SELECT 1", { parser, perStatement: false });
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].severity).toBe("warning");
+    expect(diagnostics[0].message).toBe("deprecated syntax");
+  });
+
+  it("should emit multiple diagnostics from a single statement when the parser returns several", async () => {
+    const parser = {
+      validateSql: vi.fn(async () => [
+        { message: "first", line: 1, column: 1, severity: "error" as const },
+        { message: "second", line: 1, column: 8, severity: "error" as const },
+      ]),
+      parse: vi.fn(async () => ({ success: false, errors: [] })),
+      extractTableReferences: vi.fn(async () => []),
+      extractColumnReferences: vi.fn(async () => []),
+    } as unknown as SqlParser;
+
+    const diagnostics = await lint("SELECT badcol", { parser, perStatement: false });
+
+    expect(diagnostics).toHaveLength(2);
+    expect(diagnostics.map((d) => d.message)).toEqual(["first", "second"]);
+  });
+
+  it("clamps a statement-relative error column that overshoots to the statement end", async () => {
+    // perStatement path: an error with a large column is clamped within the
+    // statement bounds by convertStatementErrorToDiagnostic.
+    const doc = "SELECT 1;";
+    const parser = {
+      validateSql: vi.fn(async () => []),
+      // The structure analyzer derives per-statement errors from parse().
+      parse: vi.fn(async () => ({
+        success: false,
+        errors: [{ message: "boom", line: 1, column: 999, severity: "error" as const }],
+      })),
+      extractTableReferences: vi.fn(async () => []),
+      extractColumnReferences: vi.fn(async () => []),
+    } as unknown as SqlParser;
+
+    const diagnostics = await lint(doc, { parser });
+
+    expect(diagnostics.length).toBeGreaterThanOrEqual(1);
+    for (const d of diagnostics) {
+      expect(d.from).toBeLessThanOrEqual(doc.length);
+      expect(d.to).toBeLessThanOrEqual(doc.length);
+      expect(d.to).toBeGreaterThanOrEqual(d.from);
+    }
+  });
 });

--- a/src/sql/__tests__/hover-integration.test.ts
+++ b/src/sql/__tests__/hover-integration.test.ts
@@ -701,6 +701,48 @@ describe("Query-aware hover behavior", () => {
       expect(filteredSchema).toHaveProperty("orders");
       expect(filteredSchema).not.toHaveProperty("products");
     });
+
+    it("should keep parent namespaces that contain a referenced child table", async () => {
+      const { filterSchemaByTableRefs } = await import("../hover.js");
+
+      // `mydb` itself is not referenced, but it holds `orders`, which is. The
+      // recursive branch keeps `mydb` with only its referenced children.
+      const nested: SQLNamespace = {
+        mydb: {
+          orders: ["id", "total"],
+          products: ["id", "name"],
+        },
+      };
+      const filtered = filterSchemaByTableRefs(nested, new Set(["orders"]));
+
+      expect(filtered).toHaveProperty("mydb");
+      const mydb = (filtered as { mydb: Record<string, unknown> }).mydb;
+      expect(mydb).toHaveProperty("orders");
+      expect(mydb).not.toHaveProperty("products");
+    });
+
+    it("should drop parent namespaces whose children are all unreferenced", async () => {
+      const { filterSchemaByTableRefs } = await import("../hover.js");
+
+      const nested: SQLNamespace = {
+        mydb: { products: ["id"] },
+      };
+      const filtered = filterSchemaByTableRefs(nested, new Set(["orders"]));
+
+      expect(filtered).not.toHaveProperty("mydb");
+      expect(filtered).toEqual({});
+    });
+
+    it("should return an array namespace unchanged", async () => {
+      const { filterSchemaByTableRefs } = await import("../hover.js");
+
+      // A top-level array (column list) is not an object namespace, so it is
+      // returned as-is regardless of the table refs.
+      const arrayNamespace: SQLNamespace = ["id", "name", "email"];
+      const filtered = filterSchemaByTableRefs(arrayNamespace, new Set(["users"]));
+
+      expect(filtered).toBe(arrayNamespace);
+    });
   });
 
   describe("Query-aware column resolution", () => {
@@ -958,6 +1000,65 @@ describe("Query-aware hover behavior - edge cases", () => {
         const html = renderTooltip(tooltip, view);
         expect(html).toContain("<strong>name</strong>");
       });
+    });
+
+    it("returns null when the hovered word is empty (side === 0 on whitespace)", async () => {
+      // Between the two spaces neither boundary condition trips, so the sliced
+      // word is empty and the source returns null (word-length guard).
+      const source = createHoverSource({ schema: { users: ["id"] }, keywords: {} });
+      const doc = "SELECT  id FROM users";
+      const view = createMockView(doc);
+      // pos 7 sits on the second space with side 0
+      expect(await source(view, 7, 0)).toBeNull();
+    });
+
+    it("resolves the schema from the sqlSchemaFacet when no schema is configured", async () => {
+      const { sqlSchemaFacet } = await import("../schema-facet.js");
+      const schema = { users: ["id", "name"] };
+      const state = EditorState.create({
+        doc: "SELECT id FROM users",
+        extensions: [sqlSchemaFacet.of(schema)],
+      });
+      const view = { state } as unknown as EditorView;
+
+      // No `schema` in config: the source must fall back to the facet value
+      const source = createHoverSource({ keywords: {} });
+      const tooltip = await source(view, "SELECT id FROM users".indexOf("users") + 2, 1);
+      expect(tooltip).not.toBeNull();
+      const html = tooltip!.create(view).dom.innerHTML;
+      expect(html).toContain("users");
+      expect(html).toContain("table");
+    });
+
+    it("prefers the explicit config schema over the facet schema", async () => {
+      const { sqlSchemaFacet } = await import("../schema-facet.js");
+      const facetSchema = { facet_only: ["x"] };
+      const configSchema = { users: ["id", "name"] };
+      const state = EditorState.create({
+        doc: "SELECT id FROM users",
+        extensions: [sqlSchemaFacet.of(facetSchema)],
+      });
+      const view = { state } as unknown as EditorView;
+
+      const source = createHoverSource({ schema: configSchema, keywords: {} });
+      const tooltip = await source(view, "SELECT id FROM users".indexOf("users") + 2, 1);
+      expect(tooltip).not.toBeNull();
+      expect(tooltip!.create(view).dom.innerHTML).toContain("users");
+    });
+
+    it("resolves a nested database/schema/namespace item via the full-schema fallback", async () => {
+      // With no parseable tables in the doc, the resolver falls back to the full
+      // schema, letting a bare namespace name resolve to a non-table item.
+      const schema = { mydb: { public: { users: ["id", "name"] } } };
+      const source = createHoverSource({ schema, keywords: {} });
+      const doc = "mydb";
+      const view = createMockView(doc);
+
+      const tooltip = await source(view, 2, 1);
+      expect(tooltip).not.toBeNull();
+      const html = tooltip!.create(view).dom.innerHTML;
+      expect(html).toContain("<strong>mydb</strong>");
+      expect(html).toContain("namespace");
     });
 
     it("does not permanently disable hovers when the keywords promise rejects", async () => {

--- a/src/sql/__tests__/hover-render.test.ts
+++ b/src/sql/__tests__/hover-render.test.ts
@@ -128,6 +128,14 @@ describe("DefaultSqlTooltipRenders.column", () => {
     expect(html).toContain('title="type"');
     expect(html).toContain("int");
   });
+
+  it("omits the related section when the only other columns are the column itself", () => {
+    // Duplicate column names mean the filtered "other columns" list is empty
+    // even though the table has more than one entry.
+    const html = render({ tableName: "t", columnName: "a", schema: { t: ["a", "a"] } });
+    expect(html).toContain("<strong>a</strong>");
+    expect(html).not.toContain("Other columns");
+  });
 });
 
 describe("DefaultSqlTooltipRenders.namespace", () => {
@@ -247,6 +255,166 @@ describe("DefaultSqlTooltipRenders.namespace", () => {
     };
     const html = render(item);
     expect(html).toContain("<strong>unknown</strong>");
+  });
+
+  it("omits the children line when the namespace is not countable", () => {
+    // A namespace value that is neither an array nor an object makes
+    // countNamespaceChildren return 0, so no "Contains N items" line renders.
+    const item: ResolvedNamespaceItem = {
+      path: ["x"],
+      type: "namespace",
+      semanticType: "namespace",
+      namespace: "not-a-namespace" as unknown as SQLNamespace,
+    };
+    const html = render(item);
+    expect(html).toContain("<strong>x</strong>");
+    expect(html).toContain("Namespace");
+    expect(html).not.toContain("Contains");
+  });
+
+  it("renders a table with no detail and no columns", () => {
+    // Exercises the table branch with an empty (array) namespace and no
+    // completion detail: no "Columns" block, no "Schema" path (single segment).
+    const item: ResolvedNamespaceItem = {
+      path: ["solo"],
+      type: "namespace",
+      semanticType: "table",
+      namespace: [] as unknown as SQLNamespace,
+    };
+    const html = render(item);
+    expect(html).toContain("<strong>solo</strong>");
+    expect(html).toContain("Table</div>");
+    expect(html).not.toContain("sql-hover-columns");
+    expect(html).not.toContain("Schema:");
+  });
+
+  it("renders a column without a table path when the path has a single segment", () => {
+    const item: ResolvedNamespaceItem = {
+      path: ["lonely"],
+      type: "string",
+      semanticType: "column",
+      value: "lonely",
+    };
+    const html = render(item);
+    expect(html).toContain("<strong>lonely</strong>");
+    expect(html).toContain("Column</div>");
+    expect(html).not.toContain("Table:");
+  });
+
+  it("renders a column with no table path when the path is empty", () => {
+    const item: ResolvedNamespaceItem = {
+      path: [],
+      type: "string",
+      semanticType: "column",
+      value: "bare",
+    };
+    const html = render(item);
+    expect(html).toContain("<strong>bare</strong>");
+    expect(html).not.toContain("sql-hover-path");
+    expect(html).not.toContain("Table:");
+  });
+
+  it("renders a database with a detail but no namespace children line", () => {
+    const item: ResolvedNamespaceItem = {
+      path: ["db"],
+      type: "completion",
+      semanticType: "database",
+      completion: { label: "db", detail: "the database" },
+    };
+    const html = render(item);
+    expect(html).toContain("Database: the database");
+    expect(html).not.toContain("Contains");
+  });
+
+  it("renders a schema with a detail but no table count", () => {
+    const item: ResolvedNamespaceItem = {
+      path: ["db", "sch"],
+      type: "completion",
+      semanticType: "schema",
+      completion: { label: "sch", detail: "a schema" },
+    };
+    const html = render(item);
+    expect(html).toContain("Schema: a schema");
+    expect(html).toContain("<code>db.sch</code>");
+    expect(html).not.toContain("Contains");
+  });
+
+  it("renders a table with an object namespace (not a column array) and skips the column list", () => {
+    const item: ResolvedNamespaceItem = {
+      path: ["sch", "t"],
+      type: "completion",
+      semanticType: "table",
+      completion: { label: "t", detail: "a table" },
+      namespace: { self: { label: "t" }, children: ["a"] } as SQLNamespace,
+    };
+    const html = render(item);
+    expect(html).toContain("Table: a table");
+    expect(html).toContain("Schema:</strong> <code>sch</code>");
+    expect(html).not.toContain("sql-hover-columns");
+  });
+
+  it("uses singular table wording for a schema with exactly one table", () => {
+    const item: ResolvedNamespaceItem = {
+      path: ["db", "public"],
+      type: "namespace",
+      semanticType: "schema",
+      namespace: { users: ["id"] },
+    };
+    const html = render(item);
+    expect(html).toContain("Contains 1 table");
+    expect(html).not.toContain("1 tables");
+  });
+
+  it("renders a database with an empty namespace and no children line", () => {
+    const item: ResolvedNamespaceItem = {
+      path: ["db"],
+      type: "namespace",
+      semanticType: "database",
+      namespace: {} as SQLNamespace,
+    };
+    const html = render(item);
+    expect(html).toContain("Database</div>");
+    expect(html).not.toContain("Contains");
+  });
+
+  it("renders a schema with an empty path and empty namespace", () => {
+    const item: ResolvedNamespaceItem = {
+      path: [],
+      type: "namespace",
+      semanticType: "schema",
+      namespace: {} as SQLNamespace,
+    };
+    const html = render(item);
+    expect(html).toContain("Schema</div>");
+    // No path segment and no children => neither block is rendered
+    expect(html).not.toContain("sql-hover-path");
+    expect(html).not.toContain("Contains");
+  });
+
+  it("renders a table with an empty path and no schema line", () => {
+    const item: ResolvedNamespaceItem = {
+      path: [],
+      type: "namespace",
+      semanticType: "table",
+      namespace: ["id"] as SQLNamespace,
+    };
+    const html = render(item);
+    expect(html).toContain("Table</div>");
+    expect(html).not.toContain("Schema:");
+    expect(html).toContain("Columns (1)");
+  });
+
+  it("renders the default namespace branch with a detail and child count", () => {
+    const item: ResolvedNamespaceItem = {
+      path: ["misc"],
+      type: "completion",
+      semanticType: "namespace",
+      completion: { label: "misc", detail: "misc ns" },
+      namespace: { a: ["x"], b: ["y"] } as SQLNamespace,
+    };
+    const html = render(item);
+    expect(html).toContain("Namespace: misc ns");
+    expect(html).toContain("Contains 2 items");
   });
 });
 
@@ -410,5 +578,50 @@ describe("hover source tooltip DOM creation", () => {
     const view = mockView(doc);
     const tooltip = await source(view, doc.indexOf("SELECT") + 2, 1);
     expect(tooltip).toBeNull();
+  });
+
+  it("renders a default namespace tooltip DOM for a nested namespace item", async () => {
+    const nestedSchema: SQLNamespace = { mydb: { public: { users: ["id", "name"] } } };
+    const source = createHoverSource({ schema: nestedSchema, keywords: {} });
+    // "mydb" alone is not a parseable query, so the resolver falls back to the
+    // full schema and resolves the bare namespace name.
+    const doc = "mydb";
+    const view = mockView(doc);
+    const tooltip = await source(view, 2, 1);
+    expect(tooltip).not.toBeNull();
+    const { dom } = tooltip!.create(view);
+    expect(dom.className).toBe("cm-sql-hover-tooltip");
+    expect(dom.innerHTML).toContain("<strong>mydb</strong>");
+    expect(dom.innerHTML).toContain("namespace");
+  });
+
+  it("uses a custom namespace renderer for namespace/schema/database items", async () => {
+    const namespace = vi.fn().mockReturnValue("<div>custom namespace</div>");
+    const nestedSchema: SQLNamespace = { mydb: { public: { users: ["id"] } } };
+    const source = createHoverSource({
+      schema: nestedSchema,
+      keywords: {},
+      tooltipRenderers: { namespace },
+    });
+    const doc = "mydb";
+    const view = mockView(doc);
+    const tooltip = await source(view, 2, 1);
+    expect(tooltip).not.toBeNull();
+    const { dom } = tooltip!.create(view);
+    expect(namespace).toHaveBeenCalledOnce();
+    expect(dom.innerHTML).toContain("custom namespace");
+  });
+
+  it("prepends the alias notice to the default tooltip when hovering a bare alias", async () => {
+    const source = createHoverSource({ schema, keywords: {} });
+    const doc = "SELECT u.id FROM users u";
+    const view = mockView(doc);
+    const tooltip = await source(view, doc.length - 1, 1);
+    expect(tooltip).not.toBeNull();
+    const { dom } = tooltip!.create(view);
+    expect(dom.innerHTML).toContain("sql-hover-alias");
+    expect(dom.innerHTML).toContain("is an alias for");
+    expect(dom.innerHTML).toContain("<code>u</code>");
+    expect(dom.innerHTML).toContain("<code>users</code>");
   });
 });

--- a/src/sql/__tests__/namespace-utils.test.ts
+++ b/src/sql/__tests__/namespace-utils.test.ts
@@ -264,6 +264,11 @@ describe("findNamespaceCompletions", () => {
       const results = findNamespaceCompletions(mockNamespaces.complexNested, "postgres.public.");
       expect(results.length).toBeGreaterThanOrEqual(2); // users, orders
     });
+
+    it("should return an empty array when the dotted base path does not resolve", () => {
+      const results = findNamespaceCompletions(mockNamespaces.simpleObject, "nonexistent.foo");
+      expect(results).toEqual([]);
+    });
   });
 
   describe("self label matching at the root", () => {
@@ -653,6 +658,239 @@ describe("performance and memory", () => {
 
     // If we get here without running out of memory, the test passes
     expect(true).toBe(true);
+  });
+});
+
+describe("semantic type classification", () => {
+  // A schema crafted so that each structural branch of determineSemanticType is
+  // reachable through the public traversal/completion helpers.
+  const semanticSchema: SQLNamespace = {
+    // object namespace whose child is an array (table) -> "database" at depth 1
+    db: {
+      tbl: ["a", createCompletion("b")],
+    },
+    // object namespace whose children are only nested objects -> "namespace"
+    nsOnly: {
+      child: { grand: ["x"] },
+    },
+    // object -> object -> object(with array) so the inner object is a "schema" at depth 3
+    deep: {
+      lvl1: {
+        sch: { t: ["x"] },
+      },
+    },
+    // self/children completion whose children is an array -> "table" at depth 1
+    tblSelf: {
+      self: createCompletion("tblSelf"),
+      children: ["c1", createCompletion("c2")],
+    },
+    // self/children completion whose object children include a table (array) -> "database"
+    dbSelf: {
+      self: createCompletion("dbSelf"),
+      children: { t1: ["x"] },
+    },
+    // self/children completion whose object children have no tables -> "database" at depth 1
+    dbSelfNoTables: {
+      self: createCompletion("dbSelfNoTables"),
+      children: { subsch: { t: ["x"] } },
+    },
+    // nested self/children completions at depth 2 -> "schema"
+    outer: {
+      mid: {
+        self: createCompletion("mid"),
+        children: { t: ["x"] },
+      },
+      midNoTables: {
+        self: createCompletion("midNoTables"),
+        children: { subsch: { t: ["x"] } },
+      },
+    },
+    // self/children completion whose children is itself a self/children node
+    // (neither array nor plain object) -> database (depth 1)
+    weirdSelf: {
+      self: createCompletion("weirdSelf"),
+      children: { self: createCompletion("inner"), children: ["x"] },
+    },
+    outerWeird: {
+      midWeird: {
+        self: createCompletion("midWeird"),
+        children: { self: createCompletion("inner2"), children: ["y"] },
+      },
+    },
+  };
+
+  describe("leaf columns in arrays", () => {
+    it("classifies a leaf string in an array as a column", () => {
+      const result = traverseNamespacePath(semanticSchema, "db.tbl.a");
+      expect(result?.type).toBe("string");
+      expect(result?.value).toBe("a");
+      expect(result?.semanticType).toBe("column");
+    });
+
+    it("classifies a leaf Completion in an array as a column", () => {
+      const result = traverseNamespacePath(semanticSchema, "db.tbl.b");
+      expect(result?.type).toBe("completion");
+      expect(result?.completion?.label).toBe("b");
+      expect(result?.semanticType).toBe("column");
+    });
+
+    it("classifies array columns as columns via findNamespaceCompletions", () => {
+      const results = findNamespaceCompletions(mockNamespaces.arrayNamespace, "");
+      expect(results.length).toBeGreaterThan(0);
+      for (const result of results) {
+        expect(result.semanticType).toBe("column");
+      }
+    });
+
+    it("classifies Completion columns of a self/children array via findNamespaceCompletions", () => {
+      // "postgres.public.users" is a self/children whose children is an array of columns
+      const results = findNamespaceCompletions(
+        mockNamespaces.complexNested,
+        "postgres.public.users.",
+      );
+      expect(results.length).toBeGreaterThan(0);
+      const completionColumn = results.find((r) => r.type === "completion");
+      expect(completionColumn).toBeTruthy();
+      expect(completionColumn?.semanticType).toBe("column");
+    });
+
+    it("classifies array columns as columns via findNamespaceItemByEndMatch", () => {
+      const results = findNamespaceItemByEndMatch(mockNamespaces.arrayNamespace, "created_at");
+      const match = results.find((r) => r.completion?.label === "created_at");
+      expect(match?.semanticType).toBe("column");
+    });
+  });
+
+  describe("array namespaces resolved as nodes", () => {
+    it("classifies an array namespace node as a table", () => {
+      const result = traverseNamespacePath(semanticSchema, "db.tbl");
+      expect(result?.type).toBe("namespace");
+      expect(result?.semanticType).toBe("table");
+    });
+  });
+
+  describe("object namespaces with tables", () => {
+    it("classifies a shallow object namespace with table children as a database", () => {
+      const result = traverseNamespacePath(semanticSchema, "db");
+      expect(result?.type).toBe("namespace");
+      expect(result?.semanticType).toBe("database");
+    });
+
+    it("classifies a deep object namespace with table children as a schema", () => {
+      const result = traverseNamespacePath(semanticSchema, "deep.lvl1.sch");
+      expect(result?.type).toBe("namespace");
+      expect(result?.semanticType).toBe("schema");
+    });
+
+    it("classifies an object namespace whose child is a self/children table as a schema (depth>1)", () => {
+      // postgres.public: children are `users` (self/children with array children) and
+      // `orders` (array), so hasTableChildren is satisfied via the self/children branch.
+      const result = traverseNamespacePath(mockNamespaces.complexNested, "postgres.public");
+      expect(result?.type).toBe("namespace");
+      expect(result?.semanticType).toBe("schema");
+    });
+  });
+
+  describe("object namespaces without tables", () => {
+    it("classifies a shallow object namespace of only nested objects as a namespace", () => {
+      const result = traverseNamespacePath(semanticSchema, "nsOnly");
+      expect(result?.type).toBe("namespace");
+      expect(result?.semanticType).toBe("namespace");
+    });
+
+    it("classifies a deeper object namespace of only nested objects as a namespace", () => {
+      const result = traverseNamespacePath(semanticSchema, "deep.lvl1");
+      expect(result?.type).toBe("namespace");
+      expect(result?.semanticType).toBe("namespace");
+    });
+  });
+
+  describe("self/children completions", () => {
+    it("classifies a self/children completion with array children as a table", () => {
+      const result = traverseNamespacePath(semanticSchema, "tblSelf");
+      expect(result?.type).toBe("completion");
+      expect(result?.completion?.label).toBe("tblSelf");
+      expect(result?.semanticType).toBe("table");
+    });
+
+    it("classifies a shallow self/children completion with table children as a database", () => {
+      const result = traverseNamespacePath(semanticSchema, "dbSelf");
+      expect(result?.type).toBe("completion");
+      expect(result?.semanticType).toBe("database");
+    });
+
+    it("classifies a shallow self/children completion without table children as a database", () => {
+      const result = traverseNamespacePath(semanticSchema, "dbSelfNoTables");
+      expect(result?.type).toBe("completion");
+      expect(result?.semanticType).toBe("database");
+    });
+
+    it("classifies a deep self/children completion with table children as a schema", () => {
+      const result = traverseNamespacePath(semanticSchema, "outer.mid");
+      expect(result?.type).toBe("completion");
+      expect(result?.completion?.label).toBe("mid");
+      expect(result?.semanticType).toBe("schema");
+    });
+
+    it("classifies a deep self/children completion without table children as a schema", () => {
+      const result = traverseNamespacePath(semanticSchema, "outer.midNoTables");
+      expect(result?.type).toBe("completion");
+      expect(result?.semanticType).toBe("schema");
+    });
+
+    it("classifies a root self/children completion (empty path) as a database", () => {
+      const result = traverseNamespacePath(mockNamespaces.selfChildren, "");
+      expect(result?.type).toBe("completion");
+      expect(result?.completion?.label).toBe("database");
+      expect(result?.semanticType).toBe("database");
+    });
+
+    it("classifies the self completion matched at the root as a database", () => {
+      const results = findNamespaceCompletions(mockNamespaces.selfChildren, "data");
+      const selfMatch = results.find((r) => r.completion?.label === "database");
+      expect(selfMatch?.semanticType).toBe("database");
+    });
+
+    it("classifies a shallow self/children completion with self/children children as a database", () => {
+      const result = traverseNamespacePath(semanticSchema, "weirdSelf");
+      expect(result?.type).toBe("completion");
+      expect(result?.semanticType).toBe("database");
+    });
+
+    it("classifies a deep self/children completion with self/children children as a schema", () => {
+      const result = traverseNamespacePath(semanticSchema, "outerWeird.midWeird");
+      expect(result?.type).toBe("completion");
+      expect(result?.semanticType).toBe("schema");
+    });
+  });
+
+  describe("array item matching", () => {
+    it("resolves an array's Completion item by its label", () => {
+      const result = traverseNamespacePath(mockNamespaces.arrayNamespace, "created_at");
+      expect(result?.type).toBe("completion");
+      expect(result?.completion?.label).toBe("created_at");
+      expect(result?.semanticType).toBe("column");
+    });
+
+    it("matches array string items case-insensitively by default", () => {
+      const result = traverseNamespacePath(mockNamespaces.arrayNamespace, "NAME");
+      expect(result?.type).toBe("string");
+      expect(result?.value).toBe("name");
+    });
+
+    it("does not match array string items when case-sensitive", () => {
+      const result = traverseNamespacePath(mockNamespaces.arrayNamespace, "NAME", {
+        caseSensitive: true,
+      });
+      expect(result).toBeNull();
+    });
+
+    it("does not match an array Completion item when case-sensitive", () => {
+      const result = traverseNamespacePath(mockNamespaces.arrayNamespace, "CREATED_AT", {
+        caseSensitive: true,
+      });
+      expect(result).toBeNull();
+    });
   });
 });
 

--- a/src/sql/__tests__/parser.test.ts
+++ b/src/sql/__tests__/parser.test.ts
@@ -89,6 +89,83 @@ describe("SqlParser", () => {
       expect(mockGetParserOptions).toHaveBeenCalledTimes(1);
       expect(mockGetParserOptions).toHaveBeenCalledWith(state);
     });
+
+    it("rewrites 'Expected ... but ... found.' messages and strips the Error: prefix", async () => {
+      // node-sql-parser produces an "Expected ... but \"F\" found." style message here
+      const result = await parser.parse("SELECT * FORM users", { state });
+
+      expect(result.success).toBe(false);
+      expect(result.errors).toHaveLength(1);
+      const message = result.errors[0].message;
+      // cleanErrorMessage rewrites the "but ... found" tail
+      expect(message).toContain("found unexpected token");
+      expect(message).not.toContain("but");
+      // and strips any leading "Error: " prefix
+      expect(message.startsWith("Error: ")).toBe(false);
+    });
+
+    it("falls back to line/column 1 for errors without location info (unsupported dialect)", async () => {
+      // An unsupported dialect throws "X is not supported currently" with no
+      // location or hash, forcing the message-regex fallback in extractErrorInfo.
+      const oracleParser = new NodeSqlParser({
+        getParserOptions: () => ({
+          // Oracle is not supported by node-sql-parser
+          database: "Oracle" as unknown as "PostgreSQL",
+        }),
+      });
+
+      const result = await oracleParser.parse("SELECT 1", { state });
+
+      expect(result.success).toBe(false);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0].message).toContain("not supported");
+      // No "line N"/"column N" in the message, so both default to 1
+      expect(result.errors[0].line).toBe(1);
+      expect(result.errors[0].column).toBe(1);
+    });
+
+    it("clamps a reported column that exceeds the sql length", async () => {
+      // "SELECT * FROM" is 13 chars; the parser reports column 14 (end of input),
+      // which extractErrorInfo clamps down to sql.length.
+      const sql = "SELECT * FROM";
+      const result = await parser.parse(sql, { state });
+
+      expect(result.success).toBe(false);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0].column).toBe(sql.length);
+    });
+  });
+
+  describe("extractTableReferences", () => {
+    it("extracts and cleans table names from a valid query", async () => {
+      const tables = await parser.extractTableReferences("SELECT id FROM users");
+      expect(tables).toContain("users");
+      // Names are cleaned of the "type::schema::table" prefixing
+      expect(tables.every((table) => !table.includes("::"))).toBe(true);
+    });
+
+    it("strips schema prefixes from qualified table names", async () => {
+      const tables = await parser.extractTableReferences("SELECT * FROM schema1.orders");
+      expect(tables).toContain("orders");
+      expect(tables.every((table) => !table.includes("::"))).toBe(true);
+    });
+
+    it("returns an empty array for invalid SQL", async () => {
+      const tables = await parser.extractTableReferences("NOT VALID SQL");
+      expect(tables).toEqual([]);
+    });
+
+    it("passes parser options through when a state is provided", async () => {
+      const getParserOptions = vi.fn().mockReturnValue({ database: "PostgreSQL" });
+      const customParser = new NodeSqlParser({ getParserOptions });
+      const tableState = EditorState.create({ doc: "SELECT id FROM users" });
+
+      const tables = await customParser.extractTableReferences("SELECT id FROM users", {
+        state: tableState,
+      });
+      expect(getParserOptions).toHaveBeenCalledWith(tableState);
+      expect(tables).toContain("users");
+    });
   });
 
   describe("extractColumnReferences", () => {
@@ -221,6 +298,29 @@ describe("SqlParser", () => {
       // The offset should be at the original position of the error
       const expectedColumn = sql.length;
       expect(error.column).toBe(expectedColumn);
+    });
+
+    it("maps the error column back through the CREATE OR REPLACE replacement (catch path)", async () => {
+      const duckdbParser = new NodeSqlParser({
+        getParserOptions: () => ({
+          database: "DuckDB",
+        }),
+      });
+
+      // Lowercase "create or replace table" is matched by indexOf at position 0,
+      // so a mid-string syntax error ("badclause") gets its column shifted back
+      // by the length removed during the replacement rather than clamped.
+      const sql = "create or replace table t (id INT) badclause";
+      const state = EditorState.create({ doc: sql });
+
+      const result = await duckdbParser.parse(sql, { state });
+
+      expect(result.success).toBe(false);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0].line).toBe(1);
+      // Column points at "badclause" in the original (pre-replacement) SQL
+      expect(result.errors[0].column).toBe(sql.indexOf("badclause") + 1);
+      expect(result.errors[0].column).toBeLessThan(sql.length);
     });
 
     it("should be successful with macro keyword", async () => {

--- a/src/sql/__tests__/query-context.test.ts
+++ b/src/sql/__tests__/query-context.test.ts
@@ -3,15 +3,31 @@ import { describe, expect, it, vi } from "vitest";
 import { NodeSqlParser } from "../parser.js";
 import {
   analyzeQueryContext,
+  maskLiteralsAndComments,
   type QueryContext,
   QueryContextAnalyzer,
   stripIdentifierQuotes,
 } from "../query-context.js";
+import type { SqlParser } from "../types.js";
 
 const parser = new NodeSqlParser();
 
 async function analyze(sql: string): Promise<QueryContext> {
   return analyzeQueryContext(sql, parser, { state: EditorState.create({ doc: sql }) });
+}
+
+async function analyzeWith(customParser: SqlParser, sql: string): Promise<QueryContext> {
+  return analyzeQueryContext(sql, customParser, { state: EditorState.create({ doc: sql }) });
+}
+
+/** Minimal parser stub; only `parse` is exercised by analyzeQueryContext. */
+function makeParser(parse: SqlParser["parse"]): SqlParser {
+  return {
+    parse,
+    validateSql: async () => [],
+    extractTableReferences: async () => [],
+    extractColumnReferences: async () => [],
+  };
 }
 
 describe("analyzeQueryContext", () => {
@@ -199,6 +215,121 @@ describe("QueryContextAnalyzer", () => {
     const second = await analyzer.getContext(sql, { state });
     expect(second).not.toBe(first);
     expect(second).toEqual(first);
+  });
+});
+
+describe("analyzeQueryContext parser fallbacks", () => {
+  it("falls back to the regex path when the parser throws", async () => {
+    const throwing = makeParser(async () => {
+      throw new Error("boom");
+    });
+    const context = await analyzeWith(throwing, "SELECT id FROM users u");
+    expect(context.aliases.get("u")).toBe("users");
+    expect(context.tables).toEqual([{ name: "users", path: ["users"], alias: "u" }]);
+  });
+
+  it("falls back to the regex path when parsing reports failure", async () => {
+    const failing = makeParser(async () => ({ success: false, errors: [] }));
+    const context = await analyzeWith(failing, "SELECT id FROM users u");
+    expect(context.aliases.get("u")).toBe("users");
+  });
+
+  it("falls back to the regex path when the parser returns a null ast", async () => {
+    const nullAst = makeParser(async () => ({ success: true, errors: [], ast: null }));
+    const context = await analyzeWith(nullAst, "SELECT id FROM users u");
+    expect(context.aliases.get("u")).toBe("users");
+  });
+
+  it("falls back to the regex path when the AST walk throws", async () => {
+    // An ast whose property access throws forces the post-parse try/catch to
+    // fall back to the regex scan.
+    const exploding: Record<string, unknown> = {};
+    Object.defineProperty(exploding, "type", {
+      enumerable: true,
+      get() {
+        throw new Error("kaboom");
+      },
+    });
+    const badAst = makeParser(async () => ({ success: true, errors: [], ast: exploding }));
+    const context = await analyzeWith(badAst, "SELECT id FROM users u");
+    // Regex fallback still resolves the alias
+    expect(context.aliases.get("u")).toBe("users");
+  });
+});
+
+describe("analyzeQueryContext multiple statements", () => {
+  it("collects tables from statements split by semicolons", async () => {
+    const context = await analyze("SELECT a FROM t1; SELECT b FROM t2");
+    const names = context.tables.map((t) => t.name).sort();
+    expect(names).toEqual(["t1", "t2"]);
+  });
+
+  it("collects select aliases across multiple statements", async () => {
+    const context = await analyze("SELECT a AS x FROM t1; SELECT b AS y FROM t2");
+    expect(context.selectAliases).toEqual(["x", "y"]);
+  });
+});
+
+describe("analyzeQueryContext CTE column inference", () => {
+  it("ignores SELECT * when inferring CTE columns from the AST", async () => {
+    const context = await analyze("WITH c AS (SELECT * FROM logs) SELECT * FROM c");
+    expect(context.ctes[0]?.name).toBe("c");
+    expect(context.ctes[0]?.columns).toEqual([]);
+  });
+
+  it("infers columns from the select body in the regex fallback, skipping stars", async () => {
+    // Trailing `c.` keeps the statement unparsable, forcing the regex fallback.
+    const sql =
+      "WITH c AS (SELECT a AS x, foo(b, c) AS f, t.*, plain FROM logs WHERE ) SELECT c. FROM c";
+    const context = await analyzeWith(parser, sql);
+    expect(context.ctes[0]?.name).toBe("c");
+    expect(context.ctes[0]?.columns).toEqual(["x", "f", "plain"]);
+  });
+});
+
+describe("analyzeQueryContext literal and comment masking", () => {
+  it("does not read FROM inside an escaped single-quoted literal as a table", async () => {
+    const context = await analyze("SELECT x. FROM users u WHERE n = 'it''s from ghost g'");
+    expect(context.tables.map((t) => t.name)).toEqual(["users"]);
+    expect(context.aliases.has("g")).toBe(false);
+    expect(context.aliases.get("u")).toBe("users");
+  });
+
+  it("resolves an alias for a bracket-quoted table name via the regex fallback", async () => {
+    const context = await analyze("SELECT x. FROM [my table] x");
+    expect(context.aliases.get("x")).toBe("my table");
+    expect(context.tables[0]?.name).toBe("my table");
+  });
+});
+
+describe("maskLiteralsAndComments", () => {
+  it("blanks single-line comments while preserving offsets", () => {
+    const input = "SELECT 1 -- from ghost\nFROM t";
+    const masked = maskLiteralsAndComments(input);
+    expect(masked).toHaveLength(input.length);
+    expect(masked).not.toContain("ghost");
+    expect(masked.endsWith("FROM t")).toBe(true);
+  });
+
+  it("blanks block comments while preserving offsets", () => {
+    const input = "SELECT /* from ghost */ 1 FROM t";
+    const masked = maskLiteralsAndComments(input);
+    expect(masked).toHaveLength(input.length);
+    expect(masked).not.toContain("ghost");
+  });
+
+  it("blanks single-quoted string literals including escaped quotes", () => {
+    const input = "SELECT 'it''s a from' FROM t";
+    const masked = maskLiteralsAndComments(input);
+    expect(masked).toHaveLength(input.length);
+    expect(masked).not.toContain("from'");
+    expect(masked.includes("FROM t")).toBe(true);
+  });
+
+  it("leaves quoted, backtick, and bracket identifiers intact", () => {
+    const input = `SELECT "a'b", \`c'd\`, [e'f] FROM t`;
+    const masked = maskLiteralsAndComments(input);
+    expect(masked).toBe(input);
   });
 });
 

--- a/src/sql/__tests__/references.test.ts
+++ b/src/sql/__tests__/references.test.ts
@@ -112,6 +112,23 @@ describe("findReferences", () => {
       const result = await resolveAt(doc, "t AS (");
       expect(result).toBeNull();
     });
+
+    it("refuses when a CTE name is also a table alias in the same statement", async () => {
+      // `x` is a CTE name and also an alias bound to `users` — two distinct
+      // bindings, so it refuses rather than mixing them
+      const doc = "WITH x AS (SELECT 1) SELECT * FROM users x";
+      const result = await resolveAt(doc, "x AS");
+      expect(result).toBeNull();
+    });
+
+    it("does not count a comma-separated select-list entry as a relation use", async () => {
+      // The `t` after `SELECT a, ` is a column, not a FROM-list relation
+      const doc = "WITH t AS (SELECT 1) SELECT a, t FROM t";
+      const result = await resolveAt(doc, "t AS");
+      // definition + `FROM t` only
+      expect(result?.references).toHaveLength(2);
+      expect(result?.references.some((r) => r.from === doc.indexOf("t FROM"))).toBe(false);
+    });
   });
 
   describe("table aliases", () => {
@@ -152,6 +169,24 @@ describe("findReferences", () => {
       const result = await resolveAt(sql, "x.a");
       expect(result).toBeNull();
     });
+
+    it("resolves an alias whose table has a quoted qualifier", async () => {
+      const sql = 'SELECT u.name FROM "mydb".users AS u';
+      const result = await resolveAt(sql, "u.name");
+      expect(result?.kind).toBe("table-alias");
+      expect(result?.name).toBe("u");
+      expect(result?.definition.from).toBe(sql.indexOf("AS u") + "AS ".length);
+      // definition + u.name
+      expect(result?.references).toHaveLength(2);
+    });
+
+    it("returns null when the cursor is on a bare (non-qualifier) alias name", async () => {
+      // The select-list `u` is not a `u.column` qualifier use, so the cursor
+      // there does not resolve to the alias
+      const sql = "SELECT u FROM users u";
+      const result = await resolveAt(sql, "u FROM");
+      expect(result).toBeNull();
+    });
   });
 
   describe("select aliases", () => {
@@ -177,6 +212,29 @@ describe("findReferences", () => {
       // definition + ORDER BY only; WHERE resolves to a column in SQL
       expect(result?.references).toHaveLength(2);
       expect(result?.references.some((r) => r.from === sql.indexOf("total > 5"))).toBe(false);
+    });
+
+    it("returns null when the cursor is on a same-named column in WHERE", async () => {
+      // The WHERE occurrence is a column, not the select alias, so the cursor
+      // there is not a resolvable reference
+      const sql = "SELECT x AS total FROM t WHERE total > 5 ORDER BY total";
+      const result = await resolveAt(sql, "total", 1);
+      expect(result).toBeNull();
+    });
+
+    it("resolves a select alias in ORDER BY when there is no FROM clause", async () => {
+      const sql = "SELECT 1 AS total ORDER BY total";
+      const result = await resolveAt(sql, "total", 1);
+      expect(result?.kind).toBe("select-alias");
+      expect(result?.references).toHaveLength(2);
+    });
+
+    it("returns null for an alias declared without the AS keyword", async () => {
+      // The definition is only located via `AS <alias>`; without AS there is
+      // no confidently-resolvable declaration token
+      const sql = "SELECT count(*) total FROM users GROUP BY total";
+      const result = await resolveAt(sql, "total", 1);
+      expect(result).toBeNull();
     });
   });
 
@@ -212,6 +270,26 @@ describe("findReferences", () => {
     it("resolves mid-edit statements via the regex fallback", async () => {
       const sql = "WITH recent AS (SELECT x FROM logs) SELECT r. FROM recent r";
       const result = await resolveAt(sql, "recent", 1);
+      expect(result?.kind).toBe("cte");
+      expect(result?.references).toHaveLength(2);
+    });
+
+    it("returns null for a token trailing after the final statement", async () => {
+      // `zzz` sits past the terminating `;`, outside the (preceding) statement
+      const sql = "WITH t AS (SELECT 1) SELECT * FROM t; zzz";
+      const result = await resolveAt(sql, "zzz");
+      expect(result).toBeNull();
+    });
+
+    it("returns null on an empty document", async () => {
+      const state = EditorState.create({ doc: "" });
+      expect(await findReferences(state, 0)).toBeNull();
+    });
+
+    it("accepts an explicit config object", async () => {
+      const sql = "WITH recent AS (SELECT 1) SELECT * FROM recent";
+      const state = EditorState.create({ doc: sql });
+      const result = await findReferences(state, sql.indexOf("recent"), {});
       expect(result?.kind).toBe("cte");
       expect(result?.references).toHaveLength(2);
     });

--- a/src/sql/__tests__/semantic-diagnostics.test.ts
+++ b/src/sql/__tests__/semantic-diagnostics.test.ts
@@ -138,6 +138,32 @@ describe("unknown tables", () => {
     expect(diagnostics).toHaveLength(1);
     expect(diagnostics[0].message).toContain("psts");
   });
+
+  it("flags the source table of an INSERT ... SELECT", async () => {
+    const diagnostics = await lint("INSERT INTO users SELECT * FROM usres", { schema: SCHEMA });
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].message).toContain("usres");
+  });
+
+  it("flags unknown REPLACE targets", async () => {
+    const diagnostics = await lint("REPLACE INTO usres (id) VALUES (1)", { schema: SCHEMA });
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].message).toContain("usres");
+  });
+
+  it("flags over-qualified table references not present at that depth", async () => {
+    // `users` exists at the top level, but `wrongschema.users` requires a
+    // deeper match that the schema does not provide
+    const diagnostics = await lint("SELECT * FROM wrongschema.users", { schema: SCHEMA });
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].message).toContain("wrongschema.users");
+  });
+
+  it("checks nested selects reached through non-standard statements (EXPLAIN)", async () => {
+    const diagnostics = await lint("EXPLAIN SELECT * FROM usres", { schema: SCHEMA });
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].message).toContain("usres");
+  });
 });
 
 describe("unknown columns", () => {
@@ -199,6 +225,29 @@ describe("unknown columns", () => {
     });
     expect(diagnostics).toHaveLength(1);
     expect(diagnostics[0].message).toContain("nme");
+  });
+
+  it("checks columns inside an unaliased FROM subquery", async () => {
+    const diagnostics = await lint("SELECT * FROM (SELECT nme FROM users)", { schema: SCHEMA });
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].message).toContain("nme");
+  });
+
+  it("checks fully qualified (db.table.column) column references", async () => {
+    const nested = { mydb: { users: ["id", "name"] } };
+    expect(await lint("SELECT mydb.users.name FROM mydb.users", { schema: nested })).toEqual([]);
+
+    const diagnostics = await lint("SELECT mydb.users.nme FROM mydb.users", { schema: nested });
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].message).toContain("nme");
+    expect(diagnostics[0].message).toContain("mydb.users");
+  });
+
+  it("does not flag unqualified columns when a table is ambiguous across schemas", async () => {
+    // `users` matches two nested tables, so its column list is not trusted and
+    // the unknown-column check is skipped
+    const schema = { a: { users: ["id"] }, b: { users: ["id"] } };
+    expect(await lint("SELECT nme FROM users", { schema })).toEqual([]);
   });
 
   it("skips unqualified columns in correlated subqueries", async () => {
@@ -351,6 +400,28 @@ describe("severity configuration", () => {
         severity: { ambiguousColumn: "off" },
       }),
     ).toEqual([]);
+  });
+
+  it("turns the unknown-column check off independently", async () => {
+    expect(
+      await lint("SELECT nme FROM users", {
+        schema: SCHEMA,
+        severity: { unknownColumn: "off" },
+      }),
+    ).toEqual([]);
+  });
+
+  it("applies distinct severities per check kind", async () => {
+    const doc = "SELECT nme FROM usres";
+    const diagnostics = await lint(doc, {
+      schema: SCHEMA,
+      severity: { unknownTable: "error", unknownColumn: "warning" },
+    });
+    // Only the unknown table is reported: `nme` cannot be checked because its
+    // single source table does not resolve
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].severity).toBe("error");
+    expect(diagnostics[0].message).toContain("usres");
   });
 });
 

--- a/src/sql/__tests__/test-utils.ts
+++ b/src/sql/__tests__/test-utils.ts
@@ -1,0 +1,85 @@
+import {
+  CompletionContext,
+  type CompletionResult,
+  type CompletionSource,
+} from "@codemirror/autocomplete";
+import type { SQLNamespace } from "@codemirror/lang-sql";
+import { EditorState, type Extension } from "@codemirror/state";
+import { sqlSchemaFacet } from "../schema-facet.js";
+
+/**
+ * Shared test helpers and fixtures.
+ *
+ * These exist so tests can exercise more behavior with less boilerplate: the
+ * `CompletionContext` plumbing, schema fixtures, and label extraction are
+ * identical across the completion-source suites, so they live here.
+ */
+
+/** A small two-table schema used across completion/diagnostic suites. */
+export const TEST_SCHEMA: SQLNamespace = {
+  users: ["id", "username", "email"],
+  orders: [{ label: "order_id", detail: "Order ID", type: "property" }, "total"],
+};
+
+/** A one-level nested (catalog.table) schema. */
+export const NESTED_SCHEMA: SQLNamespace = {
+  mydb: {
+    users: ["id", "username"],
+  },
+};
+
+/** Creates an `EditorState`, optionally installing a schema facet. */
+export function createState(doc: string, extensions: Extension[] = []): EditorState {
+  return EditorState.create({ doc, extensions });
+}
+
+/** Builds a `CompletionContext` positioned within `doc` (defaults to the end). */
+export function createCompletionContext(
+  doc: string,
+  opts: { pos?: number; explicit?: boolean; extensions?: Extension[] } = {},
+): CompletionContext {
+  const state = createState(doc, opts.extensions);
+  const pos = opts.pos ?? doc.length;
+  return new CompletionContext(state, pos, opts.explicit ?? false);
+}
+
+/** Extracts the option labels from a completion result. */
+export function labels(result: CompletionResult | null): string[] {
+  return (result?.options ?? []).map((option) => option.label);
+}
+
+/**
+ * Options accepted by the {@link completeWith} runner.
+ *
+ * `schema` is passed to the source factory as config; `facetSchema` installs a
+ * {@link sqlSchemaFacet} on the state instead (mirroring how the schema can be
+ * supplied either explicitly or via the facet).
+ */
+export interface CompleteOptions {
+  schema?: SQLNamespace;
+  pos?: number;
+  explicit?: boolean;
+  facetSchema?: SQLNamespace;
+}
+
+/**
+ * Wraps a completion-source factory into a reusable `complete(doc, opts)` runner.
+ *
+ * When only `facetSchema` is provided, the source is created without an explicit
+ * schema so it falls back to reading the facet — matching real usage.
+ */
+export function completeWith(
+  factory: (config: { schema?: SQLNamespace }) => CompletionSource,
+): (doc: string, opts?: CompleteOptions) => Promise<CompletionResult | null> {
+  return async (doc: string, opts: CompleteOptions = {}) => {
+    const source = factory(
+      opts.schema === undefined && opts.facetSchema !== undefined ? {} : { schema: opts.schema },
+    );
+    const context = createCompletionContext(doc, {
+      pos: opts.pos,
+      explicit: opts.explicit,
+      extensions: opts.facetSchema !== undefined ? [sqlSchemaFacet.of(opts.facetSchema)] : [],
+    });
+    return (await source(context)) as CompletionResult | null;
+  };
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,5 +20,5 @@
     "outDir": "./dist"
   },
   "include": ["./src"],
-  "exclude": ["./demo", "./src/**/*.test.ts"]
+  "exclude": ["./demo", "./src/**/*.test.ts", "./src/**/__tests__/**"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -18,7 +18,7 @@ export default defineConfig({
         test: {
           environment: "jsdom",
           exclude: ["src/**/browser_tests/**/*.test.ts"],
-          include: ["src/**/*.test.ts", "src/**/__tests__/**/*.ts",],
+          include: ["src/**/*.test.ts", "src/**/__tests__/**/*.test.ts"],
         }
       },
       {


### PR DESCRIPTION
## Summary
Broadens unit-test coverage and reduces test boilerplate.

Unit suite (excludes browser-covered `navigation-extension`):

| Metric | Before | After |
|---|---|---|
| Statements | 89.1% | **91.6%** |
| Branches | 81.2% | **85.9%** |
| Lines | 89.0% | **91.5%** |
| Tests | 471 | **587** (+116) |

## DRY
- New `__tests__/test-utils.ts`: shared fixtures + `createCompletionContext`/`labels`/`completeWith` runner.
- `column-` and `alias-completion-source` suites refactored onto it (~90 lines of duplicated setup removed).
- Scoped vitest's `__tests__` glob to `*.test.ts` and excluded `__tests__/**` from the `tsc` build so the helper file isn't run as a test or shipped in `dist`.

## New edge cases
- New `completion-utils` suite (previously untested).
- Added cases to `parser` (64→71% branch), `namespace-utils` (78→86%), `query-context`, `references` (79→86%), `semantic-diagnostics` (82→86%), `hover` (86→98%, lines→100%), `diagnostics` (→100%).

## Test plan
- `pnpm test` (jsdom): 587 passed, 1 pre-existing `it.fails`.
- `pnpm run typecheck` and `pnpm exec oxlint`: clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expands unit-test edge-case coverage and consolidates shared test helpers to cut boilerplate. Coverage up: statements 89.1%→91.6%, branches 81.2%→85.9%, lines 89.0%→91.5%; +116 tests.

- **Refactors**
  - Added `src/sql/__tests__/test-utils.ts` with shared fixtures and `createCompletionContext`/`completeWith`/`labels`; introduced `completion-utils` tests.
  - Refactored `column-` and `alias-completion-source` tests to use the helpers (~90 lines of duplicate setup removed).
  - Scoped `vite` test include to `src/**/__tests__/**/*.test.ts` and excluded `__tests__/**` from `tsc` so helpers aren’t executed or published.

<sup>Written for commit 6d51e0e21951ff7ca0efcd2097289b53e743b2cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marimo-team/codemirror-sql/pull/168?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

