### PR TITLE
docs: define vNext language-service contracts

### DIFF
--- a/docs/adr/0001-language-service-and-session.md
+++ b/docs/adr/0001-language-service-and-session.md
@@ -1,0 +1,592 @@
+# ADR 0001: Shared Language Service and Per-Document Sessions
+
+Status: accepted  
+Date: 2026-07-24
+
+## Context
+
+The v0.x public API exposes mutable parser and analyzer implementations.
+Parsers receive arbitrary CodeMirror `EditorState`, features can use different
+parser and schema configurations, and asynchronous work has no common revision
+or cancellation contract.
+
+Marimo demonstrates the resulting pressure:
+
+- It subclasses `NodeSqlParser` to mix local parsing with remote validation.
+- The subclass stores focus, timer, and validation state on the parser.
+- Replacing a debounce timer can leave the earlier promise unsettled.
+- DuckDB `parse()` and `validateSql()` deliberately report different evidence.
+- Connection, dialect, schema, and Python-template completion are wired through
+  separate paths.
+- Many editor instances can share configuration while requiring independent
+  mutable state.
+
+The next major may break compatibility. The API should therefore model the
+actual lifecycle instead of preserving these implementation classes.
+
+## Decision
+
+vNext has one shareable, framework-independent `SqlLanguageService` and one
+disposable `SqlDocumentSession` per open document/editor.
+
+The service owns providers, workers, shared bounded caches, and immutable
+dialect/catalog resources. A session owns document and context revisions,
+request generations, relevant subscriptions, cancellation, and
+current-document caches. The CodeMirror adapter owns editor focus, visibility,
+debounce, dispatch, and session disposal.
+
+Shared providers contain no request-local mutable state.
+
+## Stable introductory shape
+
+The target consumer shape is:
+
+```ts
+interface MarimoSqlContext extends SqlDocumentContext {
+  readonly engine: string;
+  readonly sqlMode: "default" | "validate";
+}
+
+const duckdb = duckdbDialect();
+
+const service = createSqlLanguageService<MarimoSqlContext>({
+  dialects: [duckdb, postgresDialect(), bigQueryDialect()],
+  syntax: nodeSqlParserSyntax(),
+  catalog: marimoCatalogProvider,
+  validators: [
+    marimoValidationProvider({
+      authority: "authoritative",
+      granularity: "document",
+      input: "original",
+    }),
+  ],
+});
+
+const session = service.openDocument({
+  text: "SELECT * FROM users",
+  context: {
+    dialect: duckdb.id,
+    engine: "__marimo__",
+    sqlMode: "validate",
+  },
+});
+
+const completion = await session.complete({
+  position: 19,
+  trigger: { kind: "invoked" },
+  signal,
+});
+
+if (
+  completion.status === "ready" &&
+  session.isCurrent(completion.revision)
+) {
+  render(completion.value.items);
+}
+
+session.dispose();
+service.dispose();
+```
+
+`syntax` is an opaque module accepted by the stable service factory. Its parser
+and semantic-model SPI is not stable in this ADR. Official adapters can use an
+experimental subpath until two materially different backends validate the
+normalized artifacts.
+
+## Document context
+
+The service is generic over a host context that extends the standard document
+context:
+
+```ts
+interface SqlDocumentContext {
+  readonly dialect: SqlDialectId;
+  readonly catalog?: {
+    readonly scope: string;
+    readonly searchPath?: readonly string[];
+  };
+}
+```
+
+The service resolves dialect IDs through its immutable registry and rejects
+unknown or duplicate IDs. Duplicate registration is rejected even when the
+definitions appear equivalent. Dialect identity includes an internal
+configuration revision; calling a dialect factory again does not change the
+identity of an already registered dialect.
+
+Hosts can add fields such as engine or SQL mode. Contexts must be
+structured-cloneable plain data. On open/update, the session creates and owns a
+structured clone before accepting the change. Clone failure rejects the
+complete operation without mutation. The accepted snapshot is recursively
+frozen and is the only context observed by providers. Caller mutation therefore
+cannot change an in-flight request. Providers never read ambient editor state.
+
+The session updates text and context atomically:
+
+```ts
+session.update({
+  baseRevision: session.revision,
+  document: {
+    changes: [{ from: 14, to: 19, insert: "customers" }],
+  },
+  context: nextContext,
+});
+```
+
+A full-text replacement is available for simple consumers. Incremental changes
+are ordered, non-overlapping, absolute UTF-16 ranges in the current document.
+The service validates the base revision and every range before mutating state.
+
+A context-only update is valid and also requires `baseRevision`. Accepted
+updates always create a new revision, including an `A → B → A` text cycle, so a
+previous result never becomes current again. A stale base rejects the complete
+update without partial mutation.
+
+## Revision and applicability
+
+The public revision is an opaque immutable service-generated token. Callers
+cannot construct one or supply their own version number.
+
+Internally, the revision records:
+
+- Session identity
+- Monotonic sequence
+- Document revision
+- Context and template revision
+- Relevant environment/catalog epoch
+
+The public model is deliberately global per session: any accepted text,
+context, template, relevant catalog, or provider-configuration invalidation
+advances the session revision and makes every earlier public result stale.
+Selective invalidation refers only to internal cache reuse; for example, a
+catalog change can retain statement parse artifacts. If feature-specific
+applicability is later required, it gets a separately named token.
+
+Consumers use only:
+
+```ts
+session.isCurrent(result.revision);
+```
+
+Every request captures one revision, and every result carries it. A session
+change settles prior public requests as cancelled/superseded once provider
+invocation has returned control, even if an underlying promise ignores
+cancellation. A ready result can become stale after settlement, so currency is
+checked again immediately before application.
+
+## Ranges
+
+The stable range is an ergonomic readonly object:
+
+```ts
+interface SqlTextRange {
+  readonly from: number;
+  readonly to: number;
+}
+```
+
+All public ranges are absolute original-document UTF-16 half-open coordinates.
+They satisfy:
+
+```text
+0 <= from <= to <= document.length
+```
+
+Line and column values are derived presentation data. Internally, absolute
+document offsets and statement-relative offsets use distinct branded types.
+
+Statement lookup uses explicit cursor affinity at boundaries and EOF. It must
+not reintroduce the v0.x inclusive-end behavior.
+
+## Request outcomes
+
+Every session feature request settles with the same top-level union:
+
+```ts
+type SqlRequestResult<T> =
+  | {
+      readonly status: "ready";
+      readonly revision: SqlRevision;
+      readonly value: T;
+      readonly sources: readonly SqlProviderReport[];
+    }
+  | {
+      readonly status: "unavailable";
+      readonly revision: SqlRevision;
+      readonly reason: SqlUnavailableReason;
+      readonly retryable: boolean;
+    }
+  | {
+      readonly status: "cancelled";
+      readonly revision: SqlRevision;
+      readonly reason: "caller" | "superseded" | "disposed";
+    }
+  | {
+      readonly status: "failed";
+      readonly revision: SqlRevision;
+      readonly failure: SqlServiceFailure;
+    };
+```
+
+SQL invalidity is a ready analysis result containing diagnostics, not a service
+failure. Unsupported syntax can be opaque or partial. Provider rejection,
+timeout, malformed output, and cancellation remain distinguishable.
+
+Feature-specific values describe their own completeness. For example,
+completion uses `isIncomplete`, while diagnostics carry coverage, authority,
+and document/statement scope. One generic completeness flag is not used to
+mean unrelated things.
+
+If one provider fails but useful local evidence exists, the top-level result
+can remain ready with a failed provider report. Top-level failed means no
+usable answer could be produced.
+
+Raw `Error` and parser/provider payloads do not cross the stable boundary.
+
+## Feature methods
+
+Explicit methods are preferred over one generic `request({ kind })` API:
+
+```ts
+interface SqlDocumentSession<Context extends SqlDocumentContext> {
+  readonly revision: SqlRevision;
+
+  update(update: SqlDocumentUpdate<Context>): SqlRevision;
+
+  complete(
+    request: SqlCompletionRequest,
+  ): Promise<SqlRequestResult<SqlCompletionList>>;
+
+  diagnostics(
+    request?: SqlDiagnosticsRequest,
+  ): Promise<SqlRequestResult<SqlDiagnosticSet>>;
+
+  hover(
+    request: SqlPositionRequest,
+  ): Promise<SqlRequestResult<SqlHover | null>>;
+
+  definition(
+    request: SqlPositionRequest,
+  ): Promise<SqlRequestResult<readonly SqlLocation[]>>;
+
+  references(
+    request: SqlPositionRequest,
+  ): Promise<SqlRequestResult<readonly SqlLocation[]>>;
+
+  format(
+    request?: SqlFormatRequest,
+  ): Promise<SqlRequestResult<readonly SqlTextEdit[]>>;
+
+  isCurrent(revision: SqlRevision): boolean;
+  dispose(): void;
+}
+```
+
+The walking skeleton exposes only implemented features. Adding a method is
+backward-compatible; returning placeholder success from an unimplemented method
+is not.
+
+## Provider rules
+
+Providers are narrow and async-only. Pure range, change, identifier, and
+statement-index primitives remain synchronous.
+
+Provider requests contain:
+
+- Immutable source snapshot with distinctly named `originalText`,
+  `analysisText`, and source mapping
+- Explicit document context
+- Provider configuration identity
+- `AbortSignal`
+
+Each validator declares both `granularity: "document" | "statement"` and
+`input: "original" | "analysis"`. Regardless of input form, returned public
+ranges use original-document coordinates.
+
+They do not contain:
+
+- `EditorState` or `EditorView`
+- DOM or CodeMirror completion values
+- Mutable session objects
+- Caller-controlled revision stamps
+
+The service catches both synchronous throws during provider invocation and
+asynchronous rejection. Provider invocation must return control within a
+strict bounded synchronous budget. CPU-heavy or untrusted work runs in a worker
+or process because an `AbortSignal` cannot interrupt a blocked event loop. Once
+a promise exists, the service races public settlement against cancellation. It
+validates ranges and result limits before arbitration.
+
+Authority and arbitration are feature-specific:
+
+- Completion merges, deduplicates, and deterministically ranks.
+- Diagnostics use coverage and authority; they are not blindly unioned.
+- Hover can select or attribute sections.
+- Definitions use precedence, confidence, and provenance.
+- Formatting normally selects one provider.
+
+Provider completion order cannot affect final ordering.
+
+## Parser-neutral artifacts
+
+The walking skeleton normalizes only evidence needed by its first vertical
+slice:
+
+- Statement ranges and state
+- Tokens
+- Diagnostics
+- Normalized relation references
+- Cursor-context facts
+- Exact completion replacement range
+
+It does not expose `ast?: unknown` or attempt a universal SQL AST.
+
+The later semantic IR will model query blocks, set operations, relation
+bindings, column shapes, CTE order, correlation and `LATERAL`, clause-specific
+visibility, definitions/references, provenance, and explicit unknown shapes.
+That IR is prototyped against at least two parser implementations or materially
+different conformance corpora before stabilization.
+
+## Catalog contract
+
+Catalog access is lazy and bounded. Providers search and resolve within an
+explicit scope, prefix, object-kind set, and service-clamped result limit.
+Responses carry stable entity IDs, provider epoch, pagination, and coverage.
+
+Empty-complete and empty-loading are distinct. A miss supports a definite
+unknown-object diagnostic only when the response proves complete coverage for
+the searched scope.
+
+Catalog subscriptions are scoped and disposable. An invalidation identifies
+provider ID, affected scope, and:
+
+```ts
+interface SqlCatalogEpoch {
+  readonly generation: number;
+  readonly token: string;
+}
+```
+
+Generation is monotonic within one provider and scope; token identifies the
+provider snapshot. Lower out-of-order generations are discarded and equal
+generations are duplicates. Only sessions subscribed to the affected scope
+advance their public revision, and session disposal removes the subscription.
+Internal unchanged parse artifacts remain reusable.
+
+## Template contract
+
+The no-template default is an identity mapping. A source transformer produces a
+validated virtual document with copied, masked/opaque, or generated segments.
+
+Marimo braces initially use masking that preserves the exact UTF-16 length and
+every CR/LF code unit. Every other masked code unit becomes lexically inert
+whitespace, including each half of an astral character, so masking cannot join
+adjacent SQL tokens. More complex transformers use a versioned map whose
+segments are ordered, non-overlapping, and validated for original/generated
+coverage.
+
+Edits crossing an ambiguous or unmapped boundary are rejected. Mapping failure
+is unavailable analysis, not invalid SQL.
+
+## CodeMirror adapter
+
+The adapter creates one session per view and disposes it in
+`ViewPlugin.destroy()`. It translates `ChangeSet` values into one atomic session
+update and checks the result revision immediately before dispatch.
+
+It owns:
+
+- Focus and visibility scheduling
+- Debounce timers
+- Current request handles
+- CodeMirror facets and effects
+- Safe DOM rendering
+- Composition with external completion sources
+
+Context updates are explicit:
+
+```ts
+const support = sqlEditor({
+  service,
+  initialContext,
+  features: {
+    completion: true,
+    diagnostics: true,
+    hover: true,
+    navigation: true,
+    gutter: true,
+  },
+  completion: {
+    externalSources: [pythonExpressionCompletion],
+  },
+});
+
+const view = new EditorView({
+  doc,
+  extensions: [support.extension],
+});
+
+// Context-only convenience:
+support.setContext(view, nextContext);
+
+// Or update text and context atomically:
+view.dispatch({
+  changes,
+  effects: support.contextEffect.of(nextContext),
+});
+```
+
+The adapter installs one coherent `autocompletion` configuration. Package and
+external sources have deterministic ordering, deduplication, and tie-breaking.
+The support object contains no cross-view mutable session; `setContext` is a
+context-only convenience that dispatches `contextEffect` to the target view.
+Consumers use that public typed effect when text and context must change
+together. The adapter converts a document change and context effect in one
+CodeMirror transaction into one atomic session update, and highlighting and
+service interpretation change to the same registered dialect ID.
+
+A callback form may be added only with an explicit stable equality/key
+contract. Cursor motion must not accidentally invalidate context.
+
+Stable documentation data is plain text or Markdown. Default renderers never
+use provider or catalog values as `innerHTML`. A custom trusted renderer returns
+a DOM `Node` at the CodeMirror boundary.
+
+## Cache and cancellation model
+
+Revision identity and content reuse are separate.
+
+Recommended cache layers:
+
+```text
+document
+  → source transform
+  → statement index
+  → statement parse
+  → semantic artifact
+  → catalog resolution
+  → feature request
+```
+
+Parser artifacts use statement-relative coordinates so an unchanged moved
+statement can be reused and remapped. Keys include content fingerprint,
+dialect, parser/configuration, and template identities. Catalog changes do not
+invalidate parsing. Renderer, theme, focus, and cursor changes do not invalidate
+semantic artifacts.
+
+In-flight deduplication uses the same complete key. Cancelling one consumer
+detaches it; shared underlying work is aborted only when no consumers remain.
+Caches are bounded by both item count and estimated retained bytes.
+
+`AbortSignal` cannot interrupt any synchronous provider blocking the event
+loop. CPU-heavy or untrusted providers must run in a worker or process.
+
+## Lifecycle invariants
+
+- `dispose()` is idempotent.
+- Session disposal prevents publication immediately.
+- Pending requests settle exactly once as cancelled/disposed.
+- Late provider results are drained and discarded.
+- Catalog subscriptions, timers, and workers are released.
+- Service disposal disposes all child sessions before owned providers/workers.
+- One session's edit, context, focus, cancellation, or disposal cannot affect
+  another session sharing the service.
+
+## Walking skeleton
+
+The first implementation slice contains:
+
+1. Opaque revisions and runtime-validated ranges/changes.
+2. Session open, atomic update, current-revision, and disposal.
+3. Dialect-aware statement indexing with explicit cursor affinity.
+4. One internal parser adapter producing narrow normalized syntax evidence.
+5. One bounded relation-search catalog contract.
+6. `FROM`/`JOIN` relation completion with an exact edit range and provenance.
+7. A thin CodeMirror transaction/completion adapter.
+
+Deferred from this slice:
+
+- Full semantic scope graph
+- Multi-provider arbitration
+- Remote validation
+- Workers
+- Non-identity template transforms
+- Formatting
+- Streaming
+- Broad catalog materialization
+
+## Required contract tests
+
+- Revisions are monotonic through `A → B → A`.
+- Revisions from other sessions are never current.
+- Update ranges reject negative, fractional, reversed, overlapping, stale-base,
+  and out-of-bounds changes without partial mutation.
+- UTF-16 behavior is correct around astral characters, combining characters,
+  unpaired surrogates, CRLF, EOF, and empty ranges.
+- Text and context can update atomically.
+- Non-cloneable context rejects without changing text, context, or revision.
+- Caller mutation after open/update cannot change the owned context snapshot.
+- Context-only dialect/connection changes supersede dependent results.
+- Catalog invalidation does not reparse unchanged SQL.
+- Caller abort, supersession, and disposal settle promptly when a provider
+  ignores its signal.
+- Late resolve/reject causes no dispatch or unhandled rejection.
+- Provider throw and rejection normalize identically.
+- Invalid SQL, unsupported syntax, unavailable analysis, failure, and
+  cancellation remain distinct.
+- Invalid provider ranges are rejected without corrupting valid contributions.
+- Partial catalog misses never produce definite unknown-object diagnostics.
+- Duplicate/lower catalog generations are ignored per provider and scope.
+- Duplicate dialect IDs are rejected at service construction.
+- Identical SQL in different sessions/contexts cannot contaminate caches.
+- Shared work deduplicates without cross-consumer cancellation.
+- Moving the cursor does not reparse.
+- Fifty editors dispose without retained session state.
+- Packed consumer declarations compile with `skipLibCheck: false`.
+- The marimo fixture leaves no unresolved debounce promise.
+
+## Alternatives rejected
+
+### Stateless `analyze(text, context)`
+
+Simple, but it loses session lifecycle, bounded incremental caches, shared-work
+coordination, subscriptions, and a natural stale-result boundary.
+
+### One generic request method
+
+Small in line count but weakly discoverable, poorly narrowed, and easy to
+misuse. Explicit feature methods provide clearer types.
+
+### One mega-provider
+
+Optional methods obscure capability and authority, encourage shared mutable
+state, and couple unrelated features. Providers remain narrow.
+
+### Public universal AST
+
+It would either leak the first parser's shapes or become an unstable lowest
+common denominator. Only narrow normalized evidence is exposed initially.
+
+### Provider-owned revisions
+
+A stale provider could stamp a result as current. Only the service owns result
+revisions.
+
+### Parser receives `EditorState`
+
+This makes dependencies implicit and couples the core to CodeMirror. The
+adapter extracts explicit context instead.
+
+## Consequences
+
+The architecture requires more deliberate lifecycle and result types than
+v0.x. In exchange, it makes stale publication, incomplete catalog evidence,
+provider failure, and cross-editor state leakage testable invariants.
+
+Marimo can delete `CustomSqlParser`: remote validation becomes a
+document-diagnostics provider, focus becomes scheduling policy, engine/dialect
+changes become context updates, braces become a source transformer, and Python
+completion remains an external CodeMirror completion source.
+
+Legacy `SqlParser`, `NodeSqlParser`, `SqlStructureAnalyzer`, and
+`QueryContextAnalyzer` are not part of the next-major stable API.

