### PR TITLE
chore: establish vNext quality foundation

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -2,7 +2,7 @@ name: autofix.ci # needed to securely identify the workflow
 
 on:
   push:
-    branches: [main]
+    branches: [main, dev-refactor]
   pull_request:
 
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,28 @@ on:
       - 'v*'
 
 jobs:
+  compatibility:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: ⎔ Setup pnpm
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
+
+      - name: ⎔ Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 20.19.0
+          cache: pnpm
+
+      - name: 📥 Install dependencies
+        run: pnpm install --ignore-scripts --frozen-lockfile
+
+      - name: 📦 Packed Package Smoke Test
+        run: pnpm run test:package
+
   build:
     runs-on: ubuntu-latest
     steps:
@@ -27,11 +49,26 @@ jobs:
       - name: 📥 Install dependencies
         run: pnpm install --ignore-scripts --frozen-lockfile
 
+      - name: 🧹 Lint
+        run: pnpm exec oxlint
+
+      - name: 🧪 Test Integrity
+        run: pnpm run test:integrity
+
       - name: 🔍 Type Check
         run: pnpm run typecheck
 
-      - name: 🧪 Test
-        run: pnpm run test
+      - name: 🧪 Unit Tests and Coverage
+        run: pnpm run test:coverage
+
+      - name: 🎭 Install Chromium
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: 🧪 Browser Tests
+        run: pnpm run test:browser
+
+      - name: 📦 Packed Package Smoke Test
+        run: pnpm run test:package
 
       - name: 🏗️ Build
         run: pnpm run build
@@ -76,7 +113,7 @@ jobs:
       contents: read
 
   publish:
-    needs: build
+    needs: [build, compatibility]
     runs-on: ubuntu-latest
     permissions:
       id-token: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   compatibility:
     env:
+      EXPECTED_PNPM_VERSION: "10.28.2"
       npm_config_manage_package_manager_versions: "false"
       npm_config_package_manager_strict_version: "false"
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,8 @@ jobs:
 
       - name: ⎔ Setup pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
+        with:
+          version: 10.28.2
 
       - name: ⎔ Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,9 @@ on:
 
 jobs:
   compatibility:
+    env:
+      npm_config_manage_package_manager_versions: "false"
+      npm_config_package_manager_strict_version: "false"
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -18,6 +21,7 @@ jobs:
       - name: ⎔ Setup pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
         with:
+          package_json_file: test/package-smoke/package.json
           version: 10.28.2
 
       - name: ⎔ Setup Node.js
@@ -25,6 +29,10 @@ jobs:
         with:
           node-version: 20.19.0
           cache: pnpm
+
+      - name: 🔒 Verify pnpm version
+        shell: bash
+        run: test "$(pnpm --version)" = "10.28.2"
 
       - name: 📥 Install dependencies
         run: pnpm install --ignore-scripts --frozen-lockfile

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,6 +101,7 @@ jobs:
 
   package:
     env:
+      EXPECTED_PNPM_VERSION: ${{ matrix.pnpm-version }}
       npm_config_manage_package_manager_versions: "false"
       npm_config_package_manager_strict_version: "false"
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,13 +100,18 @@ jobs:
         run: pnpm run test:browser
 
   package:
+    env:
+      npm_config_manage_package_manager_versions: "false"
+      npm_config_package_manager_strict_version: "false"
     strategy:
       fail-fast: false
       matrix:
         include:
           - node-version: "20.19.0"
+            pnpm-manifest: "test/package-smoke/package.json"
             pnpm-version: "10.28.2"
           - node-version: "24"
+            pnpm-manifest: "package.json"
             pnpm-version: "11.4.0"
     runs-on: ubuntu-latest
 
@@ -119,6 +124,7 @@ jobs:
       - name: ⎔ Setup pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
         with:
+          package_json_file: ${{ matrix.pnpm-manifest }}
           version: ${{ matrix.pnpm-version }}
 
       - name: ⎔ Setup Node.js
@@ -126,6 +132,10 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: pnpm
+
+      - name: 🔒 Verify pnpm version
+        shell: bash
+        run: test "$(pnpm --version)" = "${{ matrix.pnpm-version }}"
 
       - name: 📥 Install dependencies
         run: pnpm install --ignore-scripts --frozen-lockfile

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,8 +101,13 @@ jobs:
 
   package:
     strategy:
+      fail-fast: false
       matrix:
-        node-version: ["20.19.0", "24"]
+        include:
+          - node-version: "20.19.0"
+            pnpm-version: "10.28.2"
+          - node-version: "24"
+            pnpm-version: "11.4.0"
     runs-on: ubuntu-latest
 
     permissions:
@@ -113,6 +118,8 @@ jobs:
 
       - name: ⎔ Setup pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
+        with:
+          version: ${{ matrix.pnpm-version }}
 
       - name: ⎔ Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,10 +4,16 @@ on:
   push:
     branches:
       - main
+      - dev-refactor
 
   pull_request:
     branches:
       - main
+      - dev-refactor
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   CLICOLOR: 1
@@ -22,6 +28,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
 
       - name: ⎔ Setup pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
@@ -38,17 +46,85 @@ jobs:
       - name: 🧹 Lint
         run: pnpm exec oxlint
 
+      - name: 🧪 Test Integrity
+        run: pnpm run test:integrity
+
       - name: 🔍 Type Check
         run: pnpm run typecheck
 
-      - name: 🧪 Test
-        run: pnpm run test
+      - name: 🧪 Unit Tests and Coverage
+        run: pnpm run test:coverage
+
+      - name: 📈 Changed-Code Coverage
+        if: github.event_name == 'pull_request' || github.event_name == 'push'
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: >-
+          pnpm run test:coverage:changed
+          "${{ github.event.pull_request.base.sha || github.event.before }}"
 
       - name: 📊 Report Coverage
-        if: always()
+        if: >-
+          always() &&
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository
         uses: davelosert/vitest-coverage-report-action@3c50566c523e04813df28de8f7c48dd97d663f1c # v2
         with:
           pr-number: auto
+
+  browser:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: ⎔ Setup pnpm
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
+
+      - name: ⎔ Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: 📥 Install dependencies
+        run: pnpm install --ignore-scripts --frozen-lockfile
+
+      - name: 🎭 Install Chromium
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: 🧪 Browser Tests
+        run: pnpm run test:browser
+
+  package:
+    strategy:
+      matrix:
+        node-version: ["20.19.0", "24"]
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: ⎔ Setup pnpm
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
+
+      - name: ⎔ Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: pnpm
+
+      - name: 📥 Install dependencies
+        run: pnpm install --ignore-scripts --frozen-lockfile
+
+      - name: 📦 Packed Package Smoke Test
+        run: pnpm run test:package
 
   security:
     runs-on: ubuntu-latest