--- a/docs/vnext/capability-charter.md
+++ b/docs/vnext/capability-charter.md
@@ -1,0 +1,280 @@
+# vNext Capability Charter
+
+Status: accepted  
+Date: 2026-07-24
+
+## Product boundary
+
+vNext is a framework-independent SQL language service with a first-class
+CodeMirror 6 adapter. It provides local editor intelligence and composes
+optional catalog, database-native, formatter, and remote validation providers.
+It does not execute queries.
+
+The service must remain useful in a browser with no backend. Native and remote
+providers augment that local baseline; they do not silently replace unrelated
+local evidence.
+
+## Initial dialect tiers
+
+Dialect support is capability-scoped. A dialect is not described as
+"supported" without naming the feature.
+
+### Conformance targets
+
+The first release candidate targets:
+
+- DuckDB
+- PostgreSQL
+- BigQuery
+
+Each target needs checked-in valid, invalid, incomplete, templated, and
+multi-statement corpora. Syntax status, statement boundaries, identifier rules,
+relation and column resolution, and feature availability are tested
+independently.
+
+DuckDB is the reference native-provider integration. BigQuery is the reference
+for multi-part identifiers and non-PostgreSQL quoting. PostgreSQL is the
+reference baseline for broadly implemented relational syntax.
+
+### Compatibility dialects
+
+Dremio, SQLite, MySQL, and other existing parser dialects may ship with a
+smaller declared capability set. Highlighting or parser acceptance alone does
+not imply semantic diagnostics, navigation, formatting, or complete
+autocomplete.
+
+A compatibility dialect graduates to a conformance target only after it has an
+owned corpus and explicit feature matrix. Hosts can register experimental
+dialects without making them part of the stable compatibility promise.
+
+## Initial SQL constructs
+
+The first release candidate targets:
+
+- Multiple statements with dialect-aware boundaries
+- `SELECT`, `FROM`, joins, filters, grouping, ordering, and limits
+- CTEs, including declaration-order visibility
+- Derived tables and nested query blocks
+- Set operations
+- Qualified and unqualified relation and column references
+- Aliases with clause-specific visibility
+- Common parameters and quoted identifiers
+- Comments, strings, incomplete input, and error recovery
+- Template regions that can be masked or mapped without corrupting offsets
+
+DDL, procedural SQL, macros, table functions, vendor extensions, recursive
+CTEs, `LATERAL`, `PIVOT`, and nested/structured types must report their actual
+analysis quality. They are not assumed semantically complete merely because a
+parser accepts them.
+
+## Feature target
+
+The stable session API is intended to support:
+
+- Keyword, relation, column, function, and snippet completion
+- Syntax, semantic, and host-provided diagnostics
+- Hover documentation
+- Definition, references, highlight, and rename
+- Statement and structure indicators
+- Explicit formatting through a selected formatter provider
+
+The walking skeleton implements relation completion first. Subsequent features
+reuse the same session, revision, range, cancellation, provenance, and result
+contracts. No feature gets a separate parser or schema configuration.
+
+## Correctness contract
+
+Every public source range is:
+
+- Absolute in the original document
+- Measured in UTF-16 code units
+- Half-open: `[from, to)`
+- Validated before it can reach a consumer
+
+Every asynchronous result carries a service-generated opaque revision. Text,
+dialect, connection, template, relevant catalog, or provider-configuration
+changes advance the affected session revision. The service does not settle a
+request as ready if it is already superseded at settlement. Consumers, and
+always the CodeMirror adapter, check currency again immediately before applying
+a ready result.
+
+The service distinguishes:
+
+- Invalid SQL
+- Recovered or partial analysis
+- Unsupported capability
+- Loading or incomplete catalog evidence
+- Provider failure
+- Caller cancellation
+- Supersession
+- Disposal
+
+An absent or partial catalog cannot justify a definite unknown-object
+diagnostic.
+
+## Provider boundary
+
+Providers are separated by feature concern. They receive immutable plain-data
+requests and an `AbortSignal`; they never receive `EditorState`, `EditorView`,
+DOM values, mutable sessions, or caller-controlled revisions.
+
+Providers declare whether they consume original or transformed analysis text.
+All public ranges are mapped to the original document.
+
+Provider invocation must return control within a bounded synchronous budget.
+After a promise is obtained, the service races publication against cancellation
+even when the underlying promise ignores its signal. CPU-heavy or untrusted
+work runs in a worker or process.
+
+The stable external extension points are expected to include:
+
+- Catalog search and resolution
+- Completion augmentation
+- Document and statement diagnostics
+- Formatter selection
+- Hover and navigation augmentation
+
+Parser, statement-boundary, worker, and semantic-IR interfaces remain
+experimental until conformance tests cover at least two materially different
+implementations. Parser-specific AST types are never part of the stable root
+API.
+
+Document-granularity and statement-granularity validators are distinct
+contracts. A scheduler must not silently invoke a whole-document engine
+validator once per statement.
+
+## Catalog boundary
+
+The canonical catalog API is asynchronous, bounded, versioned, and explicit
+about coverage. It does not require a host to materialize one complete nested
+`SQLNamespace`.
+
+Catalog requests must support scoped search and resolution with result limits.
+Responses distinguish loading, partial, complete, failed, and paginated
+coverage. Stable entity identity and provider epochs prevent evidence from
+different catalog states being combined as authoritative.
+
+Catalog invalidation identifies provider, affected scope, and an epoch
+containing a provider/scope-monotonic generation plus opaque snapshot token.
+Lower generations are discarded and equal generations are duplicates. Only
+subscribed sessions advance their public revision. Internal unchanged statement
+parse artifacts remain reusable.
+
+## Template boundary
+
+The original document remains the canonical coordinate space. A template
+transformer produces either:
+
+- A length-preserving masked analysis document, or
+- A validated, versioned source map
+
+Completion edits crossing ambiguous mappings are rejected. Diagnostics wholly
+inside generated text are dropped or explicitly anchored. Mapping failure is
+an unavailable analysis capability, not evidence that the SQL is invalid.
+
+Length-preserving masks retain every UTF-16 code unit count and every CR/LF code
+unit. Each other masked code unit becomes lexically inert whitespace so adjacent
+tokens cannot be joined accidentally.
+
+Mapped segments are ordered, non-overlapping, and validated for original and
+generated coverage. Marimo `{...}` expressions are the first template
+conformance target.
+
+## Runtime and packaging support
+
+The release target is:
+
+- ESM packages
+- Node.js 20.19 and newer for package import and non-DOM core use
+- CodeMirror 6 peer dependencies
+- Current evergreen Chromium, Firefox, and WebKit families
+- Browser bundlers that honor package `exports`
+- SSR-safe import of core modules
+
+Exact minimum peer versions, browser versions, and supported bundler releases
+are recorded in the release capability matrix and exercised through packed
+consumer fixtures. A declared runtime is not supported unless its fixture runs
+in CI.
+
+The exact subpath layout is deferred to a packaging ADR after the walking
+skeleton produces bundle and packed-consumer evidence. Packaging must provide:
+
+- An SSR-safe, framework-independent core entry
+- An explicit CodeMirror entry
+- Explicit dialect entry points
+- Independently importable optional parser/provider integrations
+- No accidental transitive import of optional parsers or providers into core
+
+## Provisional performance envelopes
+
+These are product envelopes, not claims about the current implementation.
+Benchmark baselines and raw samples must replace provisional values before the
+release candidate.
+
+For a warm local service, a 10 KiB document, and a 10,000-relation indexed
+catalog:
+
+- Keystroke bookkeeping: p95 under 8 ms
+- Active-statement local analysis: p95 under 16 ms
+- Local completion response: p95 under 50 ms
+- Local diagnostics response: p95 under 150 ms
+- No routine main-thread task over 50 ms
+
+For a 1 MiB document, the service may degrade to active-statement intelligence,
+but editing must remain responsive and the degraded state must be explicit.
+
+Fifty mounted editors must have bounded retained memory after disposal and must
+share immutable dialect/catalog data. Cache budgets are enforced by both entry
+count and estimated retained bytes.
+
+Provisional compressed bundle budgets:
+
+- Core plus CodeMirror adapter, excluding parser and dialect data: 75 KiB
+- Each ordinary dialect module: 25 KiB
+- Optional `node-sql-parser` chunk: no regression from its recorded baseline
+  without an approved ADR
+
+## Security and robustness
+
+- Default renderers do not insert provider or catalog strings with
+  `innerHTML`.
+- Stable documentation values are plain text or Markdown data.
+- Provider ranges, edits, continuation tokens, and result sizes are validated.
+- Catalog and completion result counts are clamped.
+- Provider throws and rejections are normalized; raw errors do not cross the
+  stable boundary.
+- After provider invocation returns a promise, cancellation settles publication
+  promptly even when that promise ignores its signal.
+- Late provider resolution is drained without dispatch or unhandled rejection.
+- `dispose()` is idempotent and settles all pending requests.
+
+## Explicit non-goals
+
+vNext is not:
+
+- A SQL execution engine
+- A query optimizer
+- A complete database type checker
+- A guarantee that one browser parser accepts every vendor extension
+- An LSP transport implementation
+- A mandatory full-catalog loader
+- A generic universal SQL AST
+- A compatibility wrapper around mutable v0.x parser/analyzer classes
+
+Legacy behavior can be retained in migration helpers, but it does not constrain
+the next-major architecture.
+
+## Release evidence
+
+Before vNext is stable:
+
+- Every conformance target has an explicit feature matrix and corpus.
+- Repository coverage meets the thresholds in `implementation.md`.
+- Critical revision, range, mapping, cancellation, and arbitration logic has
+  mutation evidence.
+- Browser, package, SSR, marimo, fuzz, leak, and benchmark gates pass.
+- Bundle and latency budgets compare against both `main` and the previous
+  `dev-refactor` checkpoint.
+- The marimo fixture proves remote DuckDB validation, connection changes,
+  partial catalogs, Python-expression completion, rapid edits, and disposal.
+- Unsupported and partial states are documented and visible to consumers.