--- a/SQL_EDITOR_RESEARCH.md
+++ b/SQL_EDITOR_RESEARCH.md
@@ -1,0 +1,1681 @@
+# SQL Editor Research and Gap Analysis
+
+Date: 2026-07-24
+
+## Executive summary
+
+The repository has a strong foundation, especially after v0.3.0, but the
+investigation found several confirmed correctness bugs and one potential
+security issue.
+
+The biggest strategic limitation is that most semantic features are built
+around a flat, mostly location-free `node-sql-parser` AST. This makes nested
+scopes, accurately positioned diagnostics, dialect fidelity, and multi-catalog
+completion harder than they need to be.
+
+The recommended sequence is:
+
+1. Ship a correctness and security release.
+2. Consolidate parsing and semantic analysis around a shared, location-aware
+   document model.
+3. Build richer completion, schema, formatting, and language-server features on
+   that model.
+
+## Highest-priority findings
+
+### P0: Escape all default hover content
+
+Default tooltips assemble schema and keyword metadata as HTML and assign it
+through `innerHTML`. Table names, column names, completion `detail` and `info`,
+keyword descriptions, examples, and metadata are not escaped.
+
+Relevant code:
+
+- `src/sql/hover.ts`, around the tooltip DOM construction and `innerHTML`
+  assignment.
+- `src/sql/hover.ts`, in `createNamespaceTooltip`,
+  `createKeywordTooltip`, `createTableTooltip`, and `createColumnTooltip`.
+
+If schema descriptions or completion metadata originate from a database or
+service, crafted values could inject markup or script-capable elements into the
+host application.
+
+Recommended fix:
+
+- Build default tooltips with DOM nodes and `textContent`, or escape every value
+  used by the default renderers.
+- Document whether custom renderers return trusted HTML or plain text.
+- Add hostile table, column, description, and metadata tests.
+
+### P1: BigQuery dialect construction is incorrect
+
+`src/dialects/bigquery.ts` spreads the `PostgreSQL` dialect object rather than
+`PostgreSQL.spec`:
+
+```ts
+const BigQuery: SQLDialectSpec = {
+  ...PostgreSQL,
+  caseInsensitiveIdentifiers: true,
+  identifierQuotes: "`",
+};
+```
+
+Runtime inspection confirmed:
+
+- PostgreSQL has 831 registered words.
+- `BigQueryDialect` has only 295, corresponding to the standard defaults.
+- BigQuery-relevant items such as `QUALIFY` are absent.
+
+At minimum, this should spread `PostgreSQL.spec`. Preferably, the project should
+generate and maintain a real BigQuery dialect spec rather than describing it as
+a PostgreSQL wrapper.
+
+The earlier marimo
+[BigQuery quoting report](https://github.com/marimo-team/marimo/issues/5419)
+also illustrates why dialect-specific quoting and completion need to be
+accurate.
+
+### P1: The statement splitter corrupts valid SQL
+
+The custom scanner in `src/sql/structure-analyzer.ts` understands single,
+double, and backtick quotes plus comments, but not:
+
+- PostgreSQL dollar-quoted strings
+- MSSQL bracket-quoted identifiers
+- Backslash escape modes
+- Procedural `BEGIN ... END` bodies
+- Custom delimiters
+- Some dialect-specific multiline strings
+
+The following was reproduced:
+
+```sql
+SELECT $$a;b$$; SELECT [x;y] FROM t; SELECT 3
+```
+
+It was split into:
+
+```text
+SELECT $$a
+b$$
+SELECT [x
+y] FROM t
+SELECT 3
+```
+
+This affects linting, gutter state, hover scope, completion, and navigation
+simultaneously.
+
+Recommended fix:
+
+- Obtain statement boundaries from a tokenizer, parser, or CodeMirror syntax
+  tree.
+- Keep the scanner only as a documented fallback.
+- Add a dialect-specific statement-boundary corpus.
+
+### P1: Semantic diagnostics can point to the wrong text or disappear
+
+Semantic diagnostic locations are reconstructed by finding the first matching
+identifier text in the statement. This can underline an occurrence inside a
+comment or string rather than the real table or column reference.
+
+Confirmed examples:
+
+```sql
+SELECT 'usres' AS note FROM usres
+```
+
+```sql
+-- usres
+SELECT * FROM usres
+```
+
+In both cases, the unknown-table diagnostic points to the first `usres`.
+
+There is a second issue. `SqlStatement.content` has comments removed before
+semantic re-parsing, but comment removal does not preserve whitespace. These
+queries silently lose an expected unknown-column warning:
+
+```sql
+SELECT/*x*/bad FROM users
+SELECT bad/*x*/FROM users
+SELECT bad FROM/*x*/users
+```
+
+The original statement parses, but semantic analysis reparses concatenated text
+such as `SELECTbad`.
+
+Recommended fix:
+
+- Store the original statement source and parsed AST on `SqlStatement`.
+- Preserve source locations from the parser.
+- Never reparse comment-stripped display content.
+- Mask comments with spaces when offsets must be preserved.
+
+### P1: Nested query scopes leak into completion
+
+`walkAst` flattens tables from every nested query into one `QueryContext`.
+Unqualified completion then iterates the entire flattened table list.
+
+This outer-query completion was reproduced:
+
+```sql
+SELECT | FROM users
+WHERE EXISTS (SELECT 1 FROM orders)
+```
+
+With a schema containing `user_col` and `order_col`, the outer completion
+offered both. Only the columns of `users` are visible at that cursor.
+
+The query model should become a scope tree containing:
+
+- Parent and child scopes
+- Exact source ranges
+- Visible CTEs and aliases
+- Derived-table output columns
+- Correlation rules
+- The innermost scope at a cursor position
+
+This also provides a principled fix for alias shadowing and CTE visibility.
+
+### P1: State-sensitive parser results are cached only by SQL text
+
+Both `SqlStructureAnalyzer` and `QueryContextAnalyzer` cache by SQL text alone.
+However, `NodeSqlParser.getParserOptions(state)` explicitly allows dialect and
+parser options to depend on editor state.
+
+A targeted reproduction analyzed identical SQL under two states with different
+dialect facets. The parser was only called for the first state, and the second
+state received the cached result.
+
+Recommended fix:
+
+- Add a parser/dialect/configuration identity to cache keys, or
+- Invalidate analyzers when relevant facets change.
+
+### P1: Async gutter results can arrive out of order
+
+The gutter starts untracked asynchronous analysis after document, selection, or
+focus changes and dispatches each result unconditionally. A slower result for an
+older state can therefore overwrite the result for newer text.
+
+Navigation already uses generation checks. The gutter should follow the same
+pattern and verify that `view.state` still matches the captured state before
+dispatching.
+
+## Smaller confirmed issues
+
+### A zero-millisecond lint delay is ignored
+
+Both linters use:
+
+```ts
+delay: config.delay || DEFAULT_DELAY
+```
+
+As a result, `delay: 0` becomes the default delay. Use:
+
+```ts
+delay: config.delay ?? DEFAULT_DELAY
+```
+
+### Hover fuzzy-search documentation and behavior disagree
+
+The `SqlHoverConfig` documentation says fuzzy matching defaults to `false`, but
+`createHoverSource` defaults it to `true`.
+
+One side should be changed and a default-behavior test added.
+
+### Missing `@codemirror/lang-sql` peer dependency
+
+The exported `./dialects` entry requires `@codemirror/lang-sql` at runtime, but
+that package is only listed as a development dependency.
+
+It should be a peer dependency, potentially optional if consumers who never
+import `./dialects` should not be required to install it.
+
+### DuckDB syntax can be declared valid without an AST
+
+DuckDB statements beginning with `FROM` or containing `macro` are accepted
+without an AST. This prevents false syntax errors, but it also silently disables
+semantic linting, reliable hover, CTE analysis, and navigation for those
+statements.
+
+Validity and analyzability should be represented separately.
+
+### The same document is parsed repeatedly
+
+Linting, semantic linting, gutter analysis, completion, hover, and navigation
+often own separate analyzers. Semantic linting additionally parses a valid
+statement once in the structure analyzer and again for semantic checks.
+
+A shared document-analysis service should provide:
+
+- Statement boundaries
+- Original source
+- AST and tokens
+- Source locations
+- Scope information
+- Parse diagnostics
+- A state-sensitive cache identity
+
+### Parser bundle size
+
+The full local `node-sql-parser` installation occupied approximately 88 MB.
+Its documentation says that the browser build containing all database parsers
+is about 750 KB, versus about 150 KB for a specific database parser.
+
+Per-dialect imports and parser adapters are worth investigating:
+
+- [node-sql-parser documentation](https://www.npmjs.com/package/node-sql-parser)
+
+## Features worth adding
+
+### 1. Real cursor-scoped completion
+
+Support:
+
+- Nested and correlated subqueries
+- Derived tables
+- CTE `SELECT *` propagation
+- `UNION` output schemas
+- Correct catalog and schema search paths
+- Temporary tables and views created in preceding statements
+
+The open marimo report about completion with multiple DuckDB databases is
+direct product evidence:
+
+- [marimo #7499](https://github.com/marimo-team/marimo/issues/7499)
+
+### 2. A richer schema model
+
+The current `SQLNamespace` representation is useful for CodeMirror completion,
+but advanced semantic features need more information:
+
+- Catalog, schema, table, view, and function distinctions
+- Column type, nullability, description, and completion metadata
+- Primary and foreign keys
+- Relationships
+- Default catalog and schema
+- Search path
+- Asynchronous schema loading with caching and cancellation
+
+An optional migration helper can convert `SQLNamespace` into this richer model,
+but the new major should expose the richer model directly.
+
+### 3. Grammar-aware completion
+
+Add context-specific suggestions for:
+
+- Expected keywords and entity kinds at the cursor
+- Functions in expression positions
+- `INSERT` target columns
+- `UPDATE SET` columns
+- `GROUP BY` and `ORDER BY` aliases and ordinals
+- Dialect-correct quoting and casing
+
+### 4. Higher-value editor actions
+
+Potential features:
+
+- Join-condition suggestions based on foreign keys
+- Expand `*`
+- Qualify ambiguous columns
+- Generate table aliases
+- Function signature help
+- Document symbols and statement/CTE folding
+- Go-to-definition for physical tables through a host callback
+
+### 5. Formatting and lint code actions
+
+Support:
+
+- Format document
+- Format selection
+- Apply safe lint fixes
+- Configurable keyword case and indentation
+- Templating-aware regions for `{...}`, Jinja/dbt, and prepared placeholders
+
+### 6. Parameter awareness
+
+Recognize dialect-specific parameters:
+
+- `?`
+- `$1`
+- `:name`
+- `@name`
+
+The extension should avoid treating parameters as identifiers and could expose
+host callbacks for parameter metadata.
+
+This complements marimo's prepared-statement discussion:
+
+- [marimo #9445](https://github.com/marimo-team/marimo/issues/9445)
+
+## Repositories and projects to study
+
+### DTStack/dt-sql-parser and monaco-sql-languages
+
+- [DTStack/dt-sql-parser](https://github.com/DTStack/dt-sql-parser)
+- [DTStack/monaco-sql-languages](https://github.com/DTStack/monaco-sql-languages)
+
+These are the strongest direct inspiration for grammar-aware completion.
+`dt-sql-parser` returns expected keywords and entity kinds at the caret and
+associates tables with statement contexts.
+
+Its documentation also acknowledges limitations in nested subquery scenarios,
+which is useful design guidance for a scope-tree implementation.
+
+Limitations for this project's needs:
+
+- Its documented dialects focus on MySQL, Flink, Spark, Hive, PostgreSQL,
+  Trino, Impala, and generic SQL.
+- It does not directly solve DuckDB or BigQuery support.
+
+### SQLGlot
+
+- [tobymao/sqlglot](https://github.com/tobymao/sqlglot)
+
+SQLGlot is an excellent semantic reference implementation. It provides broad
+dialect coverage, qualification, type annotation, star expansion, AST
+transformations, and lineage.
+
+Because it is Python, it is best considered as:
+
+- A server-side `SqlParser` adapter for hosts such as marimo
+- A correctness oracle
+- A source of dialect and semantic test cases
+
+It is not a direct browser dependency.
+
+### DuckDB native autocomplete and DuckDB UI
+
+- [DuckDB autocomplete extension](https://duckdb.org/docs/stable/core_extensions/autocomplete.html)
+- [duckdb/duckdb-ui](https://github.com/duckdb/duckdb-ui)
+
+For DuckDB, the strongest completion source is the actual engine through
+`sql_auto_complete`. It knows attached catalogs and live schema state, which a
+static browser parser cannot infer.
+
+DuckDB UI is also useful architectural inspiration because its server API
+supports SQL tokenization and catalog-update events.
+
+A host integration could merge native DuckDB suggestions with local CodeMirror
+suggestions.
+
+### SQLFluff
+
+- [sqlfluff/sqlfluff](https://github.com/sqlfluff/sqlfluff)
+
+Study:
+
+- Dialect and templating architecture
+- Configurable lint rules
+- Automatic fixes
+- Behavior for incomplete and templated SQL
+- Broad dialect test coverage
+
+### sqruff
+
+- [quarylabs/sqruff](https://github.com/quarylabs/sqruff)
+
+sqruff is a fast Rust formatter and linter with a browser playground. It is
+worth evaluating for either a browser/WASM adapter or a host-side lint and
+formatting service.
+
+### sql-formatter
+
+- [sql-formatter-org/sql-formatter](https://github.com/sql-formatter-org/sql-formatter)
+
+This is a practical TypeScript option for document and range formatting. It
+supports many relevant dialects, configurable casing, and placeholders.
+
+Its documented limitations include stored procedures and alternate delimiter
+types, so integrations should retain escape hatches and avoid presenting it as
+a full parser.
+
+### Bytebase
+
+- [bytebase/bytebase](https://github.com/bytebase/bytebase)
+- [Bytebase SQL Editor documentation](https://docs.bytebase.com/sql-editor/run-queries)
+
+Bytebase is primarily product-level inspiration:
+
+- Inline schema details
+- SQL review rules
+- Visual `EXPLAIN`
+- Statement access modes
+- History and sharing
+- AI-assisted explanation and problem finding
+
+Not all of these belong in a CodeMirror package, but the package can provide the
+editor primitives and host callbacks needed to build them.
+
+### CodeMirror LSP client
+
+- [CodeMirror LSP client reference](https://codemirror.net/docs/ref/#lsp-client)
+
+Rather than implementing every IDE feature locally, the project should provide
+a documented composition path for SQL language servers. This gives hosts a
+route to:
+
+- Formatting
+- Document symbols
+- Signature help
+- Code actions
+- Server-backed completion and diagnostics
+
+## Recommended execution order
+
+### Batch 1: Correctness and security release
+
+1. Escape default hover content.
+2. Fix BigQuery dialect construction.
+3. Fix `delay: 0`.
+4. Resolve the fuzzy-search default mismatch.
+5. Add the missing peer dependency.
+6. Add gutter generation and stale-state checks.
+7. Add regression tests for each issue.
+
+### Batch 2: Analysis-core refactor
+
+Create one shared analysis result containing:
+
+- Original source
+- Statement boundaries
+- AST
+- Tokens and locations
+- Query scopes
+- Parse diagnostics
+- Parser and dialect cache identity
+
+Then:
+
+1. Replace the manual statement splitter where possible.
+2. Build a cursor-addressable scope tree.
+3. Share analysis across all editor features.
+4. Eliminate comment-stripped re-parsing and duplicate parsing.
+
+### Batch 3: Feature release
+
+1. Derived-table and CTE output propagation.
+2. Multi-catalog and search-path completion.
+3. Async rich schema model.
+4. Formatting hooks.
+5. LSP integration hooks.
+6. Native-engine completion adapters, beginning with DuckDB.
+
+## Verification performed
+
+The repository was verified with:
+
+```bash
+pnpm test --run
+pnpm run typecheck
+pnpm exec oxlint
+```
+
+Results:
+
+- 21 test files passed.
+- 588 tests passed.
+- 1 expected failure remained.
+- Statement coverage was 93.54%.
+- TypeScript typechecking passed.
+- oxlint reported no warnings or errors.
+
+The test suite is broad, but it should add adversarial coverage for:
+
+- Dialect changes with unchanged document text
+- Asynchronous analysis races
+- Nested query scopes
+- Hostile tooltip metadata
+- Dollar-quoted and bracket-quoted semicolons
+- Procedural statement bodies
+- Comment-adjacent tokens
+- Diagnostic locations when names also appear in strings and comments
+
+## Architectural direction
+
+The repository should make one major architectural shift: stop letting each
+editor feature independently parse and interpret SQL. Instead, it should build
+a shared SQL analysis platform and make linting, completion, hover, navigation,
+and gutter rendering thin consumers of it.
+
+The project is currently a collection of capable CodeMirror extensions. To
+become an excellent SQL editor foundation, it should become a small language
+service.
+
+### Target architecture
+
+```mermaid
+flowchart TD
+    CM["CodeMirror document + cursor"] --> COORD["Analysis coordinator"]
+    DIALECT["Dialect definition"] --> COORD
+    SCHEMA["Async schema provider"] --> COORD
+
+    COORD --> SNAP["Immutable AnalysisSnapshot"]
+
+    PARSER["Parser backend"] --> SNAP
+    SNAP --> TOKENS["Statements + tokens + locations"]
+    SNAP --> SCOPES["Scope graph"]
+    SNAP --> SYMBOLS["Symbols + references"]
+    SNAP --> TYPES["Resolved tables + columns + types"]
+
+    SNAP --> LINT["Diagnostics"]
+    SNAP --> COMPLETE["Completion"]
+    SNAP --> HOVER["Hover"]
+    SNAP --> NAV["Definition / references / rename"]
+    SNAP --> STRUCTURE["Gutter / folding / symbols"]
+    SNAP --> ACTIONS["Formatting / code actions"]
+
+    NATIVE["Native engine or LSP provider"] --> COMPLETE
+    NATIVE --> LINT
+    NATIVE --> ACTIONS
+```
+
+### 1. Introduce a single immutable analysis snapshot
+
+This is the most important refactor.
+
+Every document version should produce one `AnalysisSnapshot`:
+
+```ts
+interface AnalysisSnapshot {
+  documentVersion: number;
+  dialectId: string;
+  schemaVersion?: string;
+
+  statements: SqlStatementNode[];
+  tokens: SqlToken[];
+  diagnostics: SqlDiagnostic[];
+  scopeGraph: SqlScopeGraph;
+  symbols: SqlSymbolTable;
+
+  ast?: unknown;
+  capabilities: AnalysisCapabilities;
+}
+```
+
+Each analyzed statement should retain:
+
+- Original source text
+- Absolute document range
+- Tokens and exact source locations
+- Parsed AST
+- Parse errors
+- Root scope
+- Statement type
+- Whether the result is complete, recovered, or opaque
+
+This would eliminate:
+
+- Duplicate parsing
+- Comment-stripped re-parsing
+- Text-search diagnostic positioning
+- Inconsistent interpretations between features
+- Caches keyed only by SQL text
+
+The current `SqlStructureAnalyzer`, `QueryContextAnalyzer`, and semantic AST
+traversal should gradually collapse into this service.
+
+### 2. Build a real scope graph
+
+The semantic model should represent SQL lexical and relational scopes
+explicitly rather than flattening them into one query context:
+
+```ts
+interface SqlScope {
+  id: string;
+  kind: "statement" | "select" | "cte" | "subquery" | "dml";
+  range: SqlRange;
+  parent?: string;
+
+  sources: SqlRelation[];
+  columns: SqlColumnBinding[];
+  aliases: SqlSymbol[];
+  ctes: SqlSymbol[];
+  children: string[];
+}
+```
+
+A scope graph unlocks:
+
+- Correct completion inside nested subqueries
+- Correlated-reference handling
+- Alias shadowing
+- Derived-table columns
+- CTE output propagation
+- Reliable rename and references
+- Proper ambiguity diagnostics
+- `UNION` output schemas
+- Completion based on the cursor's exact scope
+
+This semantic intermediate representation should be independent of
+`node-sql-parser` AST shapes. Parser adapters should translate their ASTs into
+the common model. This prevents a parser replacement from requiring every
+editor feature to be rewritten.
+
+### 3. Make parser backends capability-based
+
+The current `SqlParser` interface implies that every parser can provide roughly
+the same behavior. In practice, some DuckDB fallbacks can only establish
+validity, while other dialects produce usable ASTs.
+
+Capabilities should be explicit:
+
+```ts
+interface SqlParserBackend {
+  readonly id: string;
+  readonly dialects: readonly string[];
+
+  analyze(
+    document: string,
+    options: AnalyzeOptions,
+    signal: AbortSignal,
+  ): Promise<ParserAnalysis>;
+}
+
+interface ParserAnalysis {
+  statements?: ParsedStatement[];
+  tokens?: SqlToken[];
+  diagnostics: SqlDiagnostic[];
+  ast?: unknown;
+
+  capabilities: {
+    exactLocations: boolean;
+    recovery: boolean;
+    scopes: boolean;
+    formatting: boolean;
+  };
+}
+```
+
+The architecture could then support:
+
+- `node-sql-parser` as the initial browser fallback
+- Dialect-specific ANTLR parsers where valuable
+- Native DuckDB completion and tokenization through a host
+- SQLGlot through a server-side marimo adapter
+- LSP-backed analysis
+- Future WASM parsers
+
+Features could degrade honestly based on capabilities instead of treating
+"valid but no AST" as fully analyzed.
+
+### 4. Make dialects first-class configurations
+
+A dialect should be more than CodeMirror highlighting and a
+`node-sql-parser` database name:
+
+```ts
+interface SqlDialectDefinition {
+  id: string;
+  codeMirrorDialect: SQLDialect;
+  parserDialect: string;
+
+  identifier: {
+    quote: string;
+    caseSensitivity: "sensitive" | "insensitive";
+    normalization: (name: string, quoted: boolean) => string;
+  };
+
+  parameters: ParameterStyle[];
+  statementRules: StatementBoundaryRules;
+  keywords: KeywordCatalog;
+  functions: FunctionCatalog;
+  formatterDialect?: string;
+}
+```
+
+A dialect registry should centralize:
+
+- Quoting
+- Identifier normalization
+- Keywords, types, and functions
+- Parameter syntax
+- Parser selection
+- Formatter selection
+- Statement-boundary behavior
+- Feature capability tests
+
+Every dialect should have a conformance corpus containing valid, invalid,
+incomplete, and multi-statement examples. BigQuery and DuckDB particularly need
+this.
+
+### 5. Replace `SQLNamespace` as the schema model
+
+For the next major version, replace `SQLNamespace` at the public service
+boundary rather than making it the permanent compatibility shape. Provide a
+small, optional conversion helper for migrations, but make the richer catalog
+graph the canonical API:
+
+```ts
+interface SqlCatalog {
+  version: string;
+  catalogs: SqlCatalogNode[];
+}
+
+interface SqlRelation {
+  id: string;
+  path: IdentifierPath;
+  kind: "table" | "view" | "cte" | "derived" | "function";
+  columns?: SqlColumn[];
+}
+
+interface SqlColumn {
+  name: string;
+  type?: SqlType;
+  nullable?: boolean;
+  description?: string;
+  primaryKey?: boolean;
+  references?: SqlColumnReference;
+}
+```
+
+This enables:
+
+- Join-condition suggestions
+- Type-aware function completion
+- Better hover content
+- `*` expansion
+- Type mismatch diagnostics
+- Search paths
+- Multiple catalogs containing identically named tables
+
+Schema acquisition should be asynchronous and versioned:
+
+```ts
+interface SqlSchemaProvider {
+  getCatalog(
+    request: CatalogRequest,
+    signal: AbortSignal,
+  ): Promise<SqlCatalog>;
+
+  search?(
+    query: SchemaSearchRequest,
+    signal: AbortSignal,
+  ): Promise<SqlCatalogItem[]>;
+}
+```
+
+Large databases should not require loading the entire catalog before the editor
+works.
+
+### 6. Add an analysis scheduler
+
+Parsing should not run directly from every CodeMirror plugin. A scheduler
+should provide:
+
+- Document-version tracking
+- Cancellation through `AbortSignal`
+- In-flight request deduplication
+- Stale-result rejection
+- Debouncing by workload
+- LRU analysis caching
+- Optional Web Worker execution
+- Performance instrumentation
+
+Suggested behavior:
+
+- Tokenization and statement boundaries: immediate
+- Local completion scope: low latency
+- Syntax diagnostics: debounced
+- Semantic diagnostics: more heavily debounced
+- Remote schema and native completion: cancellable
+- Formatting: explicit only
+
+For large SQL documents, worker execution will matter more than
+micro-optimizing individual traversals.
+
+### 7. Separate language intelligence from CodeMirror
+
+The core should accept plain text, positions, dialect, and schema. It should not
+require `EditorState`:
+
+```ts
+const snapshot = await languageService.analyze({
+  text,
+  version,
+  dialect,
+  schema,
+  signal,
+});
+
+const completions = languageService.complete(snapshot, position);
+const hover = languageService.hover(snapshot, position);
+```
+
+`src/codemirror/*` should adapt these results into CodeMirror extensions.
+
+Benefits:
+
+- Core behavior can be tested without DOM or CodeMirror fixtures.
+- Monaco, textarea, CLI, and backend use become possible.
+- Parser behavior no longer depends implicitly on arbitrary `EditorState`.
+- Browser tests can focus on integration instead of semantic correctness.
+
+### 8. Compose local, native-engine, and LSP providers
+
+The package should not try to outperform a live database at understanding its
+own dialect and catalog.
+
+Support layered providers:
+
+1. Return local snapshot results immediately.
+2. Request native engine or LSP results asynchronously.
+3. Merge and deduplicate results.
+4. Prefer authoritative results when available.
+
+For DuckDB:
+
+- Local completion provides immediate keywords and obvious aliases.
+- `sql_auto_complete` provides authoritative catalog-aware suggestions.
+- Catalog-change events invalidate schema caches.
+
+For marimo:
+
+- A SQLGlot-backed service could provide broader dialect parsing and semantic
+  analysis.
+- The browser library should remain functional without a backend.
+
+### 9. Modularize packaging after the core refactor
+
+Avoid one mandatory package that ships every parser, dialect catalog, formatter,
+and integration.
+
+A possible package or subpath-export structure is:
+
+```text
+@marimo-team/codemirror-sql
+  /core
+  /codemirror
+  /dialects
+  /parsers/node-sql-parser
+  /providers/lsp
+  /providers/duckdb
+  /formatters/sql-formatter
+```
+
+Goals:
+
+- Core completion users do not pay for semantic linting.
+- DuckDB users do not bundle every `node-sql-parser` dialect.
+- Formatter and LSP dependencies remain optional.
+- Tree-shaking does not depend on dynamic-import heuristics.
+
+### What not to do
+
+Avoid:
+
+- Replacing `node-sql-parser` before defining the common semantic model. That
+  changes the dependency without fixing the architecture.
+- Adding more regular expressions to repair nested scopes and statement
+  boundaries.
+- Expanding `QueryContext` into an ever-larger flat structure.
+- Making `SQLNamespace` carry every future semantic concern.
+- Letting each feature accept independently configured parsers and analyzers
+  indefinitely.
+- Building formatting, lint rules, and LSP behavior directly into CodeMirror
+  plugins.
+
+### Practical overhaul plan
+
+#### Phase 1: Stabilize
+
+Fix the security and correctness findings earlier in this document.
+
+#### Phase 2: Build the new core behind a new-major entry point
+
+Add:
+
+```text
+src/core/analysis-snapshot.ts
+src/core/language-service.ts
+src/core/scope-graph.ts
+src/core/schema-model.ts
+src/core/dialect.ts
+src/core/scheduler.ts
+src/parsers/node-sql-parser-adapter.ts
+```
+
+Reuse existing implementation details only when they satisfy the new contracts.
+Do not expose the old analyzer types through the new entry point.
+
+#### Phase 3: Replace features with vertical slices
+
+Recommended order:
+
+1. Gutter and statement selection
+2. Syntax diagnostics
+3. Completion
+4. Hover
+5. Navigation
+6. Semantic diagnostics
+
+Remove `SqlStructureAnalyzer`, `QueryContextAnalyzer`, and the old feature
+configuration surface before the new major release. The new implementation
+does not need to coexist with them in the published API.
+
+#### Phase 4: Add richer backends and features
+
+- DuckDB native provider
+- SQLGlot server adapter
+- LSP provider
+- Formatter provider
+- Rich schema and relationship completion
+
+The architectural north star is:
+
+> One document version, one semantic interpretation, many editor features.
+
+## Independent design review and consolidated direction
+
+This section records a second-pass review of the findings and architecture
+above. Three independent reviews were performed with different priorities:
+
+1. Language-tooling architecture, correctness, concurrency, and performance
+2. Source-level comparison with the upstream projects named in this report
+3. The way marimo currently consumes this package in a real application
+
+The original architectural diagnosis survives review: this project should grow
+from a collection of CodeMirror features into a shared SQL language service.
+However, the reviewers agreed that the proposed single, eager
+`AnalysisSnapshot` is the wrong implementation boundary. Data at different
+levels has different dependencies, latency, authority, and invalidation rules.
+
+The revised north star is:
+
+> One versioned document and context model, reusable statement-level analysis,
+> explicit semantic scopes, and independently cancellable consumers and
+> authoritative providers.
+
+### Major-version assumption
+
+The remainder of this recommendation assumes the overhaul can ship as the next
+major version, with breaking API and behavior changes. Backward compatibility
+is not an architectural goal.
+
+That means the project should:
+
+- Replace the existing parser/analyzer/configuration API instead of wrapping it
+  indefinitely.
+- Remove obsolete public implementation classes from the new entry point.
+- Make rich catalog, dialect, validation, templating, and provider contracts
+  canonical from day one.
+- Choose secure renderers and conservative feature defaults even when this
+  changes existing behavior.
+- Change lint granularity and scheduling only through explicit new contracts.
+- Update marimo as the reference migration while the new API is still fluid.
+
+It should still ship a migration guide, codemod or conversion helpers where
+cheap, and integration tests for important consumers. Those protect users from
+undocumented or silent changes; they do not constrain the new architecture.
+
+### Consensus
+
+All three reviews converged on the following:
+
+- Reuse analysis across completion, hover, navigation, diagnostics, and gutter
+  features.
+- Keep parser-specific ASTs behind adapters. Public features should consume a
+  normalized syntax and semantic model.
+- Make ranges, source mapping, cancellation, stale-result rejection, and
+  configuration revisions foundational rather than later refinements.
+- Analyze the active statement first and reuse unchanged statement results.
+- Treat parsing, engine validation, semantic diagnostics, formatting, and
+  completion as distinct capabilities.
+- Use a richer, partially loaded catalog model as the public service contract.
+  An optional `SQLNamespace` conversion helper can ease migration without
+  shaping the new core.
+- Keep a high-level CodeMirror extension for ordinary consumers even if the
+  intelligence core is editor-independent.
+- Prove the new design against marimo before freezing it. Marimo already
+  exercises dynamic dialects, remote validation, interpolation, partial
+  catalogs, custom completion rendering, and many editors on one page.
+- Add correctness, latency, memory, bundle-size, and adversarial-input budgets.
+  Architecture without measurable budgets will not reliably produce a
+  performant editor.
+
+### Important corrections to the earlier research
+
+The source-level ecosystem review found several places where the earlier
+summary should be more precise.
+
+#### `node-sql-parser` has partial location support
+
+Current `node-sql-parser` supports `parseOptions.includeLocations`, and a number
+of AST productions expose `loc`. This repository does not currently enable that
+option. It should be the first experiment for improving diagnostic and
+definition ranges before replacing the parser.
+
+The support is not universal, so a single `exactLocations: boolean` capability
+would still be misleading. Track capabilities such as statement, token, and
+identifier locations separately, and record the quality of each result.
+
+Sources:
+
+- [node-sql-parser parser options and types](https://github.com/taozhi8833998/node-sql-parser/blob/c1be96494794abadb26f3d5d99ddccb942de45a4/types.d.ts)
+- [location helper](https://github.com/taozhi8833998/node-sql-parser/blob/c1be96494794abadb26f3d5d99ddccb942de45a4/pegjs/common/initializer/functions.pegjs)
+- [BigQuery grammar location usage](https://github.com/taozhi8833998/node-sql-parser/blob/c1be96494794abadb26f3d5d99ddccb942de45a4/pegjs/bigquery.pegjs)
+
+#### DuckDB native completion is useful, but not scope-authoritative
+
+DuckDB's autocomplete extension is aware of the live catalog and produces typed
+candidates. Its column suggestion path currently scans columns across tables
+and views in all schemas; it does not itself constitute a complete model of
+which relations are visible in the current query block.
+
+Use DuckDB as a strong native candidate provider, then filter and rank its
+results with the local scope model. Do not assume all native suggestions are
+semantically visible at the cursor.
+
+Sources:
+
+- [DuckDB autocomplete core](https://github.com/duckdb/duckdb/blob/b8939cdd48940384cc08e16078738cc6b8834e09/src/parser/peg/autocomplete_core.cpp)
+- [DuckDB catalog provider](https://github.com/duckdb/duckdb/blob/b8939cdd48940384cc08e16078738cc6b8834e09/src/include/duckdb/parser/peg/autocomplete_catalog_provider.hpp)
+- [DuckDB catalog scans](https://github.com/duckdb/duckdb/blob/b8939cdd48940384cc08e16078738cc6b8834e09/extension/autocomplete/autocomplete_extension.cpp)
+
+#### The official CodeMirror LSP feature set is narrower than stated
+
+The official client currently includes completion, diagnostics, hover,
+signature help, definitions/declarations/implementations, references, rename,
+and formatting. It does not currently ship turnkey document-symbol or
+code-action modules.
+
+Use the official client instead of building a parallel protocol client, but
+describe unsupported features as custom extensions rather than built-ins. Its
+`WorkspaceMapping` and version-gating behavior are particularly relevant:
+asynchronous server results can be mapped through local changes or rejected
+when they overlap unsafe edits.
+
+Sources:
+
+- [CodeMirror LSP source modules](https://github.com/codemirror/lsp-client/tree/97bb453eb772a6a1dbd70ccd3b68fd2b89de28cd/src)
+- [CodeMirror LSP client and workspace mappings](https://github.com/codemirror/lsp-client/blob/97bb453eb772a6a1dbd70ccd3b68fd2b89de28cd/src/client.ts)
+- [Safe formatting application](https://github.com/codemirror/lsp-client/blob/97bb453eb772a6a1dbd70ccd3b68fd2b89de28cd/src/formatting.ts)
+
+LSP Markdown/HTML must also be sanitized. A remote language server is another
+untrusted rendering boundary.
+
+#### `sqruff` deserves a real backend evaluation
+
+`sqruff` now has a direct WASM package, LSP crate, semantic tokens, formatting,
+diagnostics, lineage, and SQL inference. Its LSP still uses full-document sync
+and does not provide completion or hover, so it is not a full language-service
+replacement. It is nevertheless a credible browser formatter, linter, and
+tokenizer backend to benchmark.
+
+Sources:
+
+- [sqruff WASM API](https://github.com/quarylabs/sqruff/blob/5a129c3486217195bb865c4789c6cbc1f35b6979/crates/lib-wasm/src/lib.rs)
+- [sqruff LSP](https://github.com/quarylabs/sqruff/blob/5a129c3486217195bb865c4789c6cbc1f35b6979/crates/lsp/src/lib.rs)
+- [sqruff lineage scopes](https://github.com/quarylabs/sqruff/blob/5a129c3486217195bb865c4789c6cbc1f35b6979/crates/lineage/src/scope.rs)
+
+### What to borrow from the researched repositories
+
+These recommendations come from source-level inspection, not only feature
+lists or READMEs.
+
+#### SQLGlot: the semantic reference model
+
+SQLGlot is the strongest reference for query semantics:
+
+- Explicit root, subquery, derived-table, CTE, union, and UDTF scopes
+- Physical tables and child scopes represented as distinct source types
+- Separate available sources from sources actually selected by a query
+- Sequential CTE construction, so a later CTE can see an earlier one
+- Explicit correlated-subquery and external-column handling
+- Scope-local traversal that does not flatten nested queries
+- Ordered treatment of `FROM`, joins, and lateral sources
+- Lazy derived caches with explicit invalidation
+
+Sources:
+
+- [SQLGlot scope model](https://github.com/tobymao/sqlglot/blob/85e0b7c89f3009fe4fbde381df30a1931a975fb4/sqlglot/optimizer/scope.py)
+- [Qualification pipeline](https://github.com/tobymao/sqlglot/blob/85e0b7c89f3009fe4fbde381df30a1931a975fb4/sqlglot/optimizer/qualify.py)
+- [Schema resolution](https://github.com/tobymao/sqlglot/blob/85e0b7c89f3009fe4fbde381df30a1931a975fb4/sqlglot/schema.py)
+
+SQLGlot's qualification and type annotation can mutate and canonicalize the AST
+and carry non-trivial overhead. It is an excellent correctness oracle or server
+backend, but should not automatically become the per-keystroke browser hot
+path.
+
+#### DTStack: minimize completion work to the active statement
+
+DTStack parses enough of the document to locate a small region around the
+caret, then performs the expensive `antlr4-c3` completion analysis on that
+fragment. It also separates grammar candidates such as “table” or “column”
+from the host's concrete catalog candidates.
+
+Source:
+
+- [DTStack completion flow](https://github.com/DTStack/dt-sql-parser/blob/1e853da4eac6ba8afd31da2243f3bf4802d0b9a5/src/parser/common/basicSQL.ts)
+
+Do not copy its mutable “last input” cache, repeat parses, scope-depth
+accessibility heuristic, simple fallback statement splitter, or generated-code
+package size without careful measurement.
+
+#### SQLFluff: dual coordinates for templated SQL
+
+SQLFluff models the original source and rendered SQL separately, maps them with
+explicit slices, and carries immutable position markers in both coordinate
+systems. That is the right conceptual foundation for marimo `{...}`
+expressions, Jinja/dbt templates, and safe formatting or quick fixes.
+
+Sources:
+
+- [SQLFluff templated file model](https://github.com/sqlfluff/sqlfluff/blob/dcb198ce3d69ddb501a727f10f58a983336fd4ca/src/sqlfluff/core/templaters/base.py)
+- [SQLFluff position markers](https://github.com/sqlfluff/sqlfluff/blob/dcb198ce3d69ddb501a727f10f58a983336fd4ca/src/sqlfluff/core/parser/markers.py)
+- [SQLFluff parse context and resource budgets](https://github.com/sqlfluff/sqlfluff/blob/dcb198ce3d69ddb501a727f10f58a983336fd4ca/src/sqlfluff/core/parser/context.py)
+
+Also borrow its hard parse-depth and node budgets. SQLFluff itself is too
+heavyweight for the browser hot path.
+
+#### DuckDB: typed completion needs and catalog-provider boundaries
+
+DuckDB's grammar produces typed needs such as keyword, relation, column,
+function, and type. A replaceable catalog provider supplies the actual objects.
+Results preserve replacement positions, semantic types, scores, and insertion
+suffixes.
+
+The normalized completion model in this project should similarly retain:
+
+- Exact replacement edit
+- Snippet or insertion suffix
+- Candidate kind
+- Provider provenance
+- Provider and local scores
+- Confidence/completeness
+- Quoting decision
+
+Reducing provider output to a label discards information required for powerful
+and deterministic composition.
+
+### Marimo consumer findings
+
+The local marimo checkout is currently pinned to `^0.2.8`. Its integration
+shows what a serious consumer already needs from this library.
+
+Marimo currently combines three intelligence paths:
+
+1. `@codemirror/lang-sql` highlighting, schema completion, and keyword
+   completion
+2. This package's lint, gutter, and hover extensions
+3. Backend parsing and `EXPLAIN` validation through the marimo kernel
+
+It also supplies a separate completion source for Python expressions inside SQL
+`{...}` regions, dynamically changes dialect and connection context, mixes
+notebook-local tables with external catalogs, and can mount many SQL editors in
+one notebook.
+
+This is direct evidence for a coordinator/provider design: marimo has already
+built an informal one around the current package.
+
+#### Critical `0.2.8` to `0.3.0` migration hazard
+
+Marimo's `CustomSqlParser` overrides:
+
+- `validateSql()` to call backend validation
+- `parse()` to return unconditional success with no AST for its internal DuckDB
+  engine
+
+Version `0.2.8` linting calls `validateSql()` on the document. Version `0.3.0`
+per-statement linting goes through `SqlStructureAnalyzer`, which calls
+`parse()`. Upgrading marimo as-is can therefore silently disable its backend
+DuckDB syntax diagnostics: every DuckDB statement is reported as valid by the
+custom `parse()` implementation.
+
+This does not require preserving the old API, but it must become a marimo
+migration test and an explicit item in the breaking-change guide.
+Whole-document and per-statement validation are different provider
+capabilities; the new API should make the choice impossible to change
+implicitly.
+
+```ts
+interface SqlValidationProvider {
+  readonly granularity: "document" | "statement";
+  validate(
+    request: SqlValidationRequest,
+    signal: AbortSignal,
+  ): Promise<readonly SqlDiagnostic[]>;
+}
+```
+
+Marimo's debounce also clears the preceding timer without resolving the Promise
+created for the preceding validation. Rapid calls can remain pending forever.
+Per-statement parallelism would make this worse. Cancellation should be a
+library contract, every request must settle, and debounce state must belong to
+an editor session rather than a shared parser.
+
+#### First-class embedded and templated regions
+
+Marimo commonly edits SQL such as:
+
+```sql
+SELECT * FROM {df}
+WHERE price < {price_threshold.value}
+```
+
+`NodeSqlParser.ignoreBrackets` currently rewrites braces for parsing while a
+separate completion source handles Python variables. The language service
+should instead understand embedded regions:
+
+```ts
+interface SqlEmbeddedRegion {
+  range: SqlRange;
+  language?: string;
+  kind: "expression" | "parameter" | "template";
+}
+```
+
+Adapters can receive a length- and newline-preserving masked document, together
+with an explicit source map. Diagnostics, scopes, statements, formatting edits,
+and navigation must map back to the original document exactly.
+
+#### Partial catalogs and dynamic connection context
+
+Marimo distinguishes unloaded, loading, complete, and failed schema branches.
+It also has nested child schemas, local ephemeral relations, tables, views,
+columns, primary keys, indexes, types, samples, and host-specific metadata.
+
+A missing catalog child cannot mean both “empty” and “not fetched.” The
+normalized catalog layer should support:
+
+- Stable entity identities
+- Explicit load states
+- Lazy path resolution and search
+- Pagination
+- Push invalidation/subscriptions
+- Local and remote precedence
+- Connection, session, search-path, and catalog revision keys
+- Opaque host metadata for custom UI rendering
+
+The same document text can be reinterpreted when marimo switches its engine,
+dialect, connection, schema, formatter, or validation backend. Every relevant
+context change must invalidate the layers that depend on it, even when there is
+no CodeMirror `docChanged` transaction.
+
+#### Preserve host extensibility
+
+Marimo does not use the package's new completion source wholesale; it combines
+schema, keyword, and Python-expression completion. A future high-level
+extension must support composition with external completion sources and custom
+renderers.
+
+Marimo also reads `BigQueryDialect.spec.identifierQuotes` outside the editor to
+format datasource queries. Stable dialect APIs should expose helpers such as:
+
+```ts
+dialect.quoteIdentifier(name);
+dialect.quotePath(parts);
+dialect.normalizeIdentifier(name, quoted);
+```
+
+Consumers should not need to inspect CodeMirror's internal dialect spec.
+
+Finally, marimo assigns the package's string tooltip renderer to `innerHTML`.
+The new major should replace this with a safe DOM-returning renderer. If a
+trusted HTML escape hatch exists, it should be separately named, opt-in, and
+documented as unsafe for untrusted metadata.
+
+### Revised architecture
+
+#### Replace the eager snapshot with layered artifacts
+
+Use a convenient snapshot facade if it improves the public API, but keep the
+internal cache and scheduling model layered:
+
+```text
+Document revision
+  └─ Embedded-region map
+      └─ Lexical tokens and statement index
+          └─ Parse artifacts per statement
+              └─ Query blocks, relations, and visibility graph
+                  └─ Catalog resolution at a catalog/session epoch
+                      └─ Feature results per cursor, request, and provider
+```
+
+Examples of independent invalidation:
+
+- Moving the cursor should not rebuild scopes.
+- Refreshing a catalog should not reparse SQL.
+- Changing a renderer should not invalidate semantic analysis.
+- Editing one statement should reuse unaffected statement artifacts.
+- A remote diagnostic should not block local completion.
+- Changing dialect lexical rules may invalidate statement boundaries, while a
+  schema update should invalidate only resolution and dependent results.
+
+The public slogan “one semantic interpretation” should not imply that a local
+partial parser, native engine, LSP, and loading schema always agree. The harder
+and more useful invariant is:
+
+> Every displayed result identifies the exact document/context revision,
+> provider, completeness, and interpretation that produced it; conflicts are
+> resolved by an explicit feature-specific policy.
+
+#### Make statement-level reuse the first performance milestone
+
+Do not promise true incremental parsing while the parser backend reparses whole
+strings. The practical and honest first target is incremental document analysis
+through statement reuse:
+
+- Maintain a dialect-aware statement index.
+- Map unchanged ranges through CodeMirror change sets.
+- Parse only changed statements.
+- Prioritize the active statement, then visible statements.
+- Run full-document background analysis only when a feature requires it.
+- Cache in-flight Promises so simultaneous features share the same work.
+- Bound caches by item count and estimated retained size.
+- Deprioritize or pause expensive work for hidden and unfocused editors.
+
+A `StatementBoundaryProvider` and conformance corpus are required. Neither a
+generic CodeMirror tree nor a failing full parser is authoritative for all
+dialects and procedural blocks.
+
+#### Model visibility, not only lexical parent scopes
+
+A parent/child scope tree is insufficient for SQL. The semantic IR should model:
+
+- Query blocks and set operations
+- Input relations and derived output relations
+- CTE declaration order and recursive visibility
+- Correlation and `LATERAL` edges
+- Clause-specific alias visibility
+- Qualified and unqualified references
+- Output column shapes, including wildcard and unknown shapes
+- Definition/reference ranges and provenance
+- Explicit partial, recovered, opaque, and failed states
+
+For example, select-list aliases may be visible in `ORDER BY` but not `WHERE`,
+depending on dialect. A typed visibility graph can express this; a simple
+lexical parent link cannot.
+
+Prototype the IR against at least two materially different parsers or
+conformance corpora before freezing it, so `node-sql-parser` limitations do not
+become permanent neutral interfaces.
+
+#### Separate providers by concern
+
+At minimum, define separate contracts for:
+
+- Statement boundaries
+- Parsing
+- Validation
+- Catalog resolution
+- Completion
+- Hover and documentation
+- Navigation
+- Formatting
+- LSP/native augmentation
+
+Capabilities and result quality should be granular and attached to artifacts,
+not only static booleans on a backend. “Parse success,” “valid SQL,” “semantic
+model available,” and “engine accepted the query” are different states.
+
+Provider arbitration must be feature-specific:
+
+- Completion can merge and deterministically rerank candidates.
+- Hover can choose one source or display attributed sections.
+- Diagnostics require authority and deduplication policies; blind unions create
+  contradictory errors.
+- Formatting should normally have one selected provider.
+- Definitions need precedence, confidence, and provenance.
+
+Remote and native providers should augment a fast local baseline and never
+silently overwrite unrelated evidence.
+
+#### Make source coordinates and request identity non-negotiable
+
+Every range should be:
+
+- Absolute in the original document
+- Measured in UTF-16 code units, matching CodeMirror
+- Half-open: `[from, to)`
+- Preserved through comments, interpolation, and other preprocessing
+
+Every asynchronous request and result should identify:
+
+- Editor/session identity
+- Monotonic document revision
+- Dialect and parser configuration identity
+- Template/source-map revision
+- Connection and session identity when relevant
+- Catalog/search-path revision when relevant
+- Provider identity and authority
+
+No result applies unless its complete dependency key is current.
+
+#### Keep mutable state out of shared providers
+
+`NodeSqlParser` currently stores `offsetRecord` on the parser instance. Two
+concurrent calls can overwrite one another's transformation mapping. Move all
+transformation and source-map state into the individual parse request.
+
+Focus, visibility, debounce timers, request generations, and cancellation
+controllers belong to a per-editor analysis session, not a parser or provider
+that might be shared across many editors.
+
+All sessions need `dispose()`:
+
+- Abort remote requests.
+- Prevent dispatch into destroyed views.
+- Release bounded caches and workers.
+- Unsubscribe from catalog changes.
+- Settle or reject pending requests.
+
+### Proposed stable API shape
+
+The library should provide both a composable core and a convenient CodeMirror
+adapter:
+
+```ts
+const service = createSqlLanguageService({
+  dialects: [duckdbDialect(), postgresDialect(), bigQueryDialect()],
+  parser: nodeSqlParserProvider(),
+  catalog: catalogProvider,
+  validators: [engineValidationProvider],
+  template: braceExpressionTemplate(),
+});
+
+const extensions = sqlEditor({
+  service,
+  context: (state) => getSqlDocumentContext(state),
+  features: {
+    completion: true,
+    hover: true,
+    diagnostics: true,
+    gutter: true,
+    navigation: true,
+  },
+  externalCompletionSources: [pythonExpressionCompletion],
+  scheduling: {
+    remoteDiagnosticsDelay: 300,
+    analyzeWhenUnfocused: false,
+  },
+  renderers: {
+    completionInfo: customCompletionRenderer,
+    hover: customHoverRenderer,
+  },
+});
+```
+
+The CodeMirror adapter should expose facets or state effects for context,
+catalog, dialect, scheduling priority, and theme changes. Parser providers
+should not receive arbitrary `EditorState`; the adapter should extract explicit
+context values.
+
+The new major should not expose legacy `SqlParser`, `NodeSqlParser`,
+`SqlStructureAnalyzer`, or `QueryContextAnalyzer` classes. Public subclassing of
+stateful implementation classes is one reason marimo's validation behavior can
+diverge between `parse()` and `validateSql()`.
+
+Replace subclassing with narrow provider interfaces. Keep raw parser adapters
+internal or explicitly unstable. A development-only comparison harness remains
+useful for validating the rewrite, but it does not need to become a public
+compatibility layer.
+
+### Non-negotiable invariants
+
+1. Every range is an absolute UTF-16 half-open range in original-document
+   coordinates.
+2. No asynchronous result applies unless its complete revision key is current.
+3. Every request settles, rejects, or is observably aborted.
+4. Parser transformation state is request-local.
+5. Analysis failure is distinct from SQL invalidity.
+6. Schema absence or incompleteness cannot produce a definite
+   unknown-object diagnostic.
+7. Untrusted metadata is never interpreted as HTML by default.
+8. A statement is parsed at most once for a given content, parser/configuration
+   identity, template mapping, and environment fingerprint; concurrent
+   consumers share in-flight work.
+9. Every resolved symbol has a range, role, provenance, and completeness state.
+10. Provider conflicts are resolved by a documented policy for each feature.
+
+### Revised execution plan
+
+#### Phase 0: stabilize and measure
+
+- Fix the confirmed security and correctness bugs earlier in this report.
+- Enable and assess `node-sql-parser` location support.
+- Make parser preprocessing and offset state request-local.
+- Reject stale results in every asynchronous feature.
+- Ensure cancellation settles all requests.
+- Add dialect/configuration revisions to current caches.
+- Add a marimo migration test proving the new document-level validation
+  provider executes and stale requests are cancelled.
+- Measure current latency, memory, cold-load time, and bundle size.
+
+#### Phase 1: analysis session and statement index
+
+- Add one disposable analysis session per editor/context.
+- Define a dialect-aware statement-boundary provider.
+- Map unchanged statements through CodeMirror changes.
+- Cache both in-flight and completed parse artifacts.
+- Prioritize active and visible statements.
+- Add bounded caches and degradation policies.
+- Reuse the current structure analyzer only as temporary scaffolding if useful;
+  do not retain its API in the new core.
+- Compare old and new lint/gutter results in development to discover
+  regressions, without requiring behavioral parity when the old behavior is
+  wrong.
+
+#### Phase 2: ranges, source maps, and parser artifacts
+
+- Define normalized parse artifacts with granular completeness and location
+  capabilities.
+- Model embedded regions and original/rendered source coordinates.
+- Implement the existing parser adapter and at least one alternate/test
+  adapter.
+- Remove downstream text searches for locations.
+- Fully migrate statement metadata and syntax diagnostics.
+
+#### Phase 3: a minimal semantic vertical slice
+
+Start with well-tested `SELECT` behavior:
+
+- Query blocks
+- CTEs
+- Base and derived relations
+- Aliases
+- Column references
+- Output shapes
+- Typed visibility edges
+- Partial and unknown states
+
+Migrate completion and hover before aggressive semantic diagnostics. These
+features benefit from partial knowledge; diagnostics should only report an
+error when the model can prove it with complete relevant scope and schema
+information.
+
+#### Phase 4: catalogs and provider composition
+
+- Add lazy catalog resolution, stable identities, load states, pagination, and
+  invalidation.
+- Define per-feature provider authority and merge policies.
+- Integrate marimo backend validation through the explicit validation contract.
+- Prototype DuckDB-native candidate augmentation.
+- Integrate the official CodeMirror LSP client where a server is available.
+- Benchmark `sqruff` WASM for formatting, diagnostics, and tokenization.
+
+#### Phase 5: advanced semantics and optional distribution changes
+
+Only after correctness and profiling:
+
+- Types and function signatures
+- `UNION`, recursive CTEs, `LATERAL`, and DML outputs
+- Cross-statement state such as temporary tables and search-path changes
+- Worker execution where benchmarks justify it
+- Formatter and additional LSP adapters
+- Optional subpath or package splits after bundle analysis and API stabilization
+
+Workers deserve an explicit prototype because a synchronous PEG or ANTLR parse
+cannot be interrupted by `AbortSignal` on the main thread. They are not an
+automatic win: startup, cloning, duplicate caches, and bundling can make small
+documents slower. Apply hard input-size, time, parse-depth, and node-count
+budgets regardless.
+
+### Performance and correctness gates
+
+Track at least:
+
+- Keystroke-to-local-completion latency
+- Active-statement parse latency
+- Large-document edit latency
+- Time to first useful result after cold parser load
+- Memory after long edit sequences and many editor instances
+- Catalog search over large and partially loaded schemas
+- Main bundle and parser/dialect chunk sizes
+- Stale-result and cancellation behavior under rapid edits
+
+Add:
+
+- Property and fuzz tests for statement boundaries and preprocessing
+- Nested, correlated, CTE, lateral, and set-operation scope goldens
+- Differential tests against SQLGlot and native DuckDB where appropriate
+- Adversarial inputs that must not hang, exhaust memory, or crash a worker
+- Range invariants across Unicode, comments, multiline strings, and templates
+- A dialect conformance matrix instead of a blanket “supported” label
+
+These gates should decide whether workers, parser replacements, and packaging
+changes ship. They should not be retrofitted after those decisions.
+
+### Consolidated recommendation
+
+Do not replace `node-sql-parser` with DTStack or another parser as the first
+move. First:
+
+1. Fix the existing security, range, cache, race, and dialect bugs.
+2. Enable and measure available parser locations.
+3. Build a disposable, revisioned analysis session with statement-level reuse.
+4. Define source-mapped templating and a SQLGlot-inspired visibility model.
+5. Separate document/statement validation from parsing.
+6. Add lazy catalogs and explicit provider authority.
+7. Migrate marimo as the reference consumer, using integration tests and
+   development comparisons to validate the new contracts.
+8. Evaluate DuckDB, LSP, SQLGlot, and `sqruff` as composable providers rather
+   than a single replacement stack.
+
+This sequence uses the major-version boundary to remove accidental APIs and
+incorrect behavioral coupling. It creates the architecture needed for a
+powerful SQL editor without committing too early to one parser, worker model,
+or package layout.
+
+### Proposed new-major release strategy
+
+Treat the next major as a replacement product surface rather than a gradual
+deprecation release:
+
+1. Freeze the current line to critical fixes only.
+2. Develop the new language service and CodeMirror adapter behind a separate
+   entry point or prerelease tag.
+3. Migrate marimo early and use it to exercise multi-editor performance,
+   dynamic connection context, templates, remote validation, and rich catalogs.
+4. Publish prereleases with a small number of design partners.
+5. Remove legacy exports before the release candidate.
+6. Publish benchmarks, a dialect capability matrix, and the migration guide
+   with the stable major.
+
+The migration guide should map old concepts to new ones, but the implementation
+should not contain permanent adapters unless they are trivial, isolated, and
+have no effect on the core design.

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,6 +1,11 @@
 [default]
 # Use typos:ignore-next-line to ignore the next line in the codebase
-extend-ignore-re = ["(#|//)\\s*typos:ignore-next-line\\n.*"]
+extend-ignore-re = [
+  "(#|//)\\s*typos:ignore-next-line\\n.*",
+  # Deliberately malformed SQL and identifiers in research reproductions
+  "\\busres\\b",
+  "\\bSELECTbad\\b",
+]
 
 [files]
 extend-exclude = [

--- a/demo/custom-renderers.ts
+++ b/demo/custom-renderers.ts
@@ -1,4 +1,5 @@
 import type { NamespaceTooltipData } from "../src/sql/hover.js";
+import { isArrayNamespace } from "../src/sql/namespace-utils.js";
 
 interface ColumnMetadata {
   type: string;
@@ -35,7 +36,11 @@ export type Schema = "users" | "posts" | "orders" | "customers" | "categories" |
 export const tableTooltipRenderer = (data: NamespaceTooltipData) => {
   // Show table name, columns, description, primary key, foreign key, index, unique, check, default, comment
   const table = data.item.path.join(".");
-  const columns = data.item.namespace?.[table] ?? [];
+  const namespace = data.item.namespace;
+  const columns =
+    namespace && isArrayNamespace(namespace)
+      ? namespace.map((column) => (typeof column === "string" ? column : column.label))
+      : [];
 
   // Enhanced table metadata (simulated for demo purposes)
   const tableMetadata = getTableMetadata(table);
@@ -146,7 +151,7 @@ export const tableTooltipRenderer = (data: NamespaceTooltipData) => {
 
 // Helper function to get enhanced table metadata
 function getTableMetadata(tableName: string): TableMetadata {
-  const metadata: Record<Schema, TableMetadata> = {
+  const metadata: Record<string, TableMetadata> = {
     users: {
       description: "User accounts and profile information",
       rowCount: "1,234",

--- a/demo/data.ts
+++ b/demo/data.ts
@@ -1,4 +1,4 @@
-import type { Schema } from "./custom-renderers";
+import type { Schema } from "./custom-renderers.js";
 
 // Default SQL content for the demo
 export const defaultSqlDoc = `-- Welcome to the SQL Editor Demo!

--- a/demo/index.ts
+++ b/demo/index.ts
@@ -8,6 +8,7 @@ import {
   defaultSqlHoverTheme,
   NodeSqlParser,
   QueryContextAnalyzer,
+  type SqlKeywordInfo,
   type SupportedDialects,
   sqlCompletion,
   sqlExtension,
@@ -63,7 +64,7 @@ const defaultKeymap = [
 ];
 
 // e.g. lazily load keyword docs
-const getKeywordDocs = async () => {
+const getKeywordDocs = async (): Promise<Record<string, SqlKeywordInfo>> => {
   const keywords = await import("@marimo-team/codemirror-sql/data/common-keywords.json");
   const duckdbKeywords = await import("@marimo-team/codemirror-sql/data/duckdb-keywords.json");
   return {

--- a/implementation.md
+++ b/implementation.md
@@ -1,0 +1,826 @@
+# SQL Language Service Overhaul: Implementation Plan
+
+Date: 2026-07-24
+
+## Objective
+
+Build the next major version of `@marimo-team/codemirror-sql` as a performant,
+robust, correct, and powerful SQL language service with a first-class
+CodeMirror adapter.
+
+This is a breaking overhaul. Compatibility with current implementation classes
+is not a design constraint. We will still publish a migration guide and use
+marimo as the reference consumer.
+
+Success means:
+
+- Correct, explicitly bounded dialect support
+- Predictable latency and bounded memory
+- Honest partial and unsupported results
+- Safety under malformed input, rapid edits, cancellation, and hostile metadata
+- A small, understandable public API
+- High confidence from independent forms of testing
+
+Before implementation, publish a vNext capability charter defining:
+
+- Initial dialects and constructs
+- Explicit non-goals and unsupported syntax
+- Browser, Node, bundler, and peer-dependency support
+- Latency, memory, and bundle envelopes
+- Which features require local, native, or remote providers
+
+## Engineering principles
+
+### Correctness before breadth
+
+Do not claim support until a construct passes its conformance corpus. Explicit
+partial results are better than confident incorrect results.
+
+### Simple before clever
+
+Prefer small modules, explicit data flow, pure transformations, and narrow
+interfaces. Optimize from profiles. Every abstraction must enforce an
+invariant, isolate a dependency, remove duplication, or improve testability.
+
+### Comments explain why
+
+Names, types, and structure should explain normal behavior. Comments should
+explain an invariant, external limitation, security boundary, performance
+tradeoff, or surprising dialect rule. If ordinary flow needs a long comment,
+first simplify the design. Public APIs and non-obvious algorithms still need
+useful documentation.
+
+### Types represent the state machine
+
+The goal is not just to compile. Revision identity, source coordinates,
+analysis completeness, catalog loading, cancellation, and provider provenance
+should be difficult to omit or combine incorrectly.
+
+### Tests provide different evidence
+
+Coverage, contracts, examples, goldens, browser tests, fuzzing, mutation
+testing, differential testing, and benchmarks find different failures. No one
+metric substitutes for the others.
+
+## Branch and delivery strategy
+
+Create `dev-refactor` as the next-major integration branch. Do not implement
+everything directly on it. Use short-lived, focused PR branches:
+
+```text
+main
+  └─ dev-refactor
+       ├─ refactor/analysis-session
+       ├─ refactor/source-mapping
+       ├─ refactor/statement-index
+       ├─ refactor/catalog-provider
+       └─ refactor/codemirror-adapter
+```
+
+Required practices:
+
+- Every PR into `dev-refactor` leaves it green and runnable.
+- Use a merge queue or serialize merges.
+- Open a continuous draft PR from `dev-refactor` to `main`.
+- Give the branch an owner, a target merge date, and explicit merge/delete
+  criteria.
+- Allow no direct commits.
+- Forward-merge `main` on a fixed cadence and document hotfix propagation.
+- Keep a continuously runnable demo and marimo integration fixture.
+- Build a canary artifact for every accepted integration commit; publish
+  prereleases only at selected checkpoints after canary gates pass.
+- Compare API, coverage, bundle, and performance against both `main` and the
+  previous `dev-refactor` commit.
+- Prefer a sequence of vertical slices to a large rewrite.
+
+The branch is an integration boundary, not permission to accumulate an
+unreviewable diff. If its lifetime or divergence becomes excessive, move vNext
+development onto `main` behind an unpublished entry point.
+
+Before branch protection is enabled, update CI triggers to include pushes and
+pull requests targeting `dev-refactor`; the current workflow targets only
+`main`.
+
+## Change sizing and review requirements
+
+Classify every PR before implementation.
+
+### Small
+
+Documentation, test data, mechanical renames, or a local fix with no public,
+semantic, concurrency, or performance effect. One normal review is sufficient.
+
+### Medium
+
+Any change to:
+
+- A public/provider interface
+- Parsing, source mapping, or semantics
+- Scheduling, caching, cancellation, or concurrency
+- Catalog resolution
+- Completion, diagnostics, hover, navigation, formatting, or gutter behavior
+- A dialect rule
+- More than one architectural layer
+
+Two independent adversarial reviews are required.
+
+Classification is fail-closed. Sensitive paths, public API diffs, dependency
+changes, concurrency modules, and cross-layer changes automatically make a PR
+medium or large. A maintainer must approve any downgrade to small.
+
+### Large
+
+A cross-cutting architecture change, new semantic subsystem, or new parser or
+remote/native provider. Split it into an ADR and multiple medium PRs. A large
+PR is a planning failure unless the change is generated or indivisible.
+
+## Phase 0: establish baselines
+
+Do this before changing production architecture.
+
+### Behavioral baseline
+
+- Capture public exports and generated declarations.
+- Record representative completion, hover, navigation, lint, and gutter output.
+- Add characterization tests for critical migration-risk behavior.
+- Put every confirmed issue from `SQL_EDITOR_RESEARCH.md` in an owned
+  traceability backlog. An unfixed case may use a commit-bound known-failure
+  fixture with an owner and expiry until its feature slice; the baseline suite
+  must not be permanently red.
+- Add a marimo fixture for document-level DuckDB validation, connection
+  changes, schema completion, many editors, and `{...}` expressions.
+- Record demo workflows in browser tests.
+
+Label characterization cases:
+
+```text
+preserve    intentional behavior
+replace     behavior intentionally changed in the new major
+bug         confirmed defect with the desired result documented
+unknown     needs a semantic or product decision
+```
+
+Characterization tests document behavior; they do not preserve known bugs.
+
+### Performance baseline
+
+Measure fixed document and catalog sizes:
+
+- Cold load and first parse
+- Active-statement edit/reparse
+- Completion and hover latency
+- Full-document diagnostics
+- Rapid-edit and stale-result behavior
+- Memory after long edit sequences
+- 1, 10, and 50 mounted editors
+- Bundle and parser chunk sizes
+
+Store JSON results and raw samples as CI artifacts. Establish budgets from
+measured baselines and product goals, not arbitrary percentages.
+
+### Quality baseline
+
+Record:
+
+- Line, statement, function, and branch coverage
+- Unsafe assertions and suppression directives
+- Public API surface
+- Bundle size and dependency inventory
+- Test runtime and flake rate
+
+Introduce ratchets from this baseline. Do not hide existing problems simply to
+make the first gate green.
+
+## Test strategy
+
+### Coverage policy
+
+Targets:
+
+| Metric | Repository | New or changed core code |
+| --- | ---: | ---: |
+| Lines | At least 95% | At least 95% per changed file |
+| Statements | At least 95% | At least 95% per changed file |
+| Functions | At least 95% | At least 95% per changed file |
+| Branches | 90%, ratcheting to 95% | At least 95% diff coverage |
+
+Branch coverage matters for failure, cancellation, partial-result, and dialect
+paths. Coverage exclusions are limited to generated data, type-only code,
+debug instrumentation, and true exhaustiveness guards. Each exclusion requires
+a reviewed reason.
+
+Coverage is a floor, not an objective. Do not add tests that execute lines
+without asserting semantics. Mutation testing must confirm that important
+assertions detect meaningful faults.
+
+Enforcement must define:
+
+- All production files as the denominator, including files not imported by
+  tests
+- Explicit checked-in include/exclude rules
+- Repository thresholds for lines, statements, functions, and branches
+- Changed executable lines and branches relative to the PR merge base,
+  including renamed files
+- Diff coverage for lines and branches; statements and functions are enforced
+  at the changed-file and risk-tier module level rather than inferred
+  unreliably from a textual diff
+- Per-module floors for revisions, ranges, source maps, cancellation, and
+  provider policy
+
+Add separate failing `test:coverage` and `coverage:diff` commands. Protect
+coverage configuration, exclusions, baselines, and generated-code rules with
+CODEOWNERS. Baseline reductions or exclusion growth require explicit approval.
+
+Apply strict changed-code gates immediately to vNext modules. The repository
+target applies to retained/new-major production code by release candidate; do
+not manufacture low-value tests for legacy modules scheduled for deletion.
+Named invariant tests and mutation evidence are required for critical logic.
+Defensive or platform-specific uncovered code needs a narrow reviewed waiver
+with an owner and expiry.
+
+### Unit tests
+
+Use focused, table-driven tests for:
+
+- Range and position primitives
+- Identifier normalization and quoting
+- Statement boundaries
+- Original/rendered source mapping
+- Cache identity and invalidation
+- Catalog load states and lookup
+- Scope and visibility rules
+- Provider authority, merge, and ranking policies
+- Completion replacement edits
+- Cancellation, disposal, and error normalization
+
+### Provider contract tests
+
+Every provider implementation must pass reusable contracts:
+
+- Ranges are absolute UTF-16 half-open ranges inside the document.
+- Every request settles, rejects, or is observably aborted.
+- Aborted or stale work cannot publish results.
+- Results identify revision, provider, authority, and completeness.
+- Incomplete catalogs cannot create definite unknown-object diagnostics.
+- Document validators are never invoked once per statement.
+- `dispose()` prevents callbacks and editor dispatch.
+- Provider errors degrade according to documented policy.
+
+### Golden semantic corpus
+
+Use structured, reviewed fixtures for:
+
+- Nested and correlated subqueries
+- CTE ordering, recursion, and shadowing
+- Derived relations and `LATERAL`
+- Set operations
+- Clause-specific alias visibility
+- Qualified, unqualified, and ambiguous references
+- Search paths and multiple catalogs
+- Quoted identifiers and case folding
+- Incomplete input at likely cursor positions
+- DML and templates/interpolation
+
+Each fixture names its dialect and expected capability. Prefer typed structured
+outputs to large parser-AST or DOM snapshots.
+
+### Snapshot tests
+
+Use snapshots only for stable, high-dimensional normalized results such as a
+scope graph or complete feature response. Prefer direct assertions for simple
+behavior. Never snapshot parser-specific ASTs, unstable ordering, incidental
+error details, or entire DOM trees. CI must not auto-update snapshots.
+
+### Property and fuzz tests
+
+Test invariants:
+
+- Statement ranges remain ordered, non-overlapping, and in bounds.
+- Template masking preserves length and newline positions.
+- Source-map conversion always yields valid ranges.
+- Arbitrary edit sequences never publish stale results.
+- Completion edits remain inside the document.
+- Identifier quote/normalize behavior round-trips where defined.
+- Caches stay bounded.
+- Arbitrary input terminates within resource budgets.
+
+Run a deterministic short suite on every PR and longer randomized campaigns
+nightly. Commit a minimal regression fixture and seed for every failure.
+
+Execute parser fuzz cases in disposable workers or processes. A normal Vitest
+timeout cannot interrupt synchronous code that blocks the event loop. The
+parent enforces wall-clock and memory limits and records the seed, input,
+dialect, dependency versions, and operation sequence. Distinguish crash,
+timeout, OOM, invalid range, unhandled rejection, and stale publication.
+
+### Differential tests
+
+Compare supported constructs with:
+
+- SQLGlot for scope and qualification
+- DuckDB for DuckDB parsing and selected catalog behavior
+- `node-sql-parser` location output while it is a backend
+- `sqruff` if used for formatting or linting
+
+Classify differences as `ours-bug`, `upstream-difference`,
+`dialect-ambiguity`, `unsupported`, or `intentional-policy`. Another tool is
+evidence, not automatically the oracle.
+
+### Integration tests
+
+Use deterministic fake providers and schedulers to test:
+
+- Edit → invalidate affected layers → publish current feature result
+- Dialect/connection changes without text edits
+- Catalog refresh without reparsing
+- Remote validation cancellation during rapid typing
+- Local/native completion composition
+- Disposal with work in flight
+- Provider timeout and worker crash recovery
+- Partial catalogs
+
+Use fake clocks; do not base correctness assertions on real time.
+
+Inject failures including malformed payloads, repeated callbacks, callback
+after abort/dispose, synchronous throws before Promise creation, rejection
+after abort, worker restart, catalog refresh storms, duplicate IDs,
+out-of-order results, and exceptions from consumer renderers.
+
+### Browser and end-to-end tests
+
+Vitest currently includes a Playwright browser project through the aggregate
+test configuration, but the documented `test:browser` script references the
+nonexistent `vitest.browser.config.ts`. Repair that script and give the browser
+project a named required CI step so configuration changes cannot silently stop
+running it.
+
+Cover:
+
+- Completion opening, filtering, refreshing, and applying the exact edit
+- Safe, attributed hover rendering
+- Diagnostic movement and removal after edits
+- Current-statement gutter and navigation
+- Dialect/connection changes without text edits
+- Stale slow-provider rejection
+- Keyboard and accessibility behavior
+
+Require Chromium on PRs. Run Firefox and WebKit nightly until sufficiently
+stable and fast. Capture traces and screenshots on failure, not as a broad
+pixel-snapshot suite.
+
+### Consumer and packaging tests
+
+Maintain a small marimo fixture here and a pinned cross-repository test in
+marimo. Cover dynamic context, document validation, many SQL cells, `{...}`
+regions, external completion composition, partial/nested catalogs, and custom
+renderers.
+
+Test a packed tarball rather than workspace source. For release candidates:
+
+- Install it in a minimal CodeMirror consumer.
+- Import every documented entry point.
+- Build with supported bundlers.
+- Run in a real browser and in the marimo fixture.
+- Verify ESM, declarations, source maps, peer dependencies, and optional
+  providers.
+- Verify core-only consumers do not bundle optional integrations.
+
+### Security tests
+
+Test hostile catalog metadata, LSP Markdown/HTML, deeply nested SQL, extremely
+long identifiers/statements, invalid/cyclic provider data, worker crashes, and
+pathological regular-expression input. CodeQL and dependency scanning remain
+required but are not substitutes for behavior tests.
+
+### Mutation testing
+
+Run mutation tests on ranges, semantics, scheduling, caching, and provider
+policy. Start nightly. Establish a baseline mutation score, narrowly classify
+equivalent mutations, and ratchet upward. High coverage with a weak mutation
+score blocks further work in that subsystem.
+
+Track mutation results per critical module and mutation class. Designated
+revision, range, source-map, cancellation, and security modules may have no
+surviving high-risk mutants. Equivalent-mutant exclusions require a reviewed
+reason and expiry.
+
+### Invariant traceability and suite integrity
+
+Maintain a checked-in invariant registry with stable ID, owner, failure mode,
+affected modules, required test layers, test references, and applicable
+performance/security budget. CI fails if an invariant loses all mapped tests.
+
+Fail CI on:
+
+- Zero discovered tests in an expected suite
+- Unexpected `.only`, skipped, or todo tests
+- Stale snapshots
+- Unhandled rejections
+- Leaked timers, handles, workers, listeners, or DOM nodes
+- Unexpected browser console errors
+- Missing fixture provenance
+
+Print test counts, duration, retry count, and first-attempt failures by category.
+Retry success must not silently erase a flake; quarantines require an owner and
+deadline.
+
+### Performance tests
+
+Report median, p95, worst observed time, and memory where measurable. Separate:
+
+- Pure core microbenchmarks
+- Edit-to-result scenario benchmarks
+- Browser/CodeMirror benchmarks
+- Bundle-size checks
+
+Exercise 1/10/100/1,000 statements, small/large/partial catalogs, cold/warm
+completion, 1/10/50 editors, rapid edits with delayed providers, and
+template-heavy documents.
+
+PR CI runs stable smoke benchmarks and fails only on meaningful regressions
+beyond agreed budgets. Full performance and leak tests run nightly on
+controlled runners. Store history to catch gradual degradation.
+
+For every blocking benchmark, define runner class, warmups, sample count,
+interleaved base/head execution, outlier policy, confidence method, minimum
+effect size, absolute ceiling, and an inconclusive result for excessive noise.
+Record hardware and runtime metadata. Use controlled runners for blocking
+latency and memory gates; hosted runners enforce only gross smoke ceilings and
+bundle size. Gate tail latency under load and event-loop blocking. Do not use
+“worst observed” as a statistical gate; use a defined percentile plus a hard
+timeout.
+
+Memory tests run in isolated processes with fixed edit/mount cycles and explicit
+GC where supported. Track heap, DOM/listener retention, worker lifecycle, cache
+size, process RSS, and retained-memory slope separately.
+
+## Type-safety standard
+
+The repo already enables `strict`, `noUncheckedIndexedAccess`, and
+`noUnusedLocals`. Keep these and evaluate:
+
+- `exactOptionalPropertyTypes`
+- `noImplicitOverride`
+- `noPropertyAccessFromIndexSignature`
+- `verbatimModuleSyntax`
+
+New-major rules:
+
+- No explicit `any`.
+- No double assertion such as `as unknown as T`.
+- No unchecked casts of parser, provider, JSON, or network data.
+- No `@ts-ignore`.
+- `@ts-expect-error` only in type tests, with the expected reason.
+- Use `unknown` at boundaries and narrow or decode it.
+- Use discriminated unions for partial, recovered, failed, and cancelled states.
+- Use opaque types where document/revision/range identity can be confused.
+- Use exhaustive checks for closed unions.
+- Prefer `satisfies`; allow useful safe constructs such as `as const`.
+
+External ASTs are untrusted boundary data. Decode them in one adapter. Feature
+code must not scatter parser-specific assertions.
+
+Automate this with type-aware lint rules, a forbidden-pattern CI check, type
+tests, declaration generation, and a public API diff. If a third-party type
+forces a narrow assertion, isolate and runtime-check it in an adapter and
+require adversarial review; do not weaken global settings.
+
+The current production `tsconfig.json` excludes tests and the demo. Add separate
+typecheck projects for production, unit tests, browser tests, demo, fixtures,
+and public type tests. Validate emitted declarations in a clean consumer with
+`skipLibCheck: false`.
+
+Forbidden assertions apply strictly to production. Tests use typed builders
+rather than double assertions, but may have a separately audited boundary
+registry for unavoidable third-party mocks. Decide each proposed compiler
+option in an early ADR; do not leave “evaluate” as a permanent gate.
+
+## Code-quality standard
+
+Enforce the dependency direction:
+
+```text
+core primitives
+  ← document/source mapping
+  ← syntax/statement analysis
+  ← semantic model
+  ← catalog and feature policies
+  ← providers
+  ← CodeMirror adapter
+```
+
+Core cannot import CodeMirror, DOM, remote providers, or parser-specific ASTs.
+Automate import-boundary and dependency-cycle checks.
+
+Set ratcheted review thresholds for complexity, function/file size, nesting,
+and parameter count. These are review triggers, not an invitation to split one
+bad function into many bad functions.
+
+Public API rules:
+
+- Keep the stable surface small.
+- Do not export implementation classes for tests.
+- Prefer interfaces and factories over subclassing.
+- Mark experimental surfaces explicitly.
+- Generate and review an API report.
+- Require examples and release notes for public behavior changes.
+
+Every runtime dependency needs bundle, license, security, maintenance, and
+alternatives review, and must remain optional where appropriate.
+
+## Two-reviewer adversarial loop
+
+Every medium change receives two independent reviews before dependent work
+continues.
+
+### Reviewer A: correctness and safety
+
+Review SQL semantics, Unicode/ranges, partial-result confidence, concurrency,
+cancellation, disposal, security boundaries, and missing negative/fuzz tests.
+
+### Reviewer B: performance and design
+
+Review parsing/allocation cost, cache identity, bounded memory, main-thread
+work, layer coupling, public API leakage, excessive abstraction, and benchmark
+evidence.
+
+Both receive the same diff, acceptance criteria, invariants, test results, API
+diff, and benchmark/bundle deltas. They do not see each other's initial
+conclusions.
+
+Loop:
+
+1. Implement the scoped change and evidence.
+2. Run automated gates.
+3. Obtain both reviews.
+4. Classify findings as blocking correctness, architecture, performance, test
+   gap, documentation gap, justified follow-up, or rejected with evidence.
+5. Resolve all blocking findings.
+6. Rerun gates. Each reviewer rechecks unresolved findings and materially
+   changed areas against the new commit.
+7. Require two full reviews again only when the revision changes public
+   contracts, architecture, concurrency, or benchmark behavior materially.
+8. After two automated resolution cycles, escalate disputes to a human
+   maintainer rather than looping indefinitely.
+9. Store reports and the resolution ledger in the PR.
+
+Reviews must be tied to the exact commit; a push invalidates prior attestations.
+Review agents supplement human maintainers and never authorize a merge.
+Prefer reviewers with different prompts or models; two identical agents are
+correlated evidence. Independent downstream work may target an accepted
+interface contract, but cannot merge until its dependency is accepted.
+
+### Review automation
+
+Generate one review packet containing:
+
+- Base/head commit and diff
+- Changed files and risk classification
+- Affected invariants and ADRs
+- Test/coverage results
+- API, benchmark, and bundle deltas
+
+Add a PR template for change size, risks, evidence, two reports, finding ledger,
+and rollback/disable strategy. CI should reject a medium PR missing commit-bound
+review attestations or containing unresolved blockers.
+
+Use independent bot/App identities to create required GitHub checks containing
+reviewer identity, model/version, packet digest, head SHA, findings, and
+disposition. Validate them through a protected reusable workflow from the base
+branch so a PR cannot approve itself. Maintainers approve classification
+overrides and rejected blocking findings.
+
+## CI architecture
+
+### Required fast PR lane
+
+Set measured per-job budgets and run independent jobs in parallel. Aim for a
+useful result within ten minutes without making that aspirational number a
+correctness constraint:
+
+- Frozen install
+- Non-mutating lint
+- Strict typecheck and forbidden-practice scan
+- Unit, contract, and deterministic short fuzz tests
+- Coverage and changed-code coverage
+- Build, declarations, and public API diff
+- Packed-package validation
+- Bundle-size budget
+- Required Chromium integration
+- Import boundaries and dependency cycles
+
+Cancel superseded runs.
+
+Add a CI self-test before branch protection: deliberately failing fixture PRs
+must prove every required check appears and blocks merging.
+
+### Required affected integration lane
+
+For relevant paths, run full browser tests, marimo fixture, packed consumers,
+performance smoke tests, and security fixtures. Core, package, TypeScript,
+lockfile, or CI changes conservatively run everything.
+
+### Nightly lane
+
+Run randomized fuzzing, mutation tests, the full performance matrix,
+memory/leak scenarios, Firefox/WebKit, dependency auditing, differential
+testing, and the dialect conformance matrix.
+
+Nightly failures should open or update a tracking issue with seeds and
+artifacts. Avoid duplicate issue spam. Maintain a scheduled-health check that
+records suite, source SHA, configuration digest, completion time, and expiry.
+Release candidates are blocked by red or stale scheduled health. Define an
+owner, triage SLA, and maximum quarantine duration.
+
+Run reduced mutation, differential, and leak sentinels in PR CI when critical
+modules change; nightly evidence alone is too delayed.
+
+### Release-candidate lane
+
+Run all scheduled-class suites against the exact tagged SHA.
+
+Build one `npm pack` artifact from that SHA in a reusable verification workflow
+and record its SHA-256 and provenance. Split release evidence:
+
+- Source/configuration gates against the exact tagged SHA: unit, coverage,
+  mutation, fuzz, static analysis, API, source-level benchmarks, and dependency
+  inventory
+- Packaging/runtime gates against the exact tarball: minimal consumers,
+  supported bundlers/peers, browser smoke tests, marimo, declarations, source
+  maps, bundle composition, and migration examples
+
+Publishing downloads that immutable artifact and requires successful release
+checks and scheduled-class evidence for the tagged SHA. Protect the npm
+environment and reject tags not reachable from the protected release branch.
+Never rebuild different bits in the publish job.
+
+Checkpoint prereleases publish the verified canary artifact under a `next`
+dist-tag with provenance after their defined subset of source and runtime gates.
+Document their versioning and retention policy; ordinary integration commits
+remain downloadable CI artifacts rather than permanent npm versions.
+
+### Supported-runtime matrix
+
+Choose explicit supported Node, browser, peer-dependency, bundler, and SSR
+versions. Test minimum and latest Node and peer sets against the tarball. Narrow
+`engines` and compatibility claims to what CI continuously validates.
+
+## Ratchets
+
+- Coverage cannot decrease for retained/new-major code and reaches the
+  repository target by release candidate; changed-code and invariant floors
+  apply immediately.
+- No new unsafe type practice is allowed from the first overhaul commit.
+- Existing unsafe practices decrease by milestone.
+- Bundle/performance budgets cannot regress without explicit approval.
+- Mutation score cannot decrease.
+- Flaky tests need an owner and expiry; quarantine is temporary.
+- Public API growth requires explicit approval.
+
+Ratchets prevent new debt immediately while allowing deliberate removal of
+existing debt.
+
+## Definition of done for a medium change
+
+- Acceptance criteria and affected invariants are satisfied.
+- Relevant unit, contract, integration, browser, fuzz, and failure tests pass.
+- Changed core code meets coverage targets.
+- No forbidden type practice is introduced.
+- Lint, typecheck, build, package, and API checks pass.
+- Performance and bundle budgets pass or their change is approved.
+- Fuzz failures have permanent regression fixtures.
+- Both independent reviews have no unresolved blocking findings.
+- Docs, ADRs, examples, and capability matrices are current.
+- The result is simpler or demonstrably more capable than what it replaces.
+
+## Implementation sequence
+
+### 1. Governance and baseline
+
+Deliver branch protection, PR/ADR templates, review automation, behavior/API/
+coverage/bundle/performance baselines, confirmed-bug tests, and the marimo
+fixture.
+
+Exit when every baseline is reproducible in CI.
+
+### 2. Quality harness and walking skeleton
+
+Deliver enforced coverage, contract/golden organization, fuzz/property harness,
+mutation pilot, explicit browser CI, package smoke tests, type/import/API
+checks, and benchmark/bundle budgets.
+
+In parallel, build a deliberately thin walking skeleton:
+
+```text
+document revision
+  → parser adapter
+  → minimal normalized result
+  → one completion result
+  → CodeMirror presentation
+```
+
+Apply final changed-code gates to this new code immediately. Do not delay
+architectural feedback while exhaustively testing legacy code scheduled for
+deletion.
+
+Exit when critical characterization exists, harnesses are reproducible, and CI
+catches deliberately introduced stale-result, unsafe-cast, range, bundle, and
+API defects. Repository-wide coverage of retained/new-major code reaches the
+target by release candidate, not as a waterfall prerequisite.
+
+### 3. Core primitives and minimal provider contracts
+
+Deliver revisions, UTF-16 half-open ranges, original/rendered source maps,
+embedded regions, statement boundaries, disposable sessions, in-flight
+deduplication, and bounded caches.
+
+Also define the minimum parser, validator, catalog, completion, and provider
+result contracts now, including capability, authority, load state,
+document-versus-statement granularity, timeout, cancellation, and provenance.
+Run early DuckDB, LSP, formatter, and worker feasibility spikes and record
+go/no-go ADRs. These contracts cannot be deferred until after features that
+depend on them.
+
+Exit when arbitrary edit properties pass, stale results cannot apply, and
+unchanged statements are reused.
+
+### 4. Parser artifacts and semantic completion slice
+
+Deliver the parser contract, measured `node-sql-parser` adapter, normalized
+artifacts, query blocks, typed visibility, CTE/relation/alias/column bindings,
+explicit partial states, and a production-quality completion vertical slice.
+
+Exit when goldens pass, parser ASTs do not leak, and differences are classified.
+
+### 5. Feature vertical slices
+
+After completion proves the end-to-end model, migrate:
+
+1. Statement selection and gutter
+2. Syntax diagnostics
+3. Hover
+4. Navigation
+5. Semantic diagnostics
+
+Each slice includes CodeMirror integration, browser tests, performance evidence,
+and the two-reviewer loop. Delete the old slice after acceptance.
+
+### 6. Catalog and provider expansion
+
+Expand the minimal contracts into lazy catalogs, stable
+identities/invalidation, production feature-specific authority, native/remote
+providers, and the recorded DuckDB/LSP/`sqruff` decisions.
+
+Exit when optional remote work never blocks the local baseline and all
+race/failure/partial-catalog contracts pass.
+
+### 7. Marimo migration and release
+
+Migrate marimo, publish performance results and a dialect capability matrix,
+resolve prerelease feedback, remove legacy exports, and finalize migration/API
+documentation.
+
+Exit when the exact release tarball passes marimo and minimal-consumer smoke
+tests plus all correctness, quality, security, performance, and review gates.
+
+## Initial automation backlog
+
+Before semantic implementation:
+
+1. Add `dev-refactor` CI triggers and prove required checks fail closed.
+2. Enforce explicit all-file Vitest coverage and per-file changed-code coverage.
+3. Add explicit Chromium browser script and required CI step.
+4. Add production/test/demo/fixture/public-consumer typecheck projects.
+5. Add package tarball, peer-version, bundler, and minimal-consumer tests.
+6. Add API declaration diffing.
+7. Add bundle reporting and budgets.
+8. Add isolated deterministic property/fuzz infrastructure.
+9. Add JSON benchmarks, base/head comparison, and noise policy.
+10. Add the hermetic marimo fixture and pinned scheduled canary.
+11. Add forbidden type-practice, import-boundary, and cycle checks.
+12. Add the invariant registry and test-suite integrity checks.
+13. Add PR risk template and review-packet generation.
+14. Add protected, commit-bound two-reviewer checks.
+15. Add verified-artifact provenance to release CI.
+16. Add nightly mutation, fuzz, cross-browser, leak, and performance workflows.
+17. Add expiring scheduled-health and deduplicated failure issues.
+18. Define the supported runtime and dependency matrix.
+
+## Final recommendation
+
+The proposed emphasis on tests, >95% coverage, type safety, simplicity, and
+adversarial review is right. The important refinements are:
+
+- Use coverage as a ratcheted floor, backed by branch coverage, mutation tests,
+  and semantic corpora so the metric cannot be gamed.
+- Establish behavior and performance baselines before replacing code.
+- Keep `dev-refactor` green with small vertical PRs.
+- Test revisions, provider contracts, partial results, cancellation, and
+  disposal as aggressively as happy-path SQL.
+- Make marimo a continuous reference consumer.
+- Tie reviews to exact commits and repeat them after changes.
+- Gate latency, memory, bundle size, API growth, and correctness with measurable
+  budgets.
+
+Automation should make the demanding path the easiest path while keeping every
+change small enough for humans and review agents to understand completely.

--- a/package.json
+++ b/package.json
@@ -13,14 +13,23 @@
   },
   "scripts": {
     "dev": "vite",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "pnpm run typecheck:src && pnpm run typecheck:tests && pnpm run typecheck:vnext-tests && pnpm run typecheck:demo",
+    "typecheck:src": "tsc --project tsconfig.json --noEmit",
+    "typecheck:tests": "tsc --project tsconfig.tests.json",
+    "typecheck:vnext-tests": "tsc --project tsconfig.vnext-tests.json",
+    "typecheck:demo": "tsc --project tsconfig.demo.json",
     "lint": "oxlint --fix",
-    "test": "vitest",
+    "test": "vitest run --config vitest.config.ts",
+    "test:coverage": "vitest run --config vitest.config.ts --coverage",
+    "test:coverage:changed": "node ./scripts/changed-coverage.mjs",
+    "test:browser": "vitest run --config vitest.browser.config.ts",
+    "test:integrity": "node ./scripts/check-test-integrity.mjs",
+    "test:package": "pnpm run build && node ./scripts/package-smoke.mjs",
     "demo": "vite build",
-    "build": "tsc",
+    "build": "pnpm run clean && tsc",
+    "clean": "node ./scripts/clean.mjs",
     "prepublishOnly": "pnpm run typecheck && pnpm run test && pnpm run build",
-    "release": "pnpm version",
-    "test:browser": "vitest --config=vitest.browser.config.ts"
+    "release": "pnpm version"
   },
   "keywords": [
     "codemirror",
@@ -31,6 +40,7 @@
   "packageManager": "pnpm@11.4.0",
   "peerDependencies": {
     "@codemirror/autocomplete": "^6",
+    "@codemirror/lang-sql": "^6",
     "@codemirror/lint": "^6",
     "@codemirror/state": "^6",
     "@codemirror/view": "^6"
@@ -39,6 +49,7 @@
     "@codemirror/lang-sql": "6.10.0",
     "@codemirror/view": "6.43.0",
     "@testing-library/dom": "10.4.1",
+    "@types/node": "24.10.1",
     "@vitest/browser-playwright": "4.1.6",
     "@vitest/coverage-v8": "4.1.6",
     "codemirror": "6.0.2",
@@ -73,7 +84,7 @@
   "types": "./dist/index.d.ts",
   "type": "module",
   "engines": {
-    "node": "*"
+    "node": ">=20.19"
   },
   "module": "./dist/index.js",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -24,9 +24,9 @@
     "test:coverage:changed": "node ./scripts/changed-coverage.mjs",
     "test:browser": "vitest run --config vitest.browser.config.ts",
     "test:integrity": "node ./scripts/check-test-integrity.mjs",
-    "test:package": "pnpm run build && node ./scripts/package-smoke.mjs",
+    "test:package": "node ./scripts/clean.mjs && tsc && node ./scripts/package-smoke.mjs",
     "demo": "vite build",
-    "build": "pnpm run clean && tsc",
+    "build": "node ./scripts/clean.mjs && tsc",
     "clean": "node ./scripts/clean.mjs",
     "prepublishOnly": "pnpm run typecheck && pnpm run test && pnpm run build",
     "release": "pnpm version"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,9 +30,12 @@ importers:
       '@testing-library/dom':
         specifier: 10.4.1
         version: 10.4.1
+      '@types/node':
+        specifier: 24.10.1
+        version: 24.10.1
       '@vitest/browser-playwright':
         specifier: 4.1.6
-        version: 4.1.6(playwright@1.61.1)(vite@8.0.13)(vitest@4.1.6)
+        version: 4.1.6(playwright@1.61.1)(vite@8.0.13(@types/node@24.10.1))(vitest@4.1.6)
       '@vitest/coverage-v8':
         specifier: 4.1.6
         version: 4.1.6(@vitest/browser@4.1.6)(vitest@4.1.6)
@@ -53,10 +56,10 @@ importers:
         version: 7.0.2
       vite:
         specifier: 8.0.13
-        version: 8.0.13
+        version: 8.0.13(@types/node@24.10.1)
       vitest:
         specifier: 4.1.6
-        version: 4.1.6(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(jsdom@29.1.1)(vite@8.0.13)
+        version: 4.1.6(@types/node@24.10.1)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(jsdom@29.1.1)(vite@8.0.13(@types/node@24.10.1))
 
 packages:
 
@@ -464,6 +467,9 @@ packages:
 
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+  '@types/node@24.10.1':
+    resolution: {integrity: sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==}
 
   '@types/pegjs@0.10.6':
     resolution: {integrity: sha512-eLYXDbZWXh2uxf+w8sXS8d6KSoXTswfps6fvCUuVAGN8eRpfe7h9eSRydxiSJvo9Bf+GzifsDOr9TMQlmJdmkw==}
@@ -1022,6 +1028,9 @@ packages:
     engines: {node: '>=16.20.0'}
     hasBin: true
 
+  undici-types@7.16.0:
+    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
+
   undici@7.28.0:
     resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
@@ -1470,6 +1479,10 @@ snapshots:
 
   '@types/estree@1.0.9': {}
 
+  '@types/node@24.10.1':
+    dependencies:
+      undici-types: 7.16.0
+
   '@types/pegjs@0.10.6': {}
 
   '@typescript/typescript-aix-ppc64@7.0.2':
@@ -1532,29 +1545,29 @@ snapshots:
   '@typescript/typescript-win32-x64@7.0.2':
     optional: true
 
-  '@vitest/browser-playwright@4.1.6(playwright@1.61.1)(vite@8.0.13)(vitest@4.1.6)':
+  '@vitest/browser-playwright@4.1.6(playwright@1.61.1)(vite@8.0.13(@types/node@24.10.1))(vitest@4.1.6)':
     dependencies:
-      '@vitest/browser': 4.1.6(vite@8.0.13)(vitest@4.1.6)
-      '@vitest/mocker': 4.1.6(vite@8.0.13)
+      '@vitest/browser': 4.1.6(vite@8.0.13(@types/node@24.10.1))(vitest@4.1.6)
+      '@vitest/mocker': 4.1.6(vite@8.0.13(@types/node@24.10.1))
       playwright: 1.61.1
       tinyrainbow: 3.1.0
-      vitest: 4.1.6(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(jsdom@29.1.1)(vite@8.0.13)
+      vitest: 4.1.6(@types/node@24.10.1)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(jsdom@29.1.1)(vite@8.0.13(@types/node@24.10.1))
     transitivePeerDependencies:
       - bufferutil
       - msw
       - utf-8-validate
       - vite
 
-  '@vitest/browser@4.1.6(vite@8.0.13)(vitest@4.1.6)':
+  '@vitest/browser@4.1.6(vite@8.0.13(@types/node@24.10.1))(vitest@4.1.6)':
     dependencies:
       '@blazediff/core': 1.9.1
-      '@vitest/mocker': 4.1.6(vite@8.0.13)
+      '@vitest/mocker': 4.1.6(vite@8.0.13(@types/node@24.10.1))
       '@vitest/utils': 4.1.6
       magic-string: 0.30.21
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.6(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(jsdom@29.1.1)(vite@8.0.13)
+      vitest: 4.1.6(@types/node@24.10.1)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(jsdom@29.1.1)(vite@8.0.13(@types/node@24.10.1))
       ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
@@ -1574,9 +1587,9 @@ snapshots:
       obug: 2.1.3
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.6(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(jsdom@29.1.1)(vite@8.0.13)
+      vitest: 4.1.6(@types/node@24.10.1)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(jsdom@29.1.1)(vite@8.0.13(@types/node@24.10.1))
     optionalDependencies:
-      '@vitest/browser': 4.1.6(vite@8.0.13)(vitest@4.1.6)
+      '@vitest/browser': 4.1.6(vite@8.0.13(@types/node@24.10.1))(vitest@4.1.6)
 
   '@vitest/expect@4.1.6':
     dependencies:
@@ -1587,13 +1600,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.6(vite@8.0.13)':
+  '@vitest/mocker@4.1.6(vite@8.0.13(@types/node@24.10.1))':
     dependencies:
       '@vitest/spy': 4.1.6
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.13
+      vite: 8.0.13(@types/node@24.10.1)
 
   '@vitest/pretty-format@4.1.6':
     dependencies:
@@ -1994,9 +2007,11 @@ snapshots:
       '@typescript/typescript-win32-arm64': 7.0.2
       '@typescript/typescript-win32-x64': 7.0.2
 
+  undici-types@7.16.0: {}
+
   undici@7.28.0: {}
 
-  vite@8.0.13:
+  vite@8.0.13(@types/node@24.10.1):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.5
@@ -2004,12 +2019,13 @@ snapshots:
       rolldown: 1.0.1
       tinyglobby: 0.2.17
     optionalDependencies:
+      '@types/node': 24.10.1
       fsevents: 2.3.3
 
-  vitest@4.1.6(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(jsdom@29.1.1)(vite@8.0.13):
+  vitest@4.1.6(@types/node@24.10.1)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(jsdom@29.1.1)(vite@8.0.13(@types/node@24.10.1)):
     dependencies:
       '@vitest/expect': 4.1.6
-      '@vitest/mocker': 4.1.6(vite@8.0.13)
+      '@vitest/mocker': 4.1.6(vite@8.0.13(@types/node@24.10.1))
       '@vitest/pretty-format': 4.1.6
       '@vitest/runner': 4.1.6
       '@vitest/snapshot': 4.1.6
@@ -2026,10 +2042,11 @@ snapshots:
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 8.0.13
+      vite: 8.0.13(@types/node@24.10.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@vitest/browser-playwright': 4.1.6(playwright@1.61.1)(vite@8.0.13)(vitest@4.1.6)
+      '@types/node': 24.10.1
+      '@vitest/browser-playwright': 4.1.6(playwright@1.61.1)(vite@8.0.13(@types/node@24.10.1))(vitest@4.1.6)
       '@vitest/coverage-v8': 4.1.6(@vitest/browser@4.1.6)(vitest@4.1.6)
       jsdom: 29.1.1
     transitivePeerDependencies:

--- a/scripts/changed-coverage.mjs
+++ b/scripts/changed-coverage.mjs
@@ -1,0 +1,86 @@
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { transformWithOxc } from "vite";
+
+const arguments_ = process.argv.slice(2).filter((argument) => argument !== "--");
+if (arguments_.length !== 1) {
+  throw new Error("Usage: pnpm run test:coverage:changed -- <git-base>");
+}
+let [base] = arguments_;
+if (/^0+$/.test(base)) {
+  const defaultBranch = process.env.DEFAULT_BRANCH ?? "main";
+  base = execFileSync(
+    "git",
+    ["merge-base", "HEAD", `refs/remotes/origin/${defaultBranch}`],
+    { encoding: "utf8" },
+  ).trim();
+}
+
+execFileSync("git", ["rev-parse", "--verify", `${base}^{commit}`], {
+  encoding: "utf8",
+  stdio: "pipe",
+});
+
+const changedProductionFiles = execFileSync(
+  "git",
+  ["diff", "--name-only", "--diff-filter=ACMR", `${base}...HEAD`, "--", "src"],
+  { encoding: "utf8" },
+)
+  .trim()
+  .split("\n")
+  .filter(
+    (path) =>
+      path.endsWith(".ts") &&
+      !path.endsWith(".test.ts") &&
+      !path.includes("/__tests__/") &&
+      !path.includes("/browser_tests/") &&
+      path !== "src/debug.ts",
+  );
+const changedRuntimeFiles = (
+  await Promise.all(
+    changedProductionFiles.map(async (path) => {
+      const result = await transformWithOxc(readFileSync(path, "utf8"), path);
+      const measurableCode = result.code
+        .split("\n")
+        .filter((line) => !/^\s*(?:import\b|export\s*(?:\{|\*))/.test(line))
+        .join("\n")
+        .trim();
+      return measurableCode.length > 0 ? path : null;
+    }),
+  )
+).filter((path) => path !== null);
+
+execFileSync(
+  "pnpm",
+  [
+    "exec",
+    "vitest",
+    "run",
+    "--config",
+    "vitest.config.ts",
+    "--coverage",
+    `--coverage.changed=${base}`,
+    "--coverage.thresholds.perFile=true",
+    "--coverage.thresholds.lines=95",
+    "--coverage.thresholds.statements=95",
+    "--coverage.thresholds.functions=95",
+    "--coverage.thresholds.branches=95",
+  ],
+  {
+    encoding: "utf8",
+    stdio: "inherit",
+  },
+);
+
+if (changedRuntimeFiles.length > 0) {
+  const summary = JSON.parse(readFileSync("coverage/coverage-summary.json", "utf8"));
+  const totals = summary.total;
+  if (
+    !totals ||
+    (totals.lines.total === 0 && totals.statements.total === 0)
+  ) {
+    throw new Error(
+      `Changed runtime files produced no measurable coverage: ${changedRuntimeFiles.join(", ")}`,
+    );
+  }
+}

--- a/scripts/check-test-integrity.mjs
+++ b/scripts/check-test-integrity.mjs
@@ -1,0 +1,99 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const forbiddenModifier =
+  /\b(?:describe|it|test)(?:\.[A-Za-z_$][\w$]*)*\.(?:only|skip|skipIf|todo|runIf)\s*\(/g;
+const expectedFailure =
+  /\b(?:it|test)(?:\.[A-Za-z_$][\w$]*)*\.fails\s*\(\s*["'`]\[known-failure: ([^\]]+)\]/g;
+const anyExpectedFailure =
+  /\b(?:it|test)(?:\.[A-Za-z_$][\w$]*)*\.fails\s*\(/g;
+const violations = [];
+const knownFailures = JSON.parse(readFileSync("test/known-failures.json", "utf8"));
+const usedKnownFailures = new Set();
+
+const bypassFixtures = [
+  "describe.concurrent.skip('suite', () => {})",
+  "test.skipIf(true)('case', () => {})",
+  "it.runIf(false)('case', () => {})",
+];
+for (const fixture of bypassFixtures) {
+  if (!forbiddenModifier.test(fixture)) {
+    throw new Error(`Integrity scanner failed its bypass fixture: ${fixture}`);
+  }
+  forbiddenModifier.lastIndex = 0;
+}
+
+const expectedFailureFixtures = [
+  "it.fails('[known-failure: direct] case', () => {})",
+  "it.concurrent.fails('[known-failure: chained] case', () => {})",
+];
+for (const fixture of expectedFailureFixtures) {
+  if (!expectedFailure.test(fixture) || !anyExpectedFailure.test(fixture)) {
+    throw new Error(`Integrity scanner failed its expected-failure fixture: ${fixture}`);
+  }
+  expectedFailure.lastIndex = 0;
+  anyExpectedFailure.lastIndex = 0;
+}
+
+function checkDirectory(directory) {
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) {
+      checkDirectory(path);
+      continue;
+    }
+    if (!entry.name.endsWith(".test.ts") && !entry.name.endsWith(".test.tsx")) {
+      continue;
+    }
+
+    const source = readFileSync(path, "utf8");
+    for (const match of source.matchAll(forbiddenModifier)) {
+      const line = source.slice(0, match.index).split("\n").length;
+      violations.push(`${path}:${line}: ${match[0]}`);
+    }
+
+    for (const match of source.matchAll(expectedFailure)) {
+      const id = match[1];
+      const entry = knownFailures[id];
+      if (!entry) {
+        violations.push(`${path}: unregistered known failure '${id}'`);
+        continue;
+      }
+      if (
+        typeof entry.owner !== "string" ||
+        typeof entry.expires !== "string" ||
+        typeof entry.trackingIssue !== "string"
+      ) {
+        violations.push(`${path}: incomplete governance for known failure '${id}'`);
+        continue;
+      }
+      if (entry.expires < new Date().toISOString().slice(0, 10)) {
+        violations.push(`${path}: known failure '${id}' expired on ${entry.expires}`);
+      }
+      usedKnownFailures.add(id);
+    }
+
+    const expectedFailureCount = [...source.matchAll(anyExpectedFailure)].length;
+    const registeredFailureCount = [...source.matchAll(expectedFailure)].length;
+    if (expectedFailureCount !== registeredFailureCount) {
+      violations.push(`${path}: every expected failure must use a registered ID`);
+    }
+  }
+}
+
+checkDirectory("src");
+checkDirectory("test");
+
+for (const id of Object.keys(knownFailures)) {
+  if (!usedKnownFailures.has(id)) {
+    violations.push(`test/known-failures.json: unused known failure '${id}'`);
+  }
+}
+
+if (violations.length > 0) {
+  console.error("Test integrity violations:");
+  for (const violation of violations) {
+    console.error(`  ${violation}`);
+  }
+  process.exitCode = 1;
+}

--- a/scripts/clean.mjs
+++ b/scripts/clean.mjs
@@ -1,0 +1,9 @@
+import { rmSync } from "node:fs";
+import { basename, resolve } from "node:path";
+
+const outputDirectory = resolve("dist");
+if (basename(outputDirectory) !== "dist") {
+  throw new Error(`Refusing to clean unexpected path: ${outputDirectory}`);
+}
+
+rmSync(outputDirectory, { force: true, recursive: true });

--- a/scripts/package-smoke.mjs
+++ b/scripts/package-smoke.mjs
@@ -13,25 +13,67 @@ import { fileURLToPath } from "node:url";
 
 const repository = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const temporaryDirectory = mkdtempSync(join(tmpdir(), "codemirror-sql-package-"));
+const packageManagerExecutable = process.env.npm_execpath;
+if (!packageManagerExecutable) {
+  throw new Error("Package smoke must run through a package-manager script");
+}
+const packageManagerEnvironment = {
+  ...process.env,
+  npm_config_manage_package_manager_versions: "false",
+  npm_config_package_manager_strict_version: "false",
+};
 
 function run(command, args, cwd) {
   execFileSync(command, args, {
     cwd,
     encoding: "utf8",
     env: {
-      ...process.env,
+      ...packageManagerEnvironment,
       COREPACK_ENABLE_DOWNLOAD_PROMPT: "0",
     },
     stdio: "inherit",
   });
 }
 
+function runPackageManager(args, cwd) {
+  run(process.execPath, [packageManagerExecutable, ...args], cwd);
+}
+
 try {
-  const packOutput = JSON.parse(
-    execFileSync("pnpm", ["pack", "--json", "--pack-destination", temporaryDirectory], {
+  const packageManagerVersion = execFileSync(
+    process.execPath,
+    [packageManagerExecutable, "--version"],
+    {
       cwd: repository,
       encoding: "utf8",
-    }),
+      env: packageManagerEnvironment,
+    },
+  ).trim();
+  if (
+    process.env.EXPECTED_PNPM_VERSION &&
+    packageManagerVersion !== process.env.EXPECTED_PNPM_VERSION
+  ) {
+    throw new Error(
+      `Package-manager child switched from ${process.env.EXPECTED_PNPM_VERSION} to ${packageManagerVersion}`,
+    );
+  }
+
+  const packOutput = JSON.parse(
+    execFileSync(
+      process.execPath,
+      [
+        packageManagerExecutable,
+        "pack",
+        "--json",
+        "--pack-destination",
+        temporaryDirectory,
+      ],
+      {
+        cwd: repository,
+        encoding: "utf8",
+        env: packageManagerEnvironment,
+      },
+    ),
   );
   const manifest = Array.isArray(packOutput) ? packOutput[0] : packOutput;
   if (!manifest || typeof manifest.filename !== "string") {
@@ -43,8 +85,7 @@ try {
   copyFileSync(join(fixture, "package.json"), join(temporaryDirectory, "package.json"));
   copyFileSync(join(fixture, "pnpm-lock.yaml"), join(temporaryDirectory, "pnpm-lock.yaml"));
 
-  run(
-    "pnpm",
+  runPackageManager(
     ["install", "--frozen-lockfile", "--ignore-scripts"],
     temporaryDirectory,
   );
@@ -144,7 +185,7 @@ if (!parseResult.success || !parseResult.ast) {
     ),
   );
 
-  run("pnpm", ["exec", "tsc", "--project", "tsconfig.json"], temporaryDirectory);
+  runPackageManager(["exec", "tsc", "--project", "tsconfig.json"], temporaryDirectory);
   run(process.execPath, ["consumer.mjs"], temporaryDirectory);
 } finally {
   if (basename(temporaryDirectory).startsWith("codemirror-sql-package-")) {

--- a/scripts/package-smoke.mjs
+++ b/scripts/package-smoke.mjs
@@ -1,0 +1,153 @@
+import { execFileSync } from "node:child_process";
+import {
+  copyFileSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repository = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const temporaryDirectory = mkdtempSync(join(tmpdir(), "codemirror-sql-package-"));
+
+function run(command, args, cwd) {
+  execFileSync(command, args, {
+    cwd,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      COREPACK_ENABLE_DOWNLOAD_PROMPT: "0",
+    },
+    stdio: "inherit",
+  });
+}
+
+try {
+  const packOutput = JSON.parse(
+    execFileSync("pnpm", ["pack", "--json", "--pack-destination", temporaryDirectory], {
+      cwd: repository,
+      encoding: "utf8",
+    }),
+  );
+  const manifest = Array.isArray(packOutput) ? packOutput[0] : packOutput;
+  if (!manifest || typeof manifest.filename !== "string") {
+    throw new Error("pnpm pack did not return an archive filename");
+  }
+
+  const archive = join(temporaryDirectory, basename(manifest.filename));
+  const fixture = join(repository, "test", "package-smoke");
+  copyFileSync(join(fixture, "package.json"), join(temporaryDirectory, "package.json"));
+  copyFileSync(join(fixture, "pnpm-lock.yaml"), join(temporaryDirectory, "pnpm-lock.yaml"));
+
+  run(
+    "pnpm",
+    ["install", "--frozen-lockfile", "--ignore-scripts"],
+    temporaryDirectory,
+  );
+
+  const packageDirectory = join(
+    temporaryDirectory,
+    "node_modules",
+    "@marimo-team",
+    "codemirror-sql",
+  );
+  mkdirSync(packageDirectory, { recursive: true });
+  run(
+    "tar",
+    ["-xzf", archive, "-C", packageDirectory, "--strip-components=1"],
+    temporaryDirectory,
+  );
+  const packedPackage = JSON.parse(
+    readFileSync(join(packageDirectory, "package.json"), "utf8"),
+  );
+  if (typeof packedPackage.dependencies?.["node-sql-parser"] !== "string") {
+    throw new Error("Packed manifest does not declare node-sql-parser");
+  }
+
+  writeFileSync(
+    join(temporaryDirectory, "consumer.mts"),
+    `import type { Extension } from "@codemirror/state";
+import {
+  NodeSqlParser,
+  sqlCompletion,
+  sqlExtension,
+} from "@marimo-team/codemirror-sql";
+import {
+  BigQueryDialect,
+  DremioDialect,
+  DuckDBDialect,
+} from "@marimo-team/codemirror-sql/dialects";
+import commonKeywords from "@marimo-team/codemirror-sql/data/common-keywords.json" with { type: "json" };
+import duckdbKeywords from "@marimo-team/codemirror-sql/data/duckdb-keywords.json" with { type: "json" };
+
+const extensions: Extension[] = [
+  sqlCompletion({ dialect: DuckDBDialect }),
+  sqlExtension(),
+];
+const parser = new NodeSqlParser();
+
+void extensions;
+void parser;
+void BigQueryDialect;
+void DremioDialect;
+void commonKeywords;
+void duckdbKeywords;
+`,
+  );
+
+  writeFileSync(
+    join(temporaryDirectory, "consumer.mjs"),
+    `import { EditorState } from "@codemirror/state";
+import * as api from "@marimo-team/codemirror-sql";
+import * as dialects from "@marimo-team/codemirror-sql/dialects";
+import commonKeywords from "@marimo-team/codemirror-sql/data/common-keywords.json" with { type: "json" };
+import duckdbKeywords from "@marimo-team/codemirror-sql/data/duckdb-keywords.json" with { type: "json" };
+
+if (typeof api.sqlExtension !== "function" || typeof api.NodeSqlParser !== "function") {
+  throw new Error("Root package exports are incomplete");
+}
+if (!dialects.BigQueryDialect || !dialects.DremioDialect || !dialects.DuckDBDialect) {
+  throw new Error("Dialect package exports are incomplete");
+}
+if (!commonKeywords.keywords || !duckdbKeywords.keywords) {
+  throw new Error("Keyword data exports are incomplete");
+}
+
+const state = EditorState.create({ doc: "SELECT 1" });
+const parseResult = await new api.NodeSqlParser().parse("SELECT 1", { state });
+if (!parseResult.success || !parseResult.ast) {
+  throw new Error("The packaged parser could not load its runtime dependency");
+}
+`,
+  );
+
+  writeFileSync(
+    join(temporaryDirectory, "tsconfig.json"),
+    JSON.stringify(
+      {
+        compilerOptions: {
+          module: "NodeNext",
+          moduleResolution: "NodeNext",
+          noEmit: true,
+          skipLibCheck: false,
+          strict: true,
+          target: "ES2022",
+        },
+        include: ["consumer.mts"],
+      },
+      null,
+      2,
+    ),
+  );
+
+  run("pnpm", ["exec", "tsc", "--project", "tsconfig.json"], temporaryDirectory);
+  run(process.execPath, ["consumer.mjs"], temporaryDirectory);
+} finally {
+  if (basename(temporaryDirectory).startsWith("codemirror-sql-package-")) {
+    rmSync(temporaryDirectory, { force: true, recursive: true });
+  }
+}

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1,4 +1,4 @@
-import { readdir } from "node:fs/promises";
+import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import * as dialects from "../dialects";
@@ -40,15 +40,17 @@ describe("index.ts exports", () => {
   });
 });
 
-describe("keywords", async () => {
-  it("should have the correct structure, keywords.keywords should be an object", async () => {
-    const dataDir = join(__dirname, "../data");
-    const files = await readdir(dataDir);
-    const keywordFiles = files.filter((file) => file.endsWith("-keywords.json"));
+describe("keywords", () => {
+  it("should have the correct structure, keywords.keywords should be an object", () => {
+    const dataDirectory = join(__dirname, "../data");
+    const keywordFiles = readdirSync(dataDirectory).filter((file) =>
+      file.endsWith("-keywords.json"),
+    );
 
+    expect(keywordFiles.length).toBeGreaterThan(0);
     for (const file of keywordFiles) {
-      const keywords = await import(`../data/${file}`);
-      expect(typeof keywords.keywords).toBe("object");
+      const data = JSON.parse(readFileSync(join(dataDirectory, file), "utf8"));
+      expect(typeof data.keywords).toBe("object");
     }
   });
 });

--- a/src/__tests__/package-exports.test.ts
+++ b/src/__tests__/package-exports.test.ts
@@ -9,6 +9,10 @@ interface PackedFile {
   path: string;
 }
 
+interface PackedManifest {
+  files: PackedFile[];
+}
+
 /**
  * Collect every string file path referenced anywhere in the package.json
  * `exports` map (recursing through conditional-export objects like
@@ -29,9 +33,17 @@ describe("published package", () => {
   // Run the real `npm pack` so we assert against the actual tarball contents,
   // not the source tree. Regression guard for the `./data/*` exports that
   // shipped dead in 0.2.5–0.2.7 because `src/data/` was missing at publish time.
-  const packed: PackedFile[] = JSON.parse(
-    execSync("npm pack --dry-run --json", { cwd: repoRoot, encoding: "utf8" }),
-  )[0].files;
+  const packOutput: PackedManifest | PackedManifest[] = JSON.parse(
+    execSync("pnpm pack --dry-run --json", {
+      cwd: repoRoot,
+      encoding: "utf8",
+    }),
+  );
+  const manifest = Array.isArray(packOutput) ? packOutput[0] : packOutput;
+  if (!manifest) {
+    throw new Error("pnpm pack returned no package manifest");
+  }
+  const packed = manifest.files;
   const packedPaths = new Set(packed.map((f) => f.path));
 
   const pkg = JSON.parse(readFileSync(join(repoRoot, "package.json"), "utf8"));

--- a/src/sql/__tests__/completion-extension.test.ts
+++ b/src/sql/__tests__/completion-extension.test.ts
@@ -7,7 +7,10 @@ import { sqlCompletion } from "../completion-extension.js";
 const schema = { users: ["id", "name", "email"] };
 
 /** Collect the `autocomplete` completion sources registered on the language. */