### PR DESCRIPTION
Defines the accepted vNext capability charter and ADR 0001 before runtime implementation. The decision establishes a shared framework-independent language service, one disposable session per document, atomic revision-guarded updates, original-document UTF-16 ranges, explicit request outcomes, scoped catalog epochs, provider source forms, and a thin CodeMirror lifecycle adapter.\n\nThe contracts were derived from the repository research and current marimo integration, then iterated through three fresh-context design reviews and two blocker-resolution loops. Local lint, typecheck, test integrity, workflow validation, diff checks, and aggregate coverage pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds ADR 0001 and a capability charter defining the vNext SQL language-service contracts. Establishes a framework-agnostic service with per-document sessions, atomic revision-guarded updates, original-document UTF-16 ranges, unified request outcomes, and a thin `CodeMirror` adapter ahead of runtime work.

- **New Features**
  - Shared `SqlLanguageService` and per-document `SqlDocumentSession` with atomic text/context updates.
  - Opaque session revisions; all results carry a revision and require a currency check before apply.
  - Standard UTF-16 half-open original-document ranges and validated incremental changes.
  - Unified request outcomes (ready, unavailable, cancelled, failed) with clear cancellation and provider reports.
  - Narrow async provider boundary (no editor/DOM), bounded sync budget, worker-friendly guidance.
  - Catalog epochs with scoped invalidation; template masking/mapping preserving original offsets; thin `CodeMirror` adapter; walking-skeleton scope (relation completion first).

<sup>Written for commit 66853b3d7a4af12afa01c06a9b7b7113459c4ab5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marimo-team/codemirror-sql/pull/171?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