-function autocompleteSources(...extensions: Parameters<typeof EditorState.create>[0]["extensions"][]) {
+type EditorStateConfig = NonNullable<Parameters<typeof EditorState.create>[0]>;
+type EditorExtension = NonNullable<EditorStateConfig["extensions"]>;
+
+function autocompleteSources(...extensions: EditorExtension[]) {
   const state = EditorState.create({
     doc: "SELECT ",
     extensions: [sql({ dialect: PostgreSQL, schema }), ...extensions],

--- a/src/sql/__tests__/parser.test.ts
+++ b/src/sql/__tests__/parser.test.ts
@@ -445,7 +445,7 @@ describe("replaceBracketsWithQuotes", () => {
     expect(result.offsetRecord).toEqual({});
   });
 
-  it.fails("should handle escaped quotes", () => {
+  it.fails("[known-failure: parser-escaped-quotes] should handle escaped quotes", () => {
     const sql = "SELECT \\'{id}\\' FROM users WHERE id = \\'{id}\\'";
     const result = replaceBracketsWithQuotes(sql);
     expect(result.sql).toBe("SELECT \\'{id}\\' FROM users WHERE id = \\'{id}\\'");

--- a/test/known-failures.json
+++ b/test/known-failures.json
@@ -1,0 +1,7 @@
+{
+  "parser-escaped-quotes": {
+    "owner": "codemirror-sql-maintainers",
+    "expires": "2026-08-31",
+    "trackingIssue": "https://github.com/marimo-team/codemirror-sql/issues/169"
+  }
+}

--- a/test/package-smoke/package.json
+++ b/test/package-smoke/package.json
@@ -1,0 +1,13 @@
+{
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@codemirror/autocomplete": "6.20.3",
+    "@codemirror/lang-sql": "6.10.0",
+    "@codemirror/lint": "6.9.7",
+    "@codemirror/state": "6.7.1",
+    "@codemirror/view": "6.43.0",
+    "node-sql-parser": "5.4.0",
+    "typescript": "7.0.2"
+  }
+}

--- a/test/package-smoke/pnpm-lock.yaml
+++ b/test/package-smoke/pnpm-lock.yaml
@@ -1,0 +1,362 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@codemirror/autocomplete':
+        specifier: 6.20.3
+        version: 6.20.3
+      '@codemirror/lang-sql':
+        specifier: 6.10.0
+        version: 6.10.0
+      '@codemirror/lint':
+        specifier: 6.9.7
+        version: 6.9.7
+      '@codemirror/state':
+        specifier: 6.7.1
+        version: 6.7.1
+      '@codemirror/view':
+        specifier: 6.43.0
+        version: 6.43.0
+      node-sql-parser:
+        specifier: 5.4.0
+        version: 5.4.0
+      typescript:
+        specifier: 7.0.2
+        version: 7.0.2
+
+packages:
+
+  '@codemirror/autocomplete@6.20.3':
+    resolution: {integrity: sha512-tlosUqb+3BbxCxZdu4tKeRghPFC+QM7q4X5YhKV2eCmPG+1r2F3f4AaSz5sCrFqUtX4Jh20VFTKecl16MgiV9g==}
+
+  '@codemirror/lang-sql@6.10.0':
+    resolution: {integrity: sha512-6ayPkEd/yRw0XKBx5uAiToSgGECo/GY2NoJIHXIIQh1EVwLuKoU8BP/qK0qH5NLXAbtJRLuT73hx7P9X34iO4w==}
+
+  '@codemirror/language@6.12.4':
+    resolution: {integrity: sha512-1q4PaT+o6PbgpkJt4Q8Fv5XJxTy4FUZ4MWETtyiDw3J0Pyr9E2vqcKL+k9wcvjNTIsauxvE7OfmWj3FRPHQ76A==}
+
+  '@codemirror/lint@6.9.7':
+    resolution: {integrity: sha512-28/+iWLYxKxsvGYhSYL7zaCZqLz5+FFFDq9tVsvGv9kv8RY4fFAchJ5WX9M3YrrRlTIsECjsXPqeNgnSmNP2dg==}
+
+  '@codemirror/state@6.7.1':
+    resolution: {integrity: sha512-9QzNDgE4EYDnAHfrTlR2lwiPciiOymLtwKK+8yHQzCc7GXhAP9xdEbEJFy2IWB1j9UGUl9BsgMmTo/ImA02T7A==}
+
+  '@codemirror/view@6.43.0':
+    resolution: {integrity: sha512-V7ZCLQO3Jus9hzh2jVCCPW3mO4IBMr43O37PqSUYautJSnnJF41YlgLw21x0fLJTYvJ+Vkm6Gp+qKGH9pltgXA==}
+
+  '@lezer/common@1.5.2':
+    resolution: {integrity: sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==}
+
+  '@lezer/highlight@1.2.3':
+    resolution: {integrity: sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==}
+
+  '@lezer/lr@1.4.10':
+    resolution: {integrity: sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==}
+
+  '@marijn/find-cluster-break@1.0.3':
+    resolution: {integrity: sha512-FY+MKLBoTsLNJF/eLWaOsXGdz6uh3Iu1axjPf6TUq92IYumcTcXWHoS747JARLkcdlJ/Waiaxc5wQfFO8jC6NA==}
+
+  '@types/pegjs@0.10.6':
+    resolution: {integrity: sha512-eLYXDbZWXh2uxf+w8sXS8d6KSoXTswfps6fvCUuVAGN8eRpfe7h9eSRydxiSJvo9Bf+GzifsDOr9TMQlmJdmkw==}
+
+  '@typescript/typescript-aix-ppc64@7.0.2':
+    resolution: {integrity: sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@typescript/typescript-darwin-arm64@7.0.2':
+    resolution: {integrity: sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@typescript/typescript-darwin-x64@7.0.2':
+    resolution: {integrity: sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@typescript/typescript-freebsd-arm64@7.0.2':
+    resolution: {integrity: sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@typescript/typescript-freebsd-x64@7.0.2':
+    resolution: {integrity: sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@typescript/typescript-linux-arm64@7.0.2':
+    resolution: {integrity: sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@typescript/typescript-linux-arm@7.0.2':
+    resolution: {integrity: sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@typescript/typescript-linux-loong64@7.0.2':
+    resolution: {integrity: sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    resolution: {integrity: sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    resolution: {integrity: sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    resolution: {integrity: sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@typescript/typescript-linux-s390x@7.0.2':
+    resolution: {integrity: sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@typescript/typescript-linux-x64@7.0.2':
+    resolution: {integrity: sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    resolution: {integrity: sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    resolution: {integrity: sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@typescript/typescript-sunos-x64@7.0.2':
+    resolution: {integrity: sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@typescript/typescript-win32-arm64@7.0.2':
+    resolution: {integrity: sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@typescript/typescript-win32-x64@7.0.2':
+    resolution: {integrity: sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [win32]
+
+  big-integer@1.6.52:
+    resolution: {integrity: sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==}
+    engines: {node: '>=0.6'}
+
+  crelt@1.0.7:
+    resolution: {integrity: sha512-aK6BbWfhf4U/wCcLHKPJl/xa6VkVstRaPywWtMKGwuOLc/wZTyQYuoxgvZnNsBvv7Kg3YTBQYYBCggcviQczuA==}
+
+  node-sql-parser@5.4.0:
+    resolution: {integrity: sha512-jVe6Z61gPcPjCElPZ6j8llB3wnqGcuQzefim1ERsqIakxnEy5JlzV7XKdO1KmacRG5TKwPc4vJTgSRQ0LfkbFw==}
+    engines: {node: '>=8'}
+
+  style-mod@4.1.3:
+    resolution: {integrity: sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==}
+
+  typescript@7.0.2:
+    resolution: {integrity: sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==}
+    engines: {node: '>=16.20.0'}
+    hasBin: true
+
+  w3c-keyname@2.2.8:
+    resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
+
+snapshots:
+
+  '@codemirror/autocomplete@6.20.3':
+    dependencies:
+      '@codemirror/language': 6.12.4
+      '@codemirror/state': 6.7.1
+      '@codemirror/view': 6.43.0
+      '@lezer/common': 1.5.2
+
+  '@codemirror/lang-sql@6.10.0':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.3
+      '@codemirror/language': 6.12.4
+      '@codemirror/state': 6.7.1
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@codemirror/language@6.12.4':
+    dependencies:
+      '@codemirror/state': 6.7.1
+      '@codemirror/view': 6.43.0
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+      style-mod: 4.1.3
+
+  '@codemirror/lint@6.9.7':
+    dependencies:
+      '@codemirror/state': 6.7.1
+      '@codemirror/view': 6.43.0
+      crelt: 1.0.7
+
+  '@codemirror/state@6.7.1':
+    dependencies:
+      '@marijn/find-cluster-break': 1.0.3
+
+  '@codemirror/view@6.43.0':
+    dependencies:
+      '@codemirror/state': 6.7.1
+      crelt: 1.0.7
+      style-mod: 4.1.3
+      w3c-keyname: 2.2.8
+
+  '@lezer/common@1.5.2': {}
+
+  '@lezer/highlight@1.2.3':
+    dependencies:
+      '@lezer/common': 1.5.2
+
+  '@lezer/lr@1.4.10':
+    dependencies:
+      '@lezer/common': 1.5.2
+
+  '@marijn/find-cluster-break@1.0.3': {}
+
+  '@types/pegjs@0.10.6': {}
+
+  '@typescript/typescript-aix-ppc64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-darwin-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-darwin-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-freebsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-freebsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-arm@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-loong64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-s390x@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-sunos-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-win32-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-win32-x64@7.0.2':
+    optional: true
+
+  big-integer@1.6.52: {}
+
+  crelt@1.0.7: {}
+
+  node-sql-parser@5.4.0:
+    dependencies:
+      '@types/pegjs': 0.10.6
+      big-integer: 1.6.52
+
+  style-mod@4.1.3: {}
+
+  typescript@7.0.2:
+    optionalDependencies:
+      '@typescript/typescript-aix-ppc64': 7.0.2
+      '@typescript/typescript-darwin-arm64': 7.0.2
+      '@typescript/typescript-darwin-x64': 7.0.2
+      '@typescript/typescript-freebsd-arm64': 7.0.2
+      '@typescript/typescript-freebsd-x64': 7.0.2
+      '@typescript/typescript-linux-arm': 7.0.2
+      '@typescript/typescript-linux-arm64': 7.0.2
+      '@typescript/typescript-linux-loong64': 7.0.2
+      '@typescript/typescript-linux-mips64el': 7.0.2
+      '@typescript/typescript-linux-ppc64': 7.0.2
+      '@typescript/typescript-linux-riscv64': 7.0.2
+      '@typescript/typescript-linux-s390x': 7.0.2
+      '@typescript/typescript-linux-x64': 7.0.2
+      '@typescript/typescript-netbsd-arm64': 7.0.2
+      '@typescript/typescript-netbsd-x64': 7.0.2
+      '@typescript/typescript-openbsd-arm64': 7.0.2
+      '@typescript/typescript-openbsd-x64': 7.0.2
+      '@typescript/typescript-sunos-x64': 7.0.2
+      '@typescript/typescript-win32-arm64': 7.0.2
+      '@typescript/typescript-win32-x64': 7.0.2
+
+  w3c-keyname@2.2.8: {}

--- a/tsconfig.demo.json
+++ b/tsconfig.demo.json
@@ -1,0 +1,24 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "allowImportingTsExtensions": true,
+    "declaration": false,
+    "declarationMap": false,
+    "inlineSources": false,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "noEmit": true,
+    "rootDir": ".",
+    "sourceMap": false
+  },
+  "include": [
+    "./demo/**/*.ts",
+    "./src/**/*.ts"
+  ],
+  "exclude": [
+    "./dist",
+    "./node_modules",
+    "./src/**/*.test.ts",
+    "./src/**/__tests__/**"
+  ]
+}

--- a/tsconfig.tests.json
+++ b/tsconfig.tests.json
@@ -1,0 +1,30 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "allowImportingTsExtensions": true,
+    "declaration": false,
+    "declarationMap": false,
+    "inlineSources": false,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "noEmit": true,
+    // Legacy tests temporarily retain these two exceptions. All vNext tests
+    // are checked by tsconfig.vnext-tests.json with both rules enabled.
+    "noUncheckedIndexedAccess": false,
+    "noUnusedLocals": false,
+    "rootDir": ".",
+    "sourceMap": false,
+    "types": [
+      "node"
+    ]
+  },
+  "include": [
+    "./src/**/*.ts",
+    "./vitest.browser.config.ts",
+    "./vitest.config.ts"
+  ],
+  "exclude": [
+    "./dist",
+    "./node_modules"
+  ]
+}

--- a/tsconfig.vnext-tests.json
+++ b/tsconfig.vnext-tests.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.tests.json",
+  "compilerOptions": {
+    "noUncheckedIndexedAccess": true,
+    "noUnusedLocals": true
+  },
+  "include": [
+    "./src/vnext/**/*.ts",
+    "./vitest.browser.config.ts",
+    "./vitest.config.ts"
+  ]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,46 +1,6 @@
-import { playwright } from "@vitest/browser-playwright";
-import { defineConfig } from "vitest/config";
+import { defineConfig } from "vite";
 
 export default defineConfig({
-  root: process.env.VITEST ? "." : "demo",
-  test: {
-    watch: false,
-    coverage: {
-      enabled: true,
-      provider: "v8",
-      reportOnFailure: true,
-      reporter: ["text", "json", "html", "json-summary"],
-      include: ["src/**/*.ts"],
-      exclude: ["src/**/*.test.ts", "src/**/__tests__/**", "src/debug.ts"],
-    },
-    projects: [
-      {
-        test: {
-          environment: "jsdom",
-          exclude: ["src/**/browser_tests/**/*.test.ts"],
-          include: ["src/**/*.test.ts", "src/**/__tests__/**/*.test.ts"],
-        }
-      },
-      {
-        test: {
-          name: "browser",
-          browser: {
-            enabled: true,
-            provider: playwright({
-              launchOptions: process.env.CI ? { channel: "chrome" } : undefined,
-            }),
-            // https://vitest.dev/guide/browser/playwright
-            instances: [
-              { browser: 'chromium' },
-            ],
-            ui: false,
-            headless: true,
-          },
-          include: ["src/**/browser_tests/**/*.test.ts"],
-          testTimeout: 5000,
-        },
-      }
-    ]
-  },
+  root: "demo",
   base: "/codemirror-sql/",
 });

--- a/vitest.browser.config.ts
+++ b/vitest.browser.config.ts
@@ -1,0 +1,19 @@
+import { playwright } from "@vitest/browser-playwright";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    allowOnly: false,
+    browser: {
+      enabled: true,
+      headless: true,
+      instances: [{ browser: "chromium" }],
+      provider: playwright(),
+      ui: false,
+    },
+    include: ["src/**/browser_tests/**/*.test.ts"],
+    passWithNoTests: false,
+    testTimeout: 5000,
+    watch: false,
+  },
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,32 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    allowOnly: false,
+    coverage: {
+      enabled: false,
+      exclude: [
+        "src/**/*.test.ts",
+        "src/**/__tests__/**",
+        "src/**/browser_tests/**",
+        "src/debug.ts",
+      ],
+      excludeAfterRemap: true,
+      include: ["src/**/*.ts"],
+      provider: "v8",
+      reporter: ["text", "json", "html", "json-summary"],
+      reportOnFailure: true,
+      thresholds: {
+        branches: 85.85,
+        functions: 90.94,
+        lines: 91.52,
+        statements: 91.61,
+      },
+    },
+    environment: "jsdom",
+    exclude: ["src/**/browser_tests/**/*.test.ts"],
+    include: ["src/**/*.test.ts", "src/**/__tests__/**/*.test.ts"],
+    passWithNoTests: false,
+    watch: false,
+  },
+});


### PR DESCRIPTION
Establishes the next-major engineering foundation before production architecture changes. Adds the research and implementation plans, split unit/browser configs, honest aggregate coverage ratchets, 95% changed-code coverage, governed known failures, strict vNext typing, clean builds, deterministic packed-consumer validation, Node floor coverage, and release-gate parity.\n\nValidated locally: lint, integrity, all TypeScript scopes, 587 unit tests plus one governed expected failure, aggregate and changed coverage, Chromium browser smoke, packed consumer/runtime parse, demo build, actionlint, and two independent adversarial review loops.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sets up the vNext quality foundation with strict typing, split unit/browser tests, honest coverage gates (aggregate + changed-code), governed known failures, and deterministic package smoke tests that preserve the `pnpm` version. Hardens CI/release and unblocks the next major architecture work.

- **New Features**
  - CI: pin Node 20.19.0 and `pnpm` 10.28.2 with version checks; disable Node-managed PM version enforcement; add concurrency with cancel-in-progress; fetch full git history; add lint and test integrity gates; split unit and headless browser runs; enforce aggregate and changed-code coverage.
  - Release: add a compatibility job that runs `pnpm pack` and a consumer smoke test; preserve and verify `pnpm` 10.28.2 across the smoke path; `autofix.yml` also runs on `dev-refactor`.
  - Known failures governed via `test/known-failures.json` with owner and expiry.
  - Added vNext docs: `SQL_EDITOR_RESEARCH.md` and `implementation.md`.

- **Refactors**
  - Split TS configs and typecheck scripts for source, legacy tests, vNext tests, and demo; vNext tests use stricter rules.
  - Extracted `vitest` configs; `vite.config.ts` now only builds the demo.
  - Minor ESM/typing fixes in demo and tests; export test now uses `pnpm pack`.

<sup>Written for commit ebbeb2fadf58dfac1c2ee20adb2fb6f10a7f3b80. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marimo-team/codemirror-sql/pull/170?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

