### PR TITLE
feat(vnext): add atomic document sessions

### DIFF
--- a/docs/adr/0001-language-service-and-session.md
+++ b/docs/adr/0001-language-service-and-session.md
@@ -149,13 +149,15 @@ update without partial mutation.
 The public revision is an opaque immutable service-generated token. Callers
 cannot construct one or supply their own version number.
 
-Internally, the revision records:
+Internally, the session snapshot associated with the revision tracks:
 
-- Session identity
 - Monotonic sequence
 - Document revision
 - Context and template revision
-- Relevant environment/catalog epoch
+
+Relevant environment/catalog epochs will join that snapshot when those
+subsystems are implemented. The revision token itself remains only an opaque
+immutable identity; it does not duplicate snapshot metadata.
 
 The public model is deliberately global per session: any accepted text,
 context, template, relevant catalog, or provider-configuration invalidation

--- a/docs/adr/0001-language-service-and-session.md
+++ b/docs/adr/0001-language-service-and-session.md
@@ -125,8 +125,10 @@ The session updates text and context atomically:
 
 ```ts
 session.update({
+  kind: "document",
   baseRevision: session.revision,
   document: {
+    kind: "changes",
     changes: [{ from: 14, to: 19, insert: "customers" }],
   },
   context: nextContext,
@@ -251,34 +253,34 @@ Explicit methods are preferred over one generic `request({ kind })` API:
 interface SqlDocumentSession<Context extends SqlDocumentContext> {
   readonly revision: SqlRevision;
 
-  update(update: SqlDocumentUpdate<Context>): SqlRevision;
+  readonly update: (update: SqlDocumentUpdate<Context>) => SqlRevision;
 
-  complete(
+  readonly complete: (
     request: SqlCompletionRequest,
-  ): Promise<SqlRequestResult<SqlCompletionList>>;
+  ) => Promise<SqlRequestResult<SqlCompletionList>>;
 
-  diagnostics(
+  readonly diagnostics: (
     request?: SqlDiagnosticsRequest,
-  ): Promise<SqlRequestResult<SqlDiagnosticSet>>;
+  ) => Promise<SqlRequestResult<SqlDiagnosticSet>>;
 
-  hover(
+  readonly hover: (
     request: SqlPositionRequest,
-  ): Promise<SqlRequestResult<SqlHover | null>>;
+  ) => Promise<SqlRequestResult<SqlHover | null>>;
 
-  definition(
+  readonly definition: (
     request: SqlPositionRequest,
-  ): Promise<SqlRequestResult<readonly SqlLocation[]>>;
+  ) => Promise<SqlRequestResult<readonly SqlLocation[]>>;
 
-  references(
+  readonly references: (
     request: SqlPositionRequest,
-  ): Promise<SqlRequestResult<readonly SqlLocation[]>>;
+  ) => Promise<SqlRequestResult<readonly SqlLocation[]>>;
 
-  format(
+  readonly format: (
     request?: SqlFormatRequest,
-  ): Promise<SqlRequestResult<readonly SqlTextEdit[]>>;
+  ) => Promise<SqlRequestResult<readonly SqlTextEdit[]>>;
 
-  isCurrent(revision: SqlRevision): boolean;
-  dispose(): void;
+  readonly isCurrent: (revision: SqlRevision) => boolean;
+  readonly dispose: () => void;
 }
 ```
 

--- a/docs/vnext/session-primitives.md
+++ b/docs/vnext/session-primitives.md
@@ -1,0 +1,76 @@
+# vNext Session Primitives
+
+Status: experimental walking skeleton  
+Import: `@marimo-team/codemirror-sql/vnext`
+
+This entry point currently provides document ownership, atomic text/context
+updates, opaque revisions, dialect registration, and lifecycle management. It
+does not yet provide parsing, completion, diagnostics, hover, or navigation.
+Those methods will be added only with working vertical slices.
+
+## Example
+
+```ts
+import {
+  createSqlLanguageService,
+  defineSqlDialect,
+  type SqlDocumentContext,
+} from "@marimo-team/codemirror-sql/vnext";
+
+interface AppSqlContext extends SqlDocumentContext {
+  readonly engine: string;
+}
+
+const service = createSqlLanguageService<AppSqlContext>({
+  dialects: [
+    defineSqlDialect({ id: "duckdb", displayName: "DuckDB" }),
+  ],
+});
+
+const session = service.openDocument({
+  text: "SELECT * FROM users",
+  context: { dialect: "duckdb", engine: "local" },
+});
+
+const revision = session.update({
+  kind: "document",
+  baseRevision: session.revision,
+  document: {
+    kind: "changes",
+    changes: [{ from: 14, to: 19, insert: "customers" }],
+  },
+});
+
+if (session.isCurrent(revision)) {
+  // Results produced for this revision may still be applied.
+}
+
+session.dispose();
+service.dispose();
+```
+
+Use `{ kind: "replace", text }` for full replacement and
+`{ kind: "context", baseRevision, context }` for a context-only update.
+
+## Contract
+
+- Every accepted update creates a new frozen, service-issued revision.
+- `baseRevision` is checked by identity and cannot come from another session.
+- Incremental ranges are ordered, non-overlapping, half-open UTF-16 offsets in
+  the pre-update document.
+- Text and context are validated completely before the session snapshot changes.
+- Context is structured-cloned and recursively frozen. Accepted values are
+  finite primitives, arrays, and string-keyed plain objects. Cycles and shared
+  references are retained. Accessors, symbols, functions, class instances,
+  typed collections, and non-finite numbers are rejected.
+- Session and service disposal are idempotent and terminal.
+- Synchronous public failures use `SqlSessionError` and a stable `code`; caught
+  platform errors are not exposed as causes.
+
+The safety envelope currently permits at most 10,000 changes in one update, a
+16 Mi-code-unit document, 1,000 registered dialects, and bounded context graph
+depth, size, properties, and string data. These are defensive walking-skeleton
+limits, not release performance claims.
+
+The `/vnext` name is provisional until the packaging ADR fixes the next-major
+subpath layout.

--- a/docs/vnext/session-primitives.md
+++ b/docs/vnext/session-primitives.md
@@ -63,6 +63,8 @@ Use `{ kind: "replace", text }` for full replacement and
   finite primitives, arrays, and string-keyed plain objects. Cycles and shared
   references are retained. Accessors, symbols, functions, class instances,
   typed collections, and non-finite numbers are rejected.
+- Public service and session operations remain bound when passed as callbacks
+  or destructured.
 - Session and service disposal are idempotent and terminal.
 - Synchronous public failures use `SqlSessionError` and a stable `code`; caught
   platform errors are not exposed as causes.

--- a/implementation.md
+++ b/implementation.md
@@ -590,6 +590,19 @@ disposition. Validate them through a protected reusable workflow from the base
 branch so a PR cannot approve itself. Maintainers approve classification
 overrides and rejected blocking findings.
 
+Request GitHub Copilot review on every medium or large PR after the head commit
+is ready for review:
+
+```bash
+gh pr edit <number> --add-reviewer @copilot
+```
+
+Copilot is an additional advisory review, not one of the two independent
+commit-bound adversarial attestations and not a substitute for human approval.
+Resolve or explicitly disposition its actionable comments in the finding
+ledger. Re-request review after a material rewrite when the prior comments no
+longer cover the current head.
+
 ## CI architecture
 
 ### Required fast PR lane
@@ -801,10 +814,11 @@ Before semantic implementation:
 12. Add the invariant registry and test-suite integrity checks.
 13. Add PR risk template and review-packet generation.
 14. Add protected, commit-bound two-reviewer checks.
-15. Add verified-artifact provenance to release CI.
-16. Add nightly mutation, fuzz, cross-browser, leak, and performance workflows.
-17. Add expiring scheduled-health and deduplicated failure issues.
-18. Define the supported runtime and dependency matrix.
+15. Automate GitHub Copilot review requests for medium and large PRs.
+16. Add verified-artifact provenance to release CI.
+17. Add nightly mutation, fuzz, cross-browser, leak, and performance workflows.
+18. Add expiring scheduled-health and deduplicated failure issues.
+19. Define the supported runtime and dependency matrix.
 
 ## Final recommendation
 

--- a/package.json
+++ b/package.json
@@ -78,6 +78,12 @@
         "default": "./dist/dialects/index.js"
       }
     },
+    "./vnext": {
+      "import": {
+        "types": "./dist/vnext/index.d.ts",
+        "default": "./dist/vnext/index.js"
+      }
+    },
     "./data/common-keywords.json": "./src/data/common-keywords.json",
     "./data/duckdb-keywords.json": "./src/data/duckdb-keywords.json"
   },

--- a/scripts/package-smoke.mjs
+++ b/scripts/package-smoke.mjs
@@ -4,6 +4,7 @@ import {
   mkdirSync,
   mkdtempSync,
   readFileSync,
+  renameSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
@@ -110,6 +111,29 @@ try {
   }
 
   writeFileSync(
+    join(temporaryDirectory, "vnext-consumer.mjs"),
+    `import {
+  createSqlLanguageService,
+  defineSqlDialect,
+} from "@marimo-team/codemirror-sql/vnext";
+
+const service = createSqlLanguageService({
+  dialects: [defineSqlDialect({ displayName: "DuckDB", id: "duckdb" })],
+});
+const session = service.openDocument({
+  context: { dialect: "duckdb" },
+  text: "SELECT 1",
+});
+session.update({
+  kind: "document",
+  baseRevision: session.revision,
+  document: { kind: "replace", text: "SELECT 2" },
+});
+service.dispose();
+`,
+  );
+
+  writeFileSync(
     join(temporaryDirectory, "consumer.mts"),
     `import type { Extension } from "@codemirror/state";
 import {
@@ -122,17 +146,39 @@ import {
   DremioDialect,
   DuckDBDialect,
 } from "@marimo-team/codemirror-sql/dialects";
+import {
+  createSqlLanguageService,
+  defineSqlDialect,
+  type SqlDocumentContext,
+} from "@marimo-team/codemirror-sql/vnext";
 import commonKeywords from "@marimo-team/codemirror-sql/data/common-keywords.json" with { type: "json" };
 import duckdbKeywords from "@marimo-team/codemirror-sql/data/duckdb-keywords.json" with { type: "json" };
+
+interface HostContext extends SqlDocumentContext {
+  readonly engine: string;
+}
 
 const extensions: Extension[] = [
   sqlCompletion({ dialect: DuckDBDialect }),
   sqlExtension(),
 ];
 const parser = new NodeSqlParser();
+const service = createSqlLanguageService<HostContext>({
+  dialects: [defineSqlDialect({ displayName: "DuckDB", id: "duckdb" })],
+});
+const session = service.openDocument({
+  context: { dialect: "duckdb", engine: "local" },
+  text: "SELECT 1",
+});
+session.update({
+  kind: "document",
+  baseRevision: session.revision,
+  document: { kind: "changes", changes: [{ from: 7, insert: "2", to: 8 }] },
+});
 
 void extensions;
 void parser;
+void session;
 void BigQueryDialect;
 void DremioDialect;
 void commonKeywords;
@@ -145,6 +191,7 @@ void duckdbKeywords;
     `import { EditorState } from "@codemirror/state";
 import * as api from "@marimo-team/codemirror-sql";
 import * as dialects from "@marimo-team/codemirror-sql/dialects";
+import * as vnext from "@marimo-team/codemirror-sql/vnext";
 import commonKeywords from "@marimo-team/codemirror-sql/data/common-keywords.json" with { type: "json" };
 import duckdbKeywords from "@marimo-team/codemirror-sql/data/duckdb-keywords.json" with { type: "json" };
 
@@ -153,6 +200,12 @@ if (typeof api.sqlExtension !== "function" || typeof api.NodeSqlParser !== "func
 }
 if (!dialects.BigQueryDialect || !dialects.DremioDialect || !dialects.DuckDBDialect) {
   throw new Error("Dialect package exports are incomplete");
+}
+if (
+  typeof vnext.createSqlLanguageService !== "function" ||
+  typeof vnext.defineSqlDialect !== "function"
+) {
+  throw new Error("vNext package exports are incomplete");
 }
 if (!commonKeywords.keywords || !duckdbKeywords.keywords) {
   throw new Error("Keyword data exports are incomplete");
@@ -163,6 +216,24 @@ const parseResult = await new api.NodeSqlParser().parse("SELECT 1", { state });
 if (!parseResult.success || !parseResult.ast) {
   throw new Error("The packaged parser could not load its runtime dependency");
 }
+
+const service = vnext.createSqlLanguageService({
+  dialects: [vnext.defineSqlDialect({ displayName: "DuckDB", id: "duckdb" })],
+});
+const session = service.openDocument({
+  context: { dialect: "duckdb" },
+  text: "SELECT 1",
+});
+const originalRevision = session.revision;
+const updatedRevision = session.update({
+  kind: "document",
+  baseRevision: originalRevision,
+  document: { kind: "replace", text: "SELECT 2" },
+});
+if (session.isCurrent(originalRevision) || !session.isCurrent(updatedRevision)) {
+  throw new Error("The packaged vNext session violated revision identity");
+}
+service.dispose();
 `,
   );
 
@@ -186,6 +257,20 @@ if (!parseResult.success || !parseResult.ast) {
   );
 
   runPackageManager(["exec", "tsc", "--project", "tsconfig.json"], temporaryDirectory);
+  const isolatedDependencies = [
+    join(temporaryDirectory, "node_modules", "node-sql-parser"),
+    join(temporaryDirectory, "node_modules", "@codemirror"),
+  ];
+  for (const dependency of isolatedDependencies) {
+    renameSync(dependency, `${dependency}.isolated`);
+  }
+  try {
+    run(process.execPath, ["vnext-consumer.mjs"], temporaryDirectory);
+  } finally {
+    for (const dependency of isolatedDependencies) {
+      renameSync(`${dependency}.isolated`, dependency);
+    }
+  }
   run(process.execPath, ["consumer.mjs"], temporaryDirectory);
 } finally {
   if (basename(temporaryDirectory).startsWith("codemirror-sql-package-")) {

--- a/scripts/package-smoke.mjs
+++ b/scripts/package-smoke.mjs
@@ -1,6 +1,7 @@
 import { execFileSync } from "node:child_process";
 import {
   copyFileSync,
+  existsSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
@@ -40,7 +41,66 @@ function runPackageManager(args, cwd) {
   run(process.execPath, [packageManagerExecutable, ...args], cwd);
 }
 
+function withRenamedPaths(paths, operation) {
+  const renamedPaths = [];
+  let operationError;
+  let operationFailed = false;
+  try {
+    for (const path of paths) {
+      renameSync(path, `${path}.isolated`);
+      renamedPaths.push(path);
+    }
+    operation();
+  } catch (error) {
+    operationFailed = true;
+    operationError = error;
+  }
+
+  const restorationErrors = [];
+  for (const path of renamedPaths.reverse()) {
+    try {
+      renameSync(`${path}.isolated`, path);
+    } catch (error) {
+      restorationErrors.push(error);
+    }
+  }
+  if (restorationErrors.length > 0) {
+    throw new AggregateError(
+      operationFailed
+        ? [operationError, ...restorationErrors]
+        : restorationErrors,
+      "Package isolation failed and could not restore every dependency",
+    );
+  }
+  if (operationFailed) {
+    throw operationError;
+  }
+}
+
+function verifyRenameRollback(directory) {
+  const existingPath = join(directory, "isolation-rollback");
+  mkdirSync(existingPath);
+  let failed = false;
+  try {
+    withRenamedPaths(
+      [existingPath, join(directory, "missing-isolation-path")],
+      () => {},
+    );
+  } catch {
+    failed = true;
+  }
+  if (
+    !failed ||
+    !existsSync(existingPath) ||
+    existsSync(`${existingPath}.isolated`)
+  ) {
+    throw new Error("Package isolation did not roll back a partial rename");
+  }
+  rmSync(existingPath, { recursive: true });
+}
+
 try {
+  verifyRenameRollback(temporaryDirectory);
   const packageManagerVersion = execFileSync(
     process.execPath,
     [packageManagerExecutable, "--version"],
@@ -261,16 +321,9 @@ service.dispose();
     join(temporaryDirectory, "node_modules", "node-sql-parser"),
     join(temporaryDirectory, "node_modules", "@codemirror"),
   ];
-  for (const dependency of isolatedDependencies) {
-    renameSync(dependency, `${dependency}.isolated`);
-  }
-  try {
+  withRenamedPaths(isolatedDependencies, () => {
     run(process.execPath, ["vnext-consumer.mjs"], temporaryDirectory);
-  } finally {
-    for (const dependency of isolatedDependencies) {
-      renameSync(`${dependency}.isolated`, dependency);
-    }
-  }
+  });
   run(process.execPath, ["consumer.mjs"], temporaryDirectory);
 } finally {
   if (basename(temporaryDirectory).startsWith("codemirror-sql-package-")) {

--- a/src/vnext/__tests__/session.test.ts
+++ b/src/vnext/__tests__/session.test.ts
@@ -1,0 +1,1138 @@
+import { describe, expect, it } from "vitest";
+import {
+  createSqlLanguageService,
+  defineSqlDialect,
+  SqlSessionError,
+} from "../index.js";
+import { DefaultSqlLanguageService } from "../session.js";
+import type {
+  SqlDocumentContext,
+  SqlDocumentReplacement,
+} from "../types.js";
+
+interface TestContext extends SqlDocumentContext {
+  readonly engine: string;
+  readonly settings?: {
+    readonly flags: readonly boolean[];
+  };
+}
+
+const duckdb = defineSqlDialect({
+  displayName: "DuckDB",
+  id: "duckdb",
+});
+const postgres = defineSqlDialect({
+  displayName: "PostgreSQL",
+  id: "postgres",
+});
+
+function createService() {
+  return new DefaultSqlLanguageService<TestContext>({
+    dialects: [duckdb, postgres],
+  });
+}
+
+function openSession(text = "SELECT * FROM users") {
+  const service = createService();
+  const session = service.openDocument({
+    context: { dialect: "duckdb", engine: "local" },
+    text,
+  });
+  return { service, session };
+}
+
+function expectSessionError(code: SqlSessionError["code"], callback: () => unknown) {
+  try {
+    callback();
+  } catch (error) {
+    expect(error).toBeInstanceOf(SqlSessionError);
+    expect((error as SqlSessionError).code).toBe(code);
+    return;
+  }
+  throw new Error(`Expected SqlSessionError: ${code}`);
+}
+
+describe("dialect definitions", () => {
+  it("creates immutable definitions", () => {
+    expect(duckdb).toEqual({ displayName: "DuckDB", id: "duckdb" });
+    expect(Object.isFrozen(duckdb)).toBe(true);
+  });
+
+  it.each([
+    [{ displayName: "DuckDB", id: " " }, "SQL dialect id must contain 1 to 256"],
+    [
+      { displayName: " ", id: "duckdb" },
+      "SQL dialect display name must contain 1 to 1024",
+    ],
+  ])("rejects invalid definitions", (definition, message) => {
+    expect(() => defineSqlDialect(definition)).toThrow(message);
+  });
+
+  it("rejects duplicate IDs", () => {
+    expectSessionError("duplicate-dialect", () => {
+      createSqlLanguageService({
+        dialects: [duckdb, { displayName: "Other", id: "duckdb" }],
+      });
+    });
+  });
+
+  it("normalizes malformed definitions without invoking accessors", () => {
+    let invoked = false;
+    expectSessionError("invalid-dialect", () => {
+      defineSqlDialect({
+        displayName: "DuckDB",
+        get id() {
+          invoked = true;
+          return "duckdb";
+        },
+      });
+    });
+    expect(invoked).toBe(false);
+    expectSessionError("invalid-dialect", () => {
+      defineSqlDialect({ displayName: "DuckDB", id: 42 } as never);
+    });
+    expectSessionError("invalid-dialect", () => {
+      defineSqlDialect(null as never);
+    });
+    expectSessionError("invalid-dialect", () => {
+      defineSqlDialect(
+        new Proxy(
+          {},
+          {
+            getOwnPropertyDescriptor() {
+              throw new Error("hostile");
+            },
+          },
+        ) as never,
+      );
+    });
+  });
+
+  it("returns only normalized dialect fields", () => {
+    const extendedDefinition = {
+      displayName: "DuckDB",
+      id: "duckdb",
+      internal: true,
+    };
+    const definition = defineSqlDialect(extendedDefinition);
+    expect(definition).toEqual({ displayName: "DuckDB", id: "duckdb" });
+  });
+});
+
+describe("document revisions", () => {
+  it("starts with a frozen current revision", () => {
+    const { session } = openSession();
+    expect(Object.isFrozen(session.revision)).toBe(true);
+    expect(session.isCurrent(session.revision)).toBe(true);
+  });
+
+  it("advances monotonically, including A to B to A", () => {
+    const { session } = openSession("A");
+    const first = session.revision;
+    const second = session.update({
+      kind: "document",
+      baseRevision: first,
+      document: { kind: "replace", text: "B" },
+    });
+    const third = session.update({
+      kind: "document",
+      baseRevision: second,
+      document: { kind: "replace", text: "A" },
+    });
+
+    expect(session.isCurrent(first)).toBe(false);
+    expect(session.isCurrent(second)).toBe(false);
+    expect(session.isCurrent(third)).toBe(true);
+    expect(third).not.toBe(first);
+  });
+
+  it("never accepts another session's revision", () => {
+    const first = openSession();
+    const second = openSession();
+
+    expect(first.session.isCurrent(second.session.revision)).toBe(false);
+    expectSessionError("stale-revision", () => {
+      first.session.update({
+        kind: "document",
+        baseRevision: second.session.revision,
+        document: { kind: "replace", text: "SELECT 1" },
+      });
+    });
+  });
+
+  it("rejects fabricated revisions", () => {
+    const { session } = openSession();
+    expect(session.isCurrent({} as never)).toBe(false);
+  });
+
+  it("makes an empty accepted update a new revision", () => {
+    const { session } = openSession();
+    const first = session.revision;
+    const second = session.update({
+      kind: "document",
+      baseRevision: first,
+      document: { kind: "changes", changes: [] },
+    });
+    expect(second).not.toBe(first);
+    expect(session.isCurrent(second)).toBe(true);
+  });
+
+  it("makes a same-text replacement a new revision", () => {
+    const { session } = openSession("SELECT 1");
+    const first = session.revision;
+    const second = session.update({
+      kind: "document",
+      baseRevision: first,
+      document: { kind: "replace", text: "SELECT 1" },
+    });
+    expect(second).not.toBe(first);
+  });
+});
+
+describe("document changes", () => {
+  it("applies ordered changes in pre-update coordinates", () => {
+    const { session } = openSession("SELECT users.id FROM users");
+    session.update({
+      kind: "document",
+      baseRevision: session.revision,
+      document: {
+        kind: "changes",
+        changes: [
+          { from: 7, insert: "customers", to: 12 },
+          { from: 21, insert: "customers", to: 26 },
+        ],
+      },
+    });
+
+    expect(session.snapshotForTesting.text).toBe(
+      "SELECT customers.id FROM customers",
+    );
+  });
+
+  it("uses JavaScript UTF-16 offsets", () => {
+    const { session } = openSession("A😀B");
+    session.update({
+      kind: "document",
+      baseRevision: session.revision,
+      document: {
+        kind: "changes",
+        changes: [{ from: 1, insert: "X", to: 3 }],
+      },
+    });
+    expect(session.snapshotForTesting.text).toBe("AXB");
+  });
+
+  it("keeps same-position insertions ordered", () => {
+    const { session } = openSession("AB");
+    session.update({
+      kind: "document",
+      baseRevision: session.revision,
+      document: {
+        kind: "changes",
+        changes: [
+          { from: 1, insert: "1", to: 1 },
+          { from: 1, insert: "2", to: 1 },
+        ],
+      },
+    });
+    expect(session.snapshotForTesting.text).toBe("A12B");
+  });
+
+  it("supports adjacent replacements and document boundaries", () => {
+    const { session } = openSession("ABCDE");
+    session.update({
+      kind: "document",
+      baseRevision: session.revision,
+      document: {
+        kind: "changes",
+        changes: [
+          { from: 0, insert: "X", to: 1 },
+          { from: 1, insert: "Y", to: 3 },
+          { from: 3, insert: "Z", to: 5 },
+          { from: 5, insert: "!", to: 5 },
+        ],
+      },
+    });
+    expect(session.snapshotForTesting.text).toBe("XYZ!");
+  });
+
+  it("deletes the entire document", () => {
+    const { session } = openSession("SELECT 1");
+    session.update({
+      kind: "document",
+      baseRevision: session.revision,
+      document: { kind: "changes", changes: [{ from: 0, insert: "", to: 8 }] },
+    });
+    expect(session.snapshotForTesting.text).toBe("");
+  });
+
+  it("allows edits at every UTF-16 boundary", () => {
+    const { session } = openSession("A😀e\u0301\r\nZ\uD800");
+    session.update({
+      kind: "document",
+      baseRevision: session.revision,
+      document: {
+        kind: "changes",
+        changes: [
+          { from: 2, insert: "X", to: 3 },
+          { from: 5, insert: "", to: 6 },
+          { from: 8, insert: "!", to: 8 },
+        ],
+      },
+    });
+    expect(session.snapshotForTesting.text).toBe("A\uD83DXe\u0301\nZ!\uD800");
+  });
+
+  it.each([
+    { from: -1, insert: "", to: 0 },
+    { from: 0, insert: "", to: -1 },
+    { from: 0.5, insert: "", to: 1 },
+    { from: Number.NaN, insert: "", to: 1 },
+    { from: 0, insert: "", to: Number.POSITIVE_INFINITY },
+    { from: Number.MAX_SAFE_INTEGER + 1, insert: "", to: 1 },
+    { from: 2, insert: "", to: 1 },
+    { from: 0, insert: "", to: 100 },
+  ])("rejects invalid range $from..$to atomically", (change) => {
+    const { session } = openSession("ABC");
+    const revision = session.revision;
+
+    expectSessionError("invalid-change", () => {
+      session.update({
+        kind: "document",
+        baseRevision: revision,
+        document: { kind: "changes", changes: [change] },
+      });
+    });
+
+    expect(session.revision).toBe(revision);
+    expect(session.snapshotForTesting.text).toBe("ABC");
+  });
+
+  it("rejects unordered and overlapping changes atomically", () => {
+    const { session } = openSession("ABCDE");
+    const revision = session.revision;
+    expectSessionError("invalid-change", () => {
+      session.update({
+        kind: "document",
+        baseRevision: revision,
+        document: {
+          kind: "changes",
+          changes: [
+            { from: 2, insert: "", to: 4 },
+            { from: 1, insert: "", to: 2 },
+          ],
+        },
+      });
+    });
+    expect(session.revision).toBe(revision);
+    expect(session.snapshotForTesting.text).toBe("ABCDE");
+  });
+
+  it("rejects non-string inserts from JavaScript callers", () => {
+    const { session } = openSession("ABC");
+    expectSessionError("invalid-change", () => {
+      session.update({
+        kind: "document",
+        baseRevision: session.revision,
+        document: {
+          kind: "changes",
+          changes: [{ from: 1, insert: 42, to: 2 }],
+        },
+      } as never);
+    });
+  });
+
+  it.each([
+    { document: {} },
+    { document: { kind: "changes", changes: [], text: "SELECT 1" } },
+    { document: { kind: "changes", changes: "invalid" } },
+    { document: { kind: "replace", text: 42 } },
+    { document: "invalid" },
+    { document: null },
+  ])("rejects an ambiguous JavaScript mutation", ({ document }) => {
+    const { session } = openSession("ABC");
+    const revision = session.revision;
+    expectSessionError("invalid-update", () => {
+      session.update({ kind: "document", baseRevision: revision, document } as never);
+    });
+    expect(session.revision).toBe(revision);
+    expect(session.snapshotForTesting.text).toBe("ABC");
+  });
+
+  it("rejects an empty JavaScript update", () => {
+    const { session } = openSession("ABC");
+    expectSessionError("invalid-update", () => {
+      session.update({ kind: "document", baseRevision: session.revision } as never);
+    });
+  });
+
+  it("rejects unknown update and document kinds", () => {
+    const { session } = openSession("ABC");
+    expectSessionError("invalid-update", () => {
+      session.update({
+        kind: "unknown",
+        baseRevision: session.revision,
+      } as never);
+    });
+    expectSessionError("invalid-update", () => {
+      session.update({
+        kind: "document",
+        baseRevision: session.revision,
+        document: { kind: "unknown" },
+      } as never);
+    });
+    expectSessionError("invalid-update", () => {
+      session.update({
+        kind: "document",
+        baseRevision: session.revision,
+        document: { kind: "replace", text: "ABC", changes: [] },
+      } as never);
+    });
+    expectSessionError("invalid-update", () => {
+      session.update({
+        kind: "context",
+        baseRevision: session.revision,
+        context: undefined,
+      } as never);
+    });
+    expectSessionError("invalid-update", () => {
+      session.update({
+        kind: "context",
+        baseRevision: session.revision,
+        context: { dialect: "duckdb", engine: "local" },
+        document: { kind: "replace", text: "lost" },
+      } as never);
+    });
+  });
+
+  it("normalizes proxy inspection failures and resets the update guard", () => {
+    const { session } = openSession("ABC");
+    const update = new Proxy(
+      {},
+      {
+        getOwnPropertyDescriptor() {
+          throw new Error("hostile");
+        },
+      },
+    );
+    expectSessionError("invalid-update", () => {
+      session.update(update as never);
+    });
+    session.update({
+      kind: "document",
+      baseRevision: session.revision,
+      document: { kind: "replace", text: "recovered" },
+    });
+    expect(session.snapshotForTesting.text).toBe("recovered");
+  });
+
+  it.each([null, "invalid", 42])(
+    "rejects a non-object JavaScript update",
+    (update) => {
+      const { session } = openSession("ABC");
+      expectSessionError("invalid-update", () => {
+        session.update(update as never);
+      });
+    },
+  );
+
+  it("rejects missing and accessor update fields without invoking accessors", () => {
+    const { session } = openSession("ABC");
+    let invoked = false;
+    const accessor = {
+      get baseRevision() {
+        invoked = true;
+        return session.revision;
+      },
+      document: { kind: "replace", text: "changed" },
+    };
+
+    expectSessionError("invalid-update", () => {
+      session.update({ document: { kind: "replace", text: "changed" } } as never);
+    });
+    expectSessionError("invalid-update", () => {
+      session.update(accessor as never);
+    });
+    expect(invoked).toBe(false);
+    expect(session.snapshotForTesting.text).toBe("ABC");
+  });
+
+  it("rejects undefined and accessor optional update fields", () => {
+    const { session } = openSession("ABC");
+    expectSessionError("invalid-update", () => {
+      session.update({
+        kind: "document",
+        baseRevision: session.revision,
+        context: undefined,
+      } as never);
+    });
+
+    let invoked = false;
+    const update = {
+      baseRevision: session.revision,
+      get document() {
+        invoked = true;
+        return { text: "changed" };
+      },
+    };
+    expectSessionError("invalid-update", () => {
+      session.update(update as never);
+    });
+    expect(invoked).toBe(false);
+  });
+
+  it("rejects accessor document fields without invoking them", () => {
+    const { session } = openSession("ABC");
+    let invoked = false;
+    const document: SqlDocumentReplacement = {
+      kind: "replace",
+      get text() {
+        invoked = true;
+        return "changed";
+      },
+    };
+    expectSessionError("invalid-update", () => {
+      session.update({
+        kind: "document",
+        baseRevision: session.revision,
+        document,
+      });
+    });
+    expect(invoked).toBe(false);
+  });
+
+  it("rejects malformed JavaScript change entries", () => {
+    const { session } = openSession("ABC");
+    for (const change of [
+      null,
+      {},
+      { from: 0, insert: "", to: 1, get extra() {
+        return true;
+      } },
+    ]) {
+      if (change && "from" in change) {
+        Object.defineProperty(change, "from", { get: () => 0 });
+      }
+      expectSessionError("invalid-change", () => {
+        session.update({
+          kind: "document",
+          baseRevision: session.revision,
+          document: { kind: "changes", changes: [change] },
+        } as never);
+      });
+    }
+  });
+
+  it("rejects reentrant updates without losing the outer transaction", () => {
+    const { session } = openSession("ABC");
+    const originalRevision = session.revision;
+    let nestedError: SqlSessionError | undefined;
+    let attempted = false;
+    const target: SqlDocumentReplacement = {
+      kind: "replace",
+      text: "outer",
+    };
+    const document = new Proxy(
+      target,
+      {
+        getOwnPropertyDescriptor(target, property) {
+          if (property === "text" && !attempted) {
+            attempted = true;
+            try {
+              session.update({
+                kind: "document",
+                baseRevision: originalRevision,
+                document: { kind: "replace", text: "nested" },
+              });
+            } catch (error) {
+              if (error instanceof SqlSessionError) {
+                nestedError = error;
+              }
+            }
+          }
+          return Reflect.getOwnPropertyDescriptor(target, property);
+        },
+      },
+    );
+
+    const revision = session.update({
+      kind: "document",
+      baseRevision: originalRevision,
+      document,
+    });
+
+    expect(nestedError?.code).toBe("reentrant-update");
+    expect(session.isCurrent(revision)).toBe(true);
+    expect(session.snapshotForTesting.text).toBe("outer");
+  });
+
+  it("cannot commit an update after reentrant disposal", () => {
+    const { session } = openSession("ABC");
+    const revision = session.revision;
+    const target: SqlDocumentReplacement = {
+      kind: "replace",
+      text: "changed",
+    };
+    let disposed = false;
+    const document = new Proxy(target, {
+      getOwnPropertyDescriptor(value, property) {
+        if (!disposed) {
+          disposed = true;
+          session.dispose();
+        }
+        return Reflect.getOwnPropertyDescriptor(value, property);
+      },
+    });
+
+    expectSessionError("session-disposed", () => {
+      session.update({
+        kind: "document",
+        baseRevision: revision,
+        document,
+      });
+    });
+    expect(session.isCurrent(revision)).toBe(false);
+    expect(session.snapshotForTesting.text).toBe("ABC");
+  });
+
+  it("bounds fragmented and oversized document updates", () => {
+    const { session } = openSession("");
+    const tooManyChanges: { from: number; insert: string; to: number }[] = [];
+    tooManyChanges.length = 10_001;
+    expectSessionError("invalid-change", () => {
+      session.update({
+        kind: "document",
+        baseRevision: session.revision,
+        document: { kind: "changes", changes: tooManyChanges },
+      });
+    });
+
+    expectSessionError("invalid-document", () => {
+      session.update({
+        kind: "document",
+        baseRevision: session.revision,
+        document: {
+          kind: "changes",
+          changes: [
+            {
+              from: 0,
+              insert: "x".repeat(16 * 1024 * 1024 + 1),
+              to: 0,
+            },
+          ],
+        },
+      });
+    });
+    expect(session.snapshotForTesting.text).toBe("");
+  });
+});
+
+describe("document context", () => {
+  it("owns and deeply freezes a structured clone", () => {
+    const flags = [true];
+    const context = {
+      dialect: "duckdb",
+      engine: "local",
+      settings: { flags },
+    } satisfies TestContext;
+    const service = createService();
+    const session = service.openDocument({ context, text: "" });
+
+    flags.push(false);
+
+    expect(session.snapshotForTesting.context).toEqual({
+      dialect: "duckdb",
+      engine: "local",
+      settings: { flags: [true] },
+    });
+    expect(Object.isFrozen(session.snapshotForTesting.context)).toBe(true);
+    expect(Object.isFrozen(session.snapshotForTesting.context.settings)).toBe(true);
+    expect(Object.isFrozen(session.snapshotForTesting.context.settings?.flags)).toBe(
+      true,
+    );
+  });
+
+  it("accepts finite numeric and bigint context data", () => {
+    const context = {
+      dialect: "duckdb",
+      engine: "local",
+      generation: 2,
+      identifier: 3n,
+    };
+    const session = new DefaultSqlLanguageService<typeof context>({
+      dialects: [duckdb],
+    }).openDocument({ context, text: "" });
+    expect(session.snapshotForTesting.context.generation).toBe(2);
+    expect(session.snapshotForTesting.context.identifier).toBe(3n);
+  });
+
+  it("preserves cycles and shared references in the owned clone", () => {
+    interface GraphContext extends TestContext {
+      left: { value: bigint };
+      right: { value: bigint };
+      self?: GraphContext;
+    }
+
+    const shared = { value: 1n };
+    const context: GraphContext = {
+      dialect: "duckdb",
+      engine: "local",
+      left: shared,
+      right: shared,
+    };
+    context.self = context;
+
+    const session = new DefaultSqlLanguageService<GraphContext>({
+      dialects: [duckdb],
+    }).openDocument({ context, text: "" });
+    const owned = session.snapshotForTesting.context;
+
+    expect(owned).not.toBe(context);
+    expect(owned.left).toBe(owned.right);
+    expect(owned.self).toBe(owned);
+    expect(Object.isFrozen(owned.self)).toBe(true);
+  });
+
+  it("accepts null-prototype objects as plain data", () => {
+    const metadata = Object.assign(Object.create(null), { value: "ok" });
+    const context = { dialect: "duckdb", engine: "local", metadata };
+    const session = new DefaultSqlLanguageService<typeof context>({
+      dialects: [duckdb],
+    }).openDocument({ context, text: "" });
+    expect(session.snapshotForTesting.context.metadata.value).toBe("ok");
+  });
+
+  it("updates text and context atomically", () => {
+    const { session } = openSession("SELECT 1");
+    session.update({
+      kind: "document",
+      baseRevision: session.revision,
+      context: { dialect: "postgres", engine: "warehouse" },
+      document: { kind: "replace", text: "SELECT 2" },
+    });
+
+    expect(session.snapshotForTesting).toMatchObject({
+      context: { dialect: "postgres", engine: "warehouse" },
+      text: "SELECT 2",
+    });
+  });
+
+  it("supports context-only updates", () => {
+    const { session } = openSession("SELECT 1");
+    session.update({
+      kind: "context",
+      baseRevision: session.revision,
+      context: { dialect: "postgres", engine: "warehouse" },
+    });
+    expect(session.snapshotForTesting.text).toBe("SELECT 1");
+    expect(session.snapshotForTesting.context.dialect).toBe("postgres");
+  });
+
+  it("retains the owned context for document-only updates", () => {
+    const { session } = openSession();
+    const context = session.snapshotForTesting.context;
+    session.update({
+      kind: "document",
+      baseRevision: session.revision,
+      document: { kind: "replace", text: "SELECT 1" },
+    });
+    expect(session.snapshotForTesting.context).toBe(context);
+  });
+
+  it("clones a supplied context again on every update", () => {
+    const { session } = openSession();
+    const context: TestContext = { dialect: "duckdb", engine: "local" };
+    session.update({ kind: "context", baseRevision: session.revision, context });
+    const firstOwned = session.snapshotForTesting.context;
+    session.update({ kind: "context", baseRevision: session.revision, context });
+    expect(session.snapshotForTesting.context).not.toBe(firstOwned);
+  });
+
+  it.each([
+    {
+      context: { dialect: "unknown", engine: "local" },
+      error: "invalid-dialect",
+    },
+    {
+      context: { dialect: "duckdb", engine: Number.NaN },
+      error: "invalid-context",
+    },
+    {
+      context: { dialect: "duckdb", engine: new Date() },
+      error: "invalid-context",
+    },
+    {
+      context: { dialect: "duckdb", engine: () => "local" },
+      error: "invalid-context",
+    },
+  ])("rejects invalid context without mutation: $error", ({ context, error }) => {
+    const { session } = openSession("SELECT 1");
+    const revision = session.revision;
+    expectSessionError(error as SqlSessionError["code"], () => {
+      session.update({
+        kind: "document",
+        baseRevision: revision,
+        context,
+        document: { kind: "replace", text: "SELECT 2" },
+      } as never);
+    });
+    expect(session.revision).toBe(revision);
+    expect(session.snapshotForTesting.text).toBe("SELECT 1");
+  });
+
+  it("rejects accessors without invoking them", () => {
+    let invoked = false;
+    const context = {
+      dialect: "duckdb",
+      get engine() {
+        invoked = true;
+        return "local";
+      },
+    };
+
+    expectSessionError("invalid-context", () => {
+      createService().openDocument({ context, text: "" });
+    });
+    expect(invoked).toBe(false);
+  });
+
+  it("rejects symbol keys", () => {
+    const context = {
+      dialect: "duckdb",
+      engine: "local",
+      [Symbol("hidden")]: true,
+    };
+    expectSessionError("invalid-context", () => {
+      createService().openDocument({ context, text: "" });
+    });
+  });
+
+  it("rejects custom array properties", () => {
+    const flags = [true];
+    Object.defineProperty(flags, "custom", { value: true });
+    expectSessionError("invalid-context", () => {
+      createService().openDocument({
+        context: {
+          dialect: "duckdb",
+          engine: "local",
+          settings: { flags },
+        },
+        text: "",
+      });
+    });
+  });
+
+  it("rejects malformed property descriptors from proxies", () => {
+    const context = new Proxy(
+      { dialect: "duckdb", engine: "local" },
+      {
+        getOwnPropertyDescriptor(target, property) {
+          if (property === "engine") {
+            return;
+          }
+          return Object.getOwnPropertyDescriptor(target, property);
+        },
+      },
+    );
+    expectSessionError("invalid-context", () => {
+      createService().openDocument({ context, text: "" });
+    });
+  });
+
+  it("enforces depth for nested paths", () => {
+    const root: Record<string, unknown> = {
+      dialect: "duckdb",
+      engine: "local",
+    };
+    let cursor: Record<string, unknown> = {};
+    root.path = cursor;
+    for (let index = 0; index < 150; index += 1) {
+      const next: Record<string, unknown> = {};
+      cursor.next = next;
+      cursor = next;
+    }
+
+    expectSessionError("invalid-context", () => {
+      createService().openDocument({ context: root, text: "" } as never);
+    });
+  });
+
+  it("rejects non-object context from JavaScript", () => {
+    expectSessionError("invalid-context", () => {
+      createService().openDocument({ context: "duckdb", text: "" } as never);
+    });
+  });
+
+  it("bounds aggregate context string data", () => {
+    expectSessionError("invalid-context", () => {
+      createService().openDocument({
+        context: {
+          dialect: "duckdb",
+          engine: "x".repeat(1_000_001),
+        },
+        text: "",
+      });
+    });
+  });
+
+  it("bounds context array length and property-name data", () => {
+    interface BoundedContext extends TestContext {
+      readonly metadata?: Readonly<Record<string, boolean>>;
+      readonly sparse?: readonly boolean[];
+    }
+    const service = new DefaultSqlLanguageService<BoundedContext>({
+      dialects: [duckdb],
+    });
+    const sparse: boolean[] = [];
+    sparse.length = 50_001;
+    expectSessionError("invalid-context", () => {
+      service.openDocument({
+        context: {
+          dialect: "duckdb",
+          engine: "local",
+          sparse,
+        },
+        text: "",
+      });
+    });
+
+    const longKey = "k".repeat(1_000_001);
+    expectSessionError("invalid-context", () => {
+      service.openDocument({
+        context: {
+          dialect: "duckdb",
+          engine: "local",
+          metadata: { [longKey]: true },
+        },
+        text: "",
+      });
+    });
+  });
+
+  it("normalizes structured-clone failures", () => {
+    const context = new Proxy(
+      { dialect: "duckdb", engine: "local" },
+      {},
+    );
+    expectSessionError("invalid-context", () => {
+      createService().openDocument({ context, text: "" });
+    });
+  });
+
+  it("checks a stale base before inspecting candidate context", () => {
+    const { session } = openSession();
+    const stale = session.revision;
+    session.update({ kind: "document", baseRevision: stale, document: { kind: "replace", text: "SELECT 1" } });
+    let inspected = false;
+    const context = {
+      dialect: "duckdb",
+      get engine() {
+        inspected = true;
+        return "local";
+      },
+    };
+    expectSessionError("stale-revision", () => {
+      session.update({ kind: "context", baseRevision: stale, context });
+    });
+    expect(inspected).toBe(false);
+  });
+});
+
+describe("lifecycle", () => {
+  it("makes session disposal idempotent and terminal", () => {
+    const { session } = openSession();
+    const revision = session.revision;
+    session.dispose();
+    session.dispose();
+
+    expect(session.isCurrent(revision)).toBe(false);
+    expectSessionError("session-disposed", () => {
+      session.update({
+        kind: "document",
+        baseRevision: revision,
+        document: { kind: "replace", text: "SELECT 1" },
+      });
+    });
+  });
+
+  it("service disposal closes sessions and is idempotent", () => {
+    const service = createService();
+    const first = service.openDocument({
+      context: { dialect: "duckdb", engine: "one" },
+      text: "",
+    });
+    const second = service.openDocument({
+      context: { dialect: "postgres", engine: "two" },
+      text: "",
+    });
+
+    service.dispose();
+    service.dispose();
+
+    expect(first.isCurrent(first.revision)).toBe(false);
+    expect(second.isCurrent(second.revision)).toBe(false);
+    expectSessionError("service-disposed", () => {
+      service.openDocument({
+        context: { dialect: "duckdb", engine: "three" },
+        text: "",
+      });
+    });
+  });
+
+  it("does not let a disposed session affect its service", () => {
+    const service = createService();
+    const first = service.openDocument({
+      context: { dialect: "duckdb", engine: "one" },
+      text: "",
+    });
+    first.dispose();
+
+    const second = service.openDocument({
+      context: { dialect: "duckdb", engine: "two" },
+      text: "",
+    });
+    expect(second.isCurrent(second.revision)).toBe(true);
+  });
+
+  it("does not register a failed document open", () => {
+    const service = createService();
+    expectSessionError("invalid-dialect", () => {
+      service.openDocument({
+        context: { dialect: "unknown", engine: "local" },
+        text: "",
+      });
+    });
+    const valid = service.openDocument({
+      context: { dialect: "duckdb", engine: "local" },
+      text: "",
+    });
+    expect(valid.isCurrent(valid.revision)).toBe(true);
+  });
+
+  it("rejects non-string initial text from JavaScript", () => {
+    expectSessionError("invalid-document", () => {
+      createService().openDocument({
+        context: { dialect: "duckdb", engine: "local" },
+        text: 42,
+      } as never);
+    });
+  });
+
+  it("rejects malformed and oversized open inputs", () => {
+    const service = createService();
+    expectSessionError("invalid-document", () => {
+      service.openDocument(null as never);
+    });
+    expectSessionError("invalid-document", () => {
+      service.openDocument({ context: undefined, text: "" } as never);
+    });
+    expectSessionError("invalid-document", () => {
+      service.openDocument({
+        context: { dialect: "duckdb", engine: "local" },
+        text: "x".repeat(16 * 1024 * 1024 + 1),
+      });
+    });
+    expectSessionError("invalid-document", () => {
+      service.openDocument(
+        new Proxy(
+          {},
+          {
+            getOwnPropertyDescriptor() {
+              throw new Error("hostile");
+            },
+          },
+        ) as never,
+      );
+    });
+  });
+
+  it("rejects open inputs with accessors without invoking them", () => {
+    const service = createService();
+    let invoked = false;
+    expectSessionError("invalid-document", () => {
+      service.openDocument({
+        context: { dialect: "duckdb", engine: "local" },
+        get text() {
+          invoked = true;
+          return "SELECT 1";
+        },
+      });
+    });
+    expect(invoked).toBe(false);
+  });
+
+  it("cannot return a session after reentrant service disposal", () => {
+    const service = createService();
+    let disposed = false;
+    const context = new Proxy(
+      { dialect: "duckdb", engine: "local" },
+      {
+        ownKeys(target) {
+          if (!disposed) {
+            disposed = true;
+            service.dispose();
+          }
+          return Reflect.ownKeys(target);
+        },
+      },
+    );
+
+    expectSessionError("service-disposed", () => {
+      service.openDocument({ context, text: "SELECT 1" });
+    });
+    expectSessionError("service-disposed", () => {
+      service.openDocument({
+        context: { dialect: "duckdb", engine: "local" },
+        text: "",
+      });
+    });
+  });
+
+  it("cannot return a session when the open-input proxy disposes the service", () => {
+    const service = createService();
+    let disposed = false;
+    const input = new Proxy(
+      {
+        context: { dialect: "duckdb", engine: "local" },
+        text: "SELECT 1",
+      },
+      {
+        getOwnPropertyDescriptor(target, property) {
+          if (!disposed) {
+            disposed = true;
+            service.dispose();
+          }
+          return Reflect.getOwnPropertyDescriptor(target, property);
+        },
+      },
+    );
+
+    expectSessionError("service-disposed", () => {
+      service.openDocument(input);
+    });
+  });
+
+  it.each([null, {}, { dialects: null }, { dialects: [] }])(
+    "normalizes invalid service options",
+    (options) => {
+      expectSessionError("invalid-service-options", () => {
+        createSqlLanguageService(options as never);
+      });
+    },
+  );
+
+  it("normalizes hostile service options", () => {
+    expectSessionError("invalid-service-options", () => {
+      createSqlLanguageService(
+        new Proxy(
+          {},
+          {
+            getOwnPropertyDescriptor() {
+              throw new Error("hostile");
+            },
+          },
+        ) as never,
+      );
+    });
+  });
+});

--- a/src/vnext/__tests__/session.test.ts
+++ b/src/vnext/__tests__/session.test.ts
@@ -474,15 +474,19 @@ describe("document changes", () => {
     let invoked = false;
     const update = {
       baseRevision: session.revision,
-      get document() {
+      document: { kind: "replace", text: "changed" },
+      kind: "document",
+      get context() {
         invoked = true;
-        return { text: "changed" };
+        return { dialect: "postgres", engine: "warehouse" };
       },
     };
     expectSessionError("invalid-update", () => {
       session.update(update as never);
     });
     expect(invoked).toBe(false);
+    expect(session.revision).toBe(revision);
+    expect(session.snapshotForTesting.text).toBe("ABC");
   });
 
   it("rejects accessor document fields without invoking them", () => {
@@ -706,6 +710,31 @@ describe("document context", () => {
     expect(session.snapshotForTesting.context.metadata.value).toBe("ok");
   });
 
+  it("requires dialect to be an own context property", () => {
+    const originalDialect = Object.getOwnPropertyDescriptor(
+      Object.prototype,
+      "dialect",
+    );
+    Object.defineProperty(Object.prototype, "dialect", {
+      configurable: true,
+      value: "duckdb",
+    });
+    try {
+      expectSessionError("invalid-dialect", () => {
+        createService().openDocument({
+          context: { engine: "local" } as TestContext,
+          text: "",
+        });
+      });
+    } finally {
+      if (originalDialect) {
+        Object.defineProperty(Object.prototype, "dialect", originalDialect);
+      } else {
+        Reflect.deleteProperty(Object.prototype, "dialect");
+      }
+    }
+  });
+
   it("updates text and context atomically", () => {
     const { session } = openSession("SELECT 1");
     session.update({
@@ -719,6 +748,17 @@ describe("document context", () => {
       context: { dialect: "postgres", engine: "warehouse" },
       text: "SELECT 2",
     });
+
+    const snapshot = session.snapshotForTesting;
+    expectSessionError("invalid-update", () => {
+      session.update({
+        kind: "document",
+        baseRevision: snapshot.revision,
+        context: { dialect: "duckdb", engine: "remote" },
+        document: { kind: "replace", text: 42 },
+      } as never);
+    });
+    expect(session.snapshotForTesting).toBe(snapshot);
   });
 
   it("supports context-only updates", () => {
@@ -888,6 +928,9 @@ describe("document context", () => {
     expectSessionError("invalid-context", () => {
       createService().openDocument({ context: "duckdb", text: "" } as never);
     });
+    expectSessionError("invalid-context", () => {
+      createService().openDocument({ context: [], text: "" } as never);
+    });
   });
 
   it("bounds aggregate context string data", () => {
@@ -966,6 +1009,34 @@ describe("document context", () => {
 });
 
 describe("lifecycle", () => {
+  it("supports detached public operations", () => {
+    const service = createService();
+    const { openDocument } = service;
+    const session = openDocument({
+      context: { dialect: "duckdb", engine: "local" },
+      text: "",
+    });
+    const { dispose, isCurrent, update } = session;
+    const revision = update({
+      kind: "document",
+      baseRevision: session.revision,
+      document: { kind: "replace", text: "SELECT 1" },
+    });
+
+    expect(isCurrent(revision)).toBe(true);
+    dispose();
+    expect(isCurrent(revision)).toBe(false);
+
+    const disposeService = service.dispose;
+    disposeService();
+    expectSessionError("service-disposed", () => {
+      openDocument({
+        context: { dialect: "duckdb", engine: "local" },
+        text: "",
+      });
+    });
+  });
+
   it("makes session disposal idempotent and terminal", () => {
     const { session } = openSession();
     const revision = session.revision;

--- a/src/vnext/__tests__/session.test.ts
+++ b/src/vnext/__tests__/session.test.ts
@@ -459,13 +459,17 @@ describe("document changes", () => {
 
   it("rejects undefined and accessor optional update fields", () => {
     const { session } = openSession("ABC");
+    const revision = session.revision;
     expectSessionError("invalid-update", () => {
       session.update({
         kind: "document",
-        baseRevision: session.revision,
+        baseRevision: revision,
         context: undefined,
+        document: { kind: "replace", text: "changed" },
       } as never);
     });
+    expect(session.revision).toBe(revision);
+    expect(session.snapshotForTesting.text).toBe("ABC");
 
     let invoked = false;
     const update = {
@@ -837,6 +841,29 @@ describe("document context", () => {
     expectSessionError("invalid-context", () => {
       createService().openDocument({ context, text: "" });
     });
+  });
+
+  it("does not read array length through a proxy", () => {
+    let invoked = false;
+    const flags = new Proxy([true], {
+      get(target, property, receiver) {
+        if (property === "length") {
+          invoked = true;
+        }
+        return Reflect.get(target, property, receiver);
+      },
+    });
+    expectSessionError("invalid-context", () => {
+      createService().openDocument({
+        context: {
+          dialect: "duckdb",
+          engine: "local",
+          settings: { flags },
+        },
+        text: "",
+      });
+    });
+    expect(invoked).toBe(false);
   });
 
   it("enforces depth for nested paths", () => {

--- a/src/vnext/index.ts
+++ b/src/vnext/index.ts
@@ -1,0 +1,23 @@
+export {
+  createSqlLanguageService,
+  defineSqlDialect,
+} from "./session.js";
+export type {
+  OpenSqlDocument,
+  SqlCatalogContext,
+  SqlContextInput,
+  SqlDialectDefinition,
+  SqlDocumentChanges,
+  SqlDocumentContext,
+  SqlDocumentEdit,
+  SqlDocumentReplacement,
+  SqlDocumentSession,
+  SqlDocumentUpdate,
+  SqlLanguageService,
+  SqlLanguageServiceOptions,
+  SqlPlainData,
+  SqlRevision,
+  SqlSessionErrorCode,
+  SqlTextChange,
+} from "./types.js";
+export { SqlSessionError } from "./types.js";

--- a/src/vnext/session.ts
+++ b/src/vnext/session.ts
@@ -190,7 +190,11 @@ function deepFreeze<T extends object>(root: T): T {
 
 function cloneContext<Context extends SqlDocumentContext>(context: Context): Context {
   try {
-    if (context === null || typeof context !== "object") {
+    if (
+      context === null ||
+      typeof context !== "object" ||
+      Array.isArray(context)
+    ) {
       throw new SqlSessionError(
         "invalid-context",
         "SQL document context must be a plain object",
@@ -215,10 +219,18 @@ function validateDialect(
   context: SqlDocumentContext,
   dialects: ReadonlySet<string>,
 ): void {
-  if (!dialects.has(context.dialect)) {
+  const dialect = readRequiredDataProperty(
+    context,
+    "dialect",
+    "invalid-dialect",
+    "SQL document context",
+  );
+  if (typeof dialect !== "string" || !dialects.has(dialect)) {
     throw new SqlSessionError(
       "invalid-dialect",
-      `Unknown SQL dialect: ${context.dialect}`,
+      typeof dialect === "string"
+        ? `Unknown SQL dialect: ${dialect}`
+        : "SQL document context dialect must be a string",
     );
   }
 }
@@ -429,7 +441,6 @@ export class DefaultSqlDocumentSession<Context extends SqlDocumentContext>
 {
   readonly #dialects: ReadonlySet<string>;
   readonly #onDispose: () => void;
-  readonly #sessionId = Symbol("SqlDocumentSession");
   #disposed = false;
   #snapshot: SessionSnapshot<Context>;
   #updating = false;
@@ -449,13 +460,7 @@ export class DefaultSqlDocumentSession<Context extends SqlDocumentContext>
       contextSequence,
       context,
       documentSequence,
-      revision: createSqlRevisionToken({
-        contextSequence,
-        documentSequence,
-        environmentEpoch: 0,
-        sequence,
-        sessionId: this.#sessionId,
-      }),
+      revision: createSqlRevisionToken(),
       sequence,
       text,
     });
@@ -469,7 +474,7 @@ export class DefaultSqlDocumentSession<Context extends SqlDocumentContext>
     return this.#snapshot;
   }
 
-  update(update: SqlDocumentUpdate<Context>): SqlRevision {
+  readonly update = (update: SqlDocumentUpdate<Context>): SqlRevision => {
     if (this.#disposed) {
       throw new SqlSessionError("session-disposed", "SQL document session is disposed");
     }
@@ -493,7 +498,7 @@ export class DefaultSqlDocumentSession<Context extends SqlDocumentContext>
     } finally {
       this.#updating = false;
     }
-  }
+  };
 
   #applyUpdate(update: SqlDocumentUpdate<Context>): SqlRevision {
     if (update === null || typeof update !== "object") {
@@ -665,13 +670,7 @@ export class DefaultSqlDocumentSession<Context extends SqlDocumentContext>
       );
     }
     const sequence = this.#snapshot.sequence + 1;
-    const revision = createSqlRevisionToken({
-      contextSequence: nextContextSequence,
-      documentSequence: nextDocumentSequence,
-      environmentEpoch: 0,
-      sequence,
-      sessionId: this.#sessionId,
-    });
+    const revision = createSqlRevisionToken();
     this.#snapshot = Object.freeze({
       contextSequence: nextContextSequence,
       context: nextContext,
@@ -683,17 +682,17 @@ export class DefaultSqlDocumentSession<Context extends SqlDocumentContext>
     return revision;
   }
 
-  isCurrent(revision: SqlRevision): boolean {
+  readonly isCurrent = (revision: SqlRevision): boolean => {
     return !this.#disposed && revision === this.#snapshot.revision;
-  }
+  };
 
-  dispose(): void {
+  readonly dispose = (): void => {
     if (this.#disposed) {
       return;
     }
     this.#disposed = true;
     this.#onDispose();
-  }
+  };
 }
 
 export class DefaultSqlLanguageService<Context extends SqlDocumentContext>
@@ -764,7 +763,9 @@ export class DefaultSqlLanguageService<Context extends SqlDocumentContext>
     }
   }
 
-  openDocument(input: OpenSqlDocument<Context>): DefaultSqlDocumentSession<Context> {
+  readonly openDocument = (
+    input: OpenSqlDocument<Context>,
+  ): DefaultSqlDocumentSession<Context> => {
     if (this.#disposed) {
       throw new SqlSessionError("service-disposed", "SQL language service is disposed");
     }
@@ -801,7 +802,7 @@ export class DefaultSqlLanguageService<Context extends SqlDocumentContext>
           "Open SQL document input requires a context value",
         );
       }
-      const context = cloneContext(candidateContext);
+      const context = cloneContext<Context>(candidateContext);
       validateDialect(context, this.#dialects);
 
       let session: DefaultSqlDocumentSession<Context>;
@@ -837,9 +838,9 @@ export class DefaultSqlLanguageService<Context extends SqlDocumentContext>
         "Open SQL document input could not be inspected safely",
       );
     }
-  }
+  };
 
-  dispose(): void {
+  readonly dispose = (): void => {
     if (this.#disposed) {
       return;
     }
@@ -848,7 +849,7 @@ export class DefaultSqlLanguageService<Context extends SqlDocumentContext>
       session.dispose();
     }
     this.#sessions.clear();
-  }
+  };
 }
 
 /** Validates and normalizes one immutable dialect registration. */

--- a/src/vnext/session.ts
+++ b/src/vnext/session.ts
@@ -1,0 +1,907 @@
+import type {
+  OpenSqlDocument,
+  SqlDialectDefinition,
+  SqlDocumentContext,
+  SqlDocumentSession,
+  SqlDocumentUpdate,
+  SqlLanguageService,
+  SqlLanguageServiceOptions,
+  SqlRevision,
+  SqlTextChange,
+} from "./types.js";
+import { createSqlRevisionToken, SqlSessionError } from "./types.js";
+
+const MAX_CONTEXT_DEPTH = 100;
+const MAX_CONTEXT_NODES = 10_000;
+const MAX_CONTEXT_PROPERTIES = 50_000;
+const MAX_CONTEXT_KEY_LENGTH = 1_000_000;
+const MAX_CONTEXT_STRING_LENGTH = 1_000_000;
+const MAX_CONTEXT_ARRAY_LENGTH = 50_000;
+const MAX_DOCUMENT_LENGTH = 16 * 1024 * 1024;
+const MAX_CHANGES_PER_UPDATE = 10_000;
+const MAX_DIALECTS = 1_000;
+const MAX_DIALECT_ID_LENGTH = 256;
+const MAX_DIALECT_DISPLAY_NAME_LENGTH = 1_024;
+
+interface PendingContextValue {
+  readonly depth: number;
+  readonly value: unknown;
+}
+
+interface DataProperties {
+  readonly keyLength: number;
+  readonly values: readonly unknown[];
+}
+
+function getDataProperties(value: object): DataProperties {
+  const values: unknown[] = [];
+  const isArray = Array.isArray(value);
+  if (isArray && value.length > MAX_CONTEXT_ARRAY_LENGTH) {
+    throw new SqlSessionError(
+      "invalid-context",
+      "SQL document context arrays are too large",
+    );
+  }
+  let keyLength = 0;
+  for (const key of Reflect.ownKeys(value)) {
+    if (isArray && key === "length") {
+      continue;
+    }
+    if (typeof key !== "string") {
+      throw new SqlSessionError(
+        "invalid-context",
+        "SQL document context cannot contain symbol keys",
+      );
+    }
+    keyLength += key.length;
+    if (
+      isArray &&
+      (!/^(0|[1-9]\d*)$/.test(key) || Number(key) >= value.length)
+    ) {
+      throw new SqlSessionError(
+        "invalid-context",
+        "SQL document context arrays cannot contain custom properties",
+      );
+    }
+    const descriptor = Object.getOwnPropertyDescriptor(value, key);
+    if (!descriptor || !("value" in descriptor)) {
+      throw new SqlSessionError(
+        "invalid-context",
+        "SQL document context cannot contain accessors",
+      );
+    }
+    values.push(descriptor.value);
+  }
+  return { keyLength, values };
+}
+
+function validatePlainData(root: unknown): void {
+  const pending: PendingContextValue[] = [{ depth: 0, value: root }];
+  const seen = new WeakSet<object>();
+  let nodeCount = 0;
+  let propertyCount = 0;
+  let keyLength = 0;
+  let stringLength = 0;
+
+  for (const current of pending) {
+    const value = current.value;
+    if (
+      value === null ||
+      value === undefined ||
+      typeof value === "boolean" ||
+      typeof value === "bigint"
+    ) {
+      continue;
+    }
+    if (typeof value === "string") {
+      stringLength += value.length;
+      if (stringLength > MAX_CONTEXT_STRING_LENGTH) {
+        throw new SqlSessionError(
+          "invalid-context",
+          "SQL document context contains too much string data",
+        );
+      }
+      continue;
+    }
+    if (typeof value === "number") {
+      if (!Number.isFinite(value)) {
+        throw new SqlSessionError(
+          "invalid-context",
+          "SQL document context numbers must be finite",
+        );
+      }
+      continue;
+    }
+    if (typeof value !== "object") {
+      throw new SqlSessionError(
+        "invalid-context",
+        "SQL document context must contain only plain data",
+      );
+    }
+    if (current.depth > MAX_CONTEXT_DEPTH) {
+      throw new SqlSessionError(
+        "invalid-context",
+        "SQL document context is too deeply nested",
+      );
+    }
+    if (seen.has(value)) {
+      continue;
+    }
+    seen.add(value);
+    nodeCount += 1;
+    if (nodeCount > MAX_CONTEXT_NODES) {
+      throw new SqlSessionError(
+        "invalid-context",
+        "SQL document context contains too many objects",
+      );
+    }
+
+    if (!Array.isArray(value)) {
+      const prototype = Object.getPrototypeOf(value);
+      if (prototype !== Object.prototype && prototype !== null) {
+        throw new SqlSessionError(
+          "invalid-context",
+          "SQL document context must contain only plain objects",
+        );
+      }
+    }
+
+    const properties = getDataProperties(value);
+    keyLength += properties.keyLength;
+    if (keyLength > MAX_CONTEXT_KEY_LENGTH) {
+      throw new SqlSessionError(
+        "invalid-context",
+        "SQL document context contains too much property-name data",
+      );
+    }
+    propertyCount += properties.values.length;
+    if (propertyCount > MAX_CONTEXT_PROPERTIES) {
+      throw new SqlSessionError(
+        "invalid-context",
+        "SQL document context contains too many properties",
+      );
+    }
+    for (const property of properties.values) {
+      pending.push({ depth: current.depth + 1, value: property });
+    }
+  }
+}
+
+function deepFreeze<T extends object>(root: T): T {
+  const pending: object[] = [root];
+  const seen = new WeakSet<object>();
+  for (const value of pending) {
+    if (seen.has(value)) {
+      continue;
+    }
+    seen.add(value);
+    for (const property of getDataProperties(value).values) {
+      if (property !== null && typeof property === "object") {
+        pending.push(property);
+      }
+    }
+    Object.freeze(value);
+  }
+  return root;
+}
+
+function cloneContext<Context extends SqlDocumentContext>(context: Context): Context {
+  try {
+    if (context === null || typeof context !== "object") {
+      throw new SqlSessionError(
+        "invalid-context",
+        "SQL document context must be a plain object",
+      );
+    }
+    validatePlainData(context);
+    const clone = structuredClone(context);
+    validatePlainData(clone);
+    return deepFreeze(clone);
+  } catch (error) {
+    if (error instanceof SqlSessionError) {
+      throw error;
+    }
+    throw new SqlSessionError(
+      "invalid-context",
+      "SQL document context must be structured-cloneable plain data",
+    );
+  }
+}
+
+function validateDialect(
+  context: SqlDocumentContext,
+  dialects: ReadonlySet<string>,
+): void {
+  if (!dialects.has(context.dialect)) {
+    throw new SqlSessionError(
+      "invalid-dialect",
+      `Unknown SQL dialect: ${context.dialect}`,
+    );
+  }
+}
+
+interface MissingDataProperty {
+  readonly found: false;
+}
+
+interface FoundDataProperty<Value> {
+  readonly found: true;
+  readonly value: Value;
+}
+
+type DataProperty<Value> = MissingDataProperty | FoundDataProperty<Value>;
+
+function readOwnDataProperty<Value extends object, Key extends keyof Value>(
+  value: Value,
+  key: Key,
+  code: SqlSessionError["code"],
+  subject: string,
+): DataProperty<Value[Key]>;
+function readOwnDataProperty(
+  value: object,
+  key: PropertyKey,
+  code: SqlSessionError["code"],
+  subject: string,
+): DataProperty<unknown>;
+function readOwnDataProperty(
+  value: object,
+  key: PropertyKey,
+  code: SqlSessionError["code"],
+  subject: string,
+): DataProperty<unknown> {
+  const descriptor = Object.getOwnPropertyDescriptor(value, key);
+  if (!descriptor) {
+    return { found: false };
+  }
+  if (!("value" in descriptor)) {
+    throw new SqlSessionError(
+      code,
+      `${subject} property ${String(key)} cannot be an accessor`,
+    );
+  }
+  return { found: true, value: descriptor.value };
+}
+
+function readRequiredDataProperty<Value extends object, Key extends keyof Value>(
+  value: Value,
+  key: Key,
+  code: SqlSessionError["code"],
+  subject: string,
+): Value[Key];
+function readRequiredDataProperty(
+  value: object,
+  key: PropertyKey,
+  code: SqlSessionError["code"],
+  subject: string,
+): unknown;
+function readRequiredDataProperty(
+  value: object,
+  key: PropertyKey,
+  code: SqlSessionError["code"],
+  subject: string,
+): unknown {
+  const property = readOwnDataProperty(value, key, code, subject);
+  if (!property.found) {
+    throw new SqlSessionError(
+      code,
+      `${subject} requires a data property named ${String(key)}`,
+    );
+  }
+  return property.value;
+}
+
+function validateDocumentLength(text: string): void {
+  if (text.length > MAX_DOCUMENT_LENGTH) {
+    throw new SqlSessionError(
+      "invalid-document",
+      `SQL documents cannot exceed ${MAX_DOCUMENT_LENGTH} UTF-16 code units`,
+    );
+  }
+}
+
+function readArrayLength(
+  value: readonly unknown[],
+  code: SqlSessionError["code"],
+  subject: string,
+): number {
+  const length = readRequiredDataProperty(value, "length", code, subject);
+  if (typeof length !== "number" || !Number.isSafeInteger(length) || length < 0) {
+    throw new SqlSessionError(code, `${subject} has an invalid length`);
+  }
+  return length;
+}
+
+function normalizeChanges(text: string, changes: readonly unknown[]): SqlTextChange[] {
+  const changeCount = readArrayLength(
+    changes,
+    "invalid-change",
+    "SQL document changes",
+  );
+  if (changeCount > MAX_CHANGES_PER_UPDATE) {
+    throw new SqlSessionError(
+      "invalid-change",
+      `SQL document updates cannot contain more than ${MAX_CHANGES_PER_UPDATE} changes`,
+    );
+  }
+  const normalized: SqlTextChange[] = [];
+  let previousEnd = 0;
+  let nextLength = text.length;
+
+  for (let index = 0; index < changeCount; index += 1) {
+    const change = readRequiredDataProperty(
+      changes,
+      index,
+      "invalid-change",
+      "SQL document changes",
+    );
+    if (change === null || typeof change !== "object") {
+      throw new SqlSessionError(
+        "invalid-change",
+        `SQL change ${index} must be an object`,
+      );
+    }
+    const from = readRequiredDataProperty(
+      change,
+      "from",
+      "invalid-change",
+      `SQL change ${index}`,
+    );
+    const to = readRequiredDataProperty(
+      change,
+      "to",
+      "invalid-change",
+      `SQL change ${index}`,
+    );
+    const insert = readRequiredDataProperty(
+      change,
+      "insert",
+      "invalid-change",
+      `SQL change ${index}`,
+    );
+    if (
+      typeof from !== "number" ||
+      typeof to !== "number" ||
+      !Number.isSafeInteger(from) ||
+      !Number.isSafeInteger(to) ||
+      from < 0 ||
+      from > to ||
+      to > text.length
+    ) {
+      throw new SqlSessionError(
+        "invalid-change",
+        `Invalid UTF-16 range in SQL change ${index}`,
+      );
+    }
+    if (from < previousEnd) {
+      throw new SqlSessionError(
+        "invalid-change",
+        "SQL document changes must be ordered and non-overlapping",
+      );
+    }
+    if (typeof insert !== "string") {
+      throw new SqlSessionError("invalid-change", "SQL change insert must be a string");
+    }
+    nextLength += insert.length - (to - from);
+    if (nextLength > MAX_DOCUMENT_LENGTH) {
+      throw new SqlSessionError(
+        "invalid-document",
+        `SQL documents cannot exceed ${MAX_DOCUMENT_LENGTH} UTF-16 code units`,
+      );
+    }
+    normalized.push(
+      Object.freeze({
+        from,
+        insert,
+        to,
+      }),
+    );
+    previousEnd = to;
+  }
+
+  return normalized;
+}
+
+function applyChanges(text: string, changes: readonly SqlTextChange[]): string {
+  let cursor = 0;
+  const output: string[] = [];
+  for (const change of changes) {
+    output.push(text.slice(cursor, change.from), change.insert);
+    cursor = change.to;
+  }
+  output.push(text.slice(cursor));
+  return output.join("");
+}
+
+interface SessionSnapshot<Context extends SqlDocumentContext> {
+  readonly contextSequence: number;
+  readonly context: Context;
+  readonly documentSequence: number;
+  readonly revision: SqlRevision;
+  readonly sequence: number;
+  readonly text: string;
+}
+
+export class DefaultSqlDocumentSession<Context extends SqlDocumentContext>
+  implements SqlDocumentSession<Context>
+{
+  readonly #dialects: ReadonlySet<string>;
+  readonly #onDispose: () => void;
+  readonly #sessionId = Symbol("SqlDocumentSession");
+  #disposed = false;
+  #snapshot: SessionSnapshot<Context>;
+  #updating = false;
+
+  constructor(
+    text: string,
+    context: Context,
+    dialects: ReadonlySet<string>,
+    onDispose: () => void,
+  ) {
+    this.#dialects = dialects;
+    this.#onDispose = onDispose;
+    const sequence = 0;
+    const contextSequence = 0;
+    const documentSequence = 0;
+    this.#snapshot = Object.freeze({
+      contextSequence,
+      context,
+      documentSequence,
+      revision: createSqlRevisionToken({
+        contextSequence,
+        documentSequence,
+        environmentEpoch: 0,
+        sequence,
+        sessionId: this.#sessionId,
+      }),
+      sequence,
+      text,
+    });
+  }
+
+  get revision(): SqlRevision {
+    return this.#snapshot.revision;
+  }
+
+  get snapshotForTesting(): SessionSnapshot<Context> {
+    return this.#snapshot;
+  }
+
+  update(update: SqlDocumentUpdate<Context>): SqlRevision {
+    if (this.#disposed) {
+      throw new SqlSessionError("session-disposed", "SQL document session is disposed");
+    }
+    if (this.#updating) {
+      throw new SqlSessionError(
+        "reentrant-update",
+        "SQL document updates cannot be reentrant",
+      );
+    }
+    this.#updating = true;
+    try {
+      return this.#applyUpdate(update);
+    } catch (error) {
+      if (error instanceof SqlSessionError) {
+        throw error;
+      }
+      throw new SqlSessionError(
+        "invalid-update",
+        "SQL document update could not be inspected safely",
+      );
+    } finally {
+      this.#updating = false;
+    }
+  }
+
+  #applyUpdate(update: SqlDocumentUpdate<Context>): SqlRevision {
+    if (update === null || typeof update !== "object") {
+      throw new SqlSessionError(
+        "invalid-update",
+        "SQL document update must be an object",
+      );
+    }
+    const kind = readRequiredDataProperty(
+      update,
+      "kind",
+      "invalid-update",
+      "SQL document update",
+    );
+    const baseRevision = readRequiredDataProperty(
+      update,
+      "baseRevision",
+      "invalid-update",
+      "SQL document update",
+    );
+    if (baseRevision !== this.#snapshot.revision) {
+      throw new SqlSessionError("stale-revision", "SQL document revision is stale");
+    }
+    if (kind !== "document" && kind !== "context") {
+      throw new SqlSessionError(
+        "invalid-update",
+        "SQL document update kind must be document or context",
+      );
+    }
+
+    let nextContextSequence = this.#snapshot.contextSequence;
+    let nextContext = this.#snapshot.context;
+    let nextDocumentSequence = this.#snapshot.documentSequence;
+    let nextText = this.#snapshot.text;
+
+    if (kind === "context") {
+      if (
+        readOwnDataProperty(
+          update,
+          "document",
+          "invalid-update",
+          "SQL context update",
+        ).found
+      ) {
+        throw new SqlSessionError(
+          "invalid-update",
+          "SQL context update cannot contain a document mutation",
+        );
+      }
+      const context = readRequiredDataProperty(
+        update,
+        "context",
+        "invalid-update",
+        "SQL context update",
+      );
+      if (context === undefined) {
+        throw new SqlSessionError(
+          "invalid-update",
+          "SQL context update requires a context value",
+        );
+      }
+      nextContext = cloneContext(context);
+      nextContextSequence += 1;
+    } else {
+      const document = readRequiredDataProperty(
+        update,
+        "document",
+        "invalid-update",
+        "SQL document update",
+      );
+      const context = readOwnDataProperty(
+        update,
+        "context",
+        "invalid-update",
+        "SQL document update",
+      );
+      if (context.found && context.value !== undefined) {
+        nextContext = cloneContext(context.value);
+        nextContextSequence += 1;
+      }
+      if (document === null || typeof document !== "object") {
+        throw new SqlSessionError(
+          "invalid-update",
+          "SQL document mutation must be an object",
+        );
+      }
+      const documentKind = readRequiredDataProperty(
+        document,
+        "kind",
+        "invalid-update",
+        "SQL document mutation",
+      );
+      if (documentKind === "replace") {
+        if (
+          readOwnDataProperty(
+            document,
+            "changes",
+            "invalid-update",
+            "SQL document replacement",
+          ).found
+        ) {
+          throw new SqlSessionError(
+            "invalid-update",
+            "SQL document replacement cannot also contain changes",
+          );
+        }
+        const text = readRequiredDataProperty(
+          document,
+          "text",
+          "invalid-update",
+          "SQL document replacement",
+        );
+        if (typeof text !== "string") {
+          throw new SqlSessionError(
+            "invalid-update",
+            "SQL replacement text must be a string",
+          );
+        }
+        validateDocumentLength(text);
+        nextText = text;
+      } else if (documentKind === "changes") {
+        if (
+          readOwnDataProperty(
+            document,
+            "text",
+            "invalid-update",
+            "SQL document changes",
+          ).found
+        ) {
+          throw new SqlSessionError(
+            "invalid-update",
+            "SQL document changes cannot also contain replacement text",
+          );
+        }
+        const changes = readRequiredDataProperty(
+          document,
+          "changes",
+          "invalid-update",
+          "SQL document changes",
+        );
+        if (!Array.isArray(changes)) {
+          throw new SqlSessionError(
+            "invalid-update",
+            "SQL document changes must be an array",
+          );
+        }
+        const normalizedChanges = normalizeChanges(nextText, changes);
+        nextText = applyChanges(nextText, normalizedChanges);
+      } else {
+        throw new SqlSessionError(
+          "invalid-update",
+          "SQL document mutation kind must be replace or changes",
+        );
+      }
+      nextDocumentSequence += 1;
+    }
+
+    validateDialect(nextContext, this.#dialects);
+    if (this.#disposed) {
+      throw new SqlSessionError(
+        "session-disposed",
+        "SQL document session was disposed during the update",
+      );
+    }
+    const sequence = this.#snapshot.sequence + 1;
+    const revision = createSqlRevisionToken({
+      contextSequence: nextContextSequence,
+      documentSequence: nextDocumentSequence,
+      environmentEpoch: 0,
+      sequence,
+      sessionId: this.#sessionId,
+    });
+    this.#snapshot = Object.freeze({
+      contextSequence: nextContextSequence,
+      context: nextContext,
+      documentSequence: nextDocumentSequence,
+      revision,
+      sequence,
+      text: nextText,
+    });
+    return revision;
+  }
+
+  isCurrent(revision: SqlRevision): boolean {
+    return !this.#disposed && revision === this.#snapshot.revision;
+  }
+
+  dispose(): void {
+    if (this.#disposed) {
+      return;
+    }
+    this.#disposed = true;
+    this.#onDispose();
+  }
+}
+
+export class DefaultSqlLanguageService<Context extends SqlDocumentContext>
+  implements SqlLanguageService<Context>
+{
+  readonly #dialects: ReadonlySet<string>;
+  readonly #sessions = new Set<DefaultSqlDocumentSession<Context>>();
+  #disposed = false;
+
+  constructor(options: SqlLanguageServiceOptions) {
+    try {
+      if (options === null || typeof options !== "object") {
+        throw new SqlSessionError(
+          "invalid-service-options",
+          "SQL language service options must be an object",
+        );
+      }
+      const configuredDialects = readRequiredDataProperty(
+        options,
+        "dialects",
+        "invalid-service-options",
+        "SQL language service options",
+      );
+      if (!Array.isArray(configuredDialects)) {
+        throw new SqlSessionError(
+          "invalid-service-options",
+          "SQL language service dialects must be an array",
+        );
+      }
+      const dialectCount = readArrayLength(
+        configuredDialects,
+        "invalid-service-options",
+        "SQL language service dialects",
+      );
+      if (dialectCount === 0 || dialectCount > MAX_DIALECTS) {
+        throw new SqlSessionError(
+          "invalid-service-options",
+          `SQL language service requires between 1 and ${MAX_DIALECTS} dialects`,
+        );
+      }
+
+      const dialects = new Set<string>();
+      for (let index = 0; index < dialectCount; index += 1) {
+        const dialect = readRequiredDataProperty(
+          configuredDialects,
+          index,
+          "invalid-service-options",
+          "SQL language service dialects",
+        );
+        const definition = defineSqlDialect(dialect);
+        if (dialects.has(definition.id)) {
+          throw new SqlSessionError(
+            "duplicate-dialect",
+            `Duplicate SQL dialect: ${definition.id}`,
+          );
+        }
+        dialects.add(definition.id);
+      }
+      this.#dialects = dialects;
+    } catch (error) {
+      if (error instanceof SqlSessionError) {
+        throw error;
+      }
+      throw new SqlSessionError(
+        "invalid-service-options",
+        "SQL language service options could not be inspected safely",
+      );
+    }
+  }
+
+  openDocument(input: OpenSqlDocument<Context>): DefaultSqlDocumentSession<Context> {
+    if (this.#disposed) {
+      throw new SqlSessionError("service-disposed", "SQL language service is disposed");
+    }
+
+    try {
+      if (input === null || typeof input !== "object") {
+        throw new SqlSessionError(
+          "invalid-document",
+          "Open SQL document input must be an object",
+        );
+      }
+      const text = readRequiredDataProperty(
+        input,
+        "text",
+        "invalid-document",
+        "Open SQL document input",
+      );
+      if (typeof text !== "string") {
+        throw new SqlSessionError(
+          "invalid-document",
+          "SQL document text must be a string",
+        );
+      }
+      validateDocumentLength(text);
+      const candidateContext = readRequiredDataProperty(
+        input,
+        "context",
+        "invalid-document",
+        "Open SQL document input",
+      );
+      if (candidateContext === undefined) {
+        throw new SqlSessionError(
+          "invalid-document",
+          "Open SQL document input requires a context value",
+        );
+      }
+      const context = cloneContext(candidateContext);
+      validateDialect(context, this.#dialects);
+
+      let session: DefaultSqlDocumentSession<Context>;
+      session = new DefaultSqlDocumentSession(
+        text,
+        context,
+        this.#dialects,
+        () => {
+          this.#sessions.delete(session);
+        },
+      );
+      if (this.#disposed) {
+        session.dispose();
+        throw new SqlSessionError(
+          "service-disposed",
+          "SQL language service was disposed while opening the document",
+        );
+      }
+      this.#sessions.add(session);
+      return session;
+    } catch (error) {
+      if (this.#disposed) {
+        throw new SqlSessionError(
+          "service-disposed",
+          "SQL language service was disposed while opening the document",
+        );
+      }
+      if (error instanceof SqlSessionError) {
+        throw error;
+      }
+      throw new SqlSessionError(
+        "invalid-document",
+        "Open SQL document input could not be inspected safely",
+      );
+    }
+  }
+
+  dispose(): void {
+    if (this.#disposed) {
+      return;
+    }
+    this.#disposed = true;
+    for (const session of this.#sessions) {
+      session.dispose();
+    }
+    this.#sessions.clear();
+  }
+}
+
+/** Validates and normalizes one immutable dialect registration. */
+export function defineSqlDialect(
+  definition: SqlDialectDefinition,
+): SqlDialectDefinition {
+  try {
+    if (definition === null || typeof definition !== "object") {
+      throw new SqlSessionError(
+        "invalid-dialect",
+        "SQL dialect definition must be an object",
+      );
+    }
+    const id = readRequiredDataProperty(
+      definition,
+      "id",
+      "invalid-dialect",
+      "SQL dialect definition",
+    );
+    const displayName = readRequiredDataProperty(
+      definition,
+      "displayName",
+      "invalid-dialect",
+      "SQL dialect definition",
+    );
+    if (
+      typeof id !== "string" ||
+      id.length === 0 ||
+      id.length > MAX_DIALECT_ID_LENGTH ||
+      id.trim().length === 0
+    ) {
+      throw new SqlSessionError(
+        "invalid-dialect",
+        `SQL dialect id must contain 1 to ${MAX_DIALECT_ID_LENGTH} code units`,
+      );
+    }
+    if (
+      typeof displayName !== "string" ||
+      displayName.length === 0 ||
+      displayName.length > MAX_DIALECT_DISPLAY_NAME_LENGTH ||
+      displayName.trim().length === 0
+    ) {
+      throw new SqlSessionError(
+        "invalid-dialect",
+        `SQL dialect display name must contain 1 to ${MAX_DIALECT_DISPLAY_NAME_LENGTH} code units`,
+      );
+    }
+    return Object.freeze({ displayName, id });
+  } catch (error) {
+    if (error instanceof SqlSessionError) {
+      throw error;
+    }
+    throw new SqlSessionError(
+      "invalid-dialect",
+      "SQL dialect definition could not be inspected safely",
+    );
+  }
+}
+
+/** Creates a framework-independent SQL service with an immutable dialect registry. */
+export function createSqlLanguageService<
+  Context extends SqlDocumentContext = SqlDocumentContext,
+>(options: SqlLanguageServiceOptions): SqlLanguageService<Context> {
+  return new DefaultSqlLanguageService<Context>(options);
+}

--- a/src/vnext/session.ts
+++ b/src/vnext/session.ts
@@ -36,7 +36,10 @@ interface DataProperties {
 function getDataProperties(value: object): DataProperties {
   const values: unknown[] = [];
   const isArray = Array.isArray(value);
-  if (isArray && value.length > MAX_CONTEXT_ARRAY_LENGTH) {
+  const arrayLength = isArray
+    ? readArrayLength(value, "invalid-context", "SQL document context array")
+    : undefined;
+  if (arrayLength !== undefined && arrayLength > MAX_CONTEXT_ARRAY_LENGTH) {
     throw new SqlSessionError(
       "invalid-context",
       "SQL document context arrays are too large",
@@ -55,8 +58,8 @@ function getDataProperties(value: object): DataProperties {
     }
     keyLength += key.length;
     if (
-      isArray &&
-      (!/^(0|[1-9]\d*)$/.test(key) || Number(key) >= value.length)
+      arrayLength !== undefined &&
+      (!/^(0|[1-9]\d*)$/.test(key) || Number(key) >= arrayLength)
     ) {
       throw new SqlSessionError(
         "invalid-context",
@@ -567,7 +570,13 @@ export class DefaultSqlDocumentSession<Context extends SqlDocumentContext>
         "invalid-update",
         "SQL document update",
       );
-      if (context.found && context.value !== undefined) {
+      if (context.found) {
+        if (context.value === undefined) {
+          throw new SqlSessionError(
+            "invalid-update",
+            "SQL document update context cannot be undefined",
+          );
+        }
         nextContext = cloneContext(context.value);
         nextContextSequence += 1;
       }

--- a/src/vnext/types.ts
+++ b/src/vnext/types.ts
@@ -5,24 +5,11 @@ export interface SqlRevision {
   readonly [revisionBrand]: "SqlRevision";
 }
 
-export interface SqlRevisionMetadata {
-  readonly contextSequence: number;
-  readonly documentSequence: number;
-  readonly environmentEpoch: number;
-  readonly sequence: number;
-  readonly sessionId: symbol;
-}
-
-const revisionMetadata = new WeakMap<SqlRevision, SqlRevisionMetadata>();
-
-export function createSqlRevisionToken(
-  metadata: SqlRevisionMetadata,
-): SqlRevision {
+export function createSqlRevisionToken(): SqlRevision {
   const revision: SqlRevision = {
     [revisionBrand]: "SqlRevision",
   };
   Object.freeze(revision);
-  revisionMetadata.set(revision, Object.freeze(metadata));
   return revision;
 }
 

--- a/src/vnext/types.ts
+++ b/src/vnext/types.ts
@@ -85,7 +85,7 @@ export type SqlDocumentUpdate<Context extends SqlDocumentContext> =
       readonly kind: "document";
       readonly baseRevision: SqlRevision;
       readonly document: SqlDocumentEdit;
-      readonly context?: SqlContextInput<Context> | undefined;
+      readonly context?: SqlContextInput<Context>;
     }
   | {
       readonly kind: "context";

--- a/src/vnext/types.ts
+++ b/src/vnext/types.ts
@@ -1,0 +1,142 @@
+const revisionBrand: unique symbol = Symbol("SqlRevision");
+
+/** Immutable identity issued by a document session. */
+export interface SqlRevision {
+  readonly [revisionBrand]: "SqlRevision";
+}
+
+export interface SqlRevisionMetadata {
+  readonly contextSequence: number;
+  readonly documentSequence: number;
+  readonly environmentEpoch: number;
+  readonly sequence: number;
+  readonly sessionId: symbol;
+}
+
+const revisionMetadata = new WeakMap<SqlRevision, SqlRevisionMetadata>();
+
+export function createSqlRevisionToken(
+  metadata: SqlRevisionMetadata,
+): SqlRevision {
+  const revision: SqlRevision = {
+    [revisionBrand]: "SqlRevision",
+  };
+  Object.freeze(revision);
+  revisionMetadata.set(revision, Object.freeze(metadata));
+  return revision;
+}
+
+export interface SqlCatalogContext {
+  readonly scope: string;
+  readonly searchPath?: readonly string[];
+}
+
+export interface SqlDocumentContext {
+  readonly dialect: string;
+  readonly catalog?: SqlCatalogContext;
+}
+
+/** Recursively maps a type to the plain-data values accepted at runtime. */
+export type SqlPlainData<Value> =
+  Value extends null | undefined | string | number | boolean | bigint
+    ? Value
+    : Value extends (...arguments_: never[]) => unknown
+      ? never
+    : Value extends readonly unknown[]
+      ? { readonly [Key in keyof Value]: SqlPlainData<Value[Key]> }
+      : Value extends object
+        ? {
+            readonly [Key in keyof Value]: Key extends string
+              ? SqlPlainData<Value[Key]>
+              : never;
+          }
+        : never;
+
+export type SqlContextInput<Context extends SqlDocumentContext> =
+  Context & SqlPlainData<Context>;
+
+export interface SqlDialectDefinition {
+  readonly id: string;
+  readonly displayName: string;
+}
+
+/** One half-open UTF-16 edit in pre-update document coordinates. */
+export interface SqlTextChange {
+  readonly from: number;
+  readonly to: number;
+  readonly insert: string;
+}
+
+export interface SqlDocumentReplacement {
+  readonly kind: "replace";
+  readonly text: string;
+}
+
+export interface SqlDocumentChanges {
+  readonly kind: "changes";
+  readonly changes: readonly SqlTextChange[];
+}
+
+export type SqlDocumentEdit = SqlDocumentReplacement | SqlDocumentChanges;
+
+/** An atomic document or context transaction against one base revision. */
+export type SqlDocumentUpdate<Context extends SqlDocumentContext> =
+  | {
+      readonly kind: "document";
+      readonly baseRevision: SqlRevision;
+      readonly document: SqlDocumentEdit;
+      readonly context?: SqlContextInput<Context> | undefined;
+    }
+  | {
+      readonly kind: "context";
+      readonly baseRevision: SqlRevision;
+      readonly context: SqlContextInput<Context>;
+    };
+
+export interface OpenSqlDocument<Context extends SqlDocumentContext> {
+  readonly text: string;
+  readonly context: SqlContextInput<Context>;
+}
+
+/** Owns all mutable state for one open SQL document. */
+export interface SqlDocumentSession<Context extends SqlDocumentContext> {
+  readonly revision: SqlRevision;
+  readonly update: (update: SqlDocumentUpdate<Context>) => SqlRevision;
+  readonly isCurrent: (revision: SqlRevision) => boolean;
+  readonly dispose: () => void;
+}
+
+/** Shareable service configuration and lifecycle for multiple documents. */
+export interface SqlLanguageService<Context extends SqlDocumentContext> {
+  readonly openDocument: (
+    input: OpenSqlDocument<Context>,
+  ) => SqlDocumentSession<Context>;
+  readonly dispose: () => void;
+}
+
+export interface SqlLanguageServiceOptions {
+  readonly dialects: readonly SqlDialectDefinition[];
+}
+
+export type SqlSessionErrorCode =
+  | "duplicate-dialect"
+  | "invalid-change"
+  | "invalid-context"
+  | "invalid-dialect"
+  | "invalid-document"
+  | "invalid-service-options"
+  | "invalid-update"
+  | "reentrant-update"
+  | "service-disposed"
+  | "session-disposed"
+  | "stale-revision";
+
+export class SqlSessionError extends Error {
+  readonly code: SqlSessionErrorCode;
+
+  constructor(code: SqlSessionErrorCode, message: string) {
+    super(message);
+    this.name = "SqlSessionError";
+    this.code = code;
+  }
+}

--- a/test/vnext-types/session.test-d.ts
+++ b/test/vnext-types/session.test-d.ts
@@ -1,0 +1,75 @@
+import {
+  createSqlLanguageService,
+  defineSqlDialect,
+  type SqlDocumentContext,
+  type SqlDocumentSession,
+  type SqlLanguageService,
+  type SqlRevision,
+  type SqlTextChange,
+} from "../../src/vnext/index.js";
+
+interface HostContext extends SqlDocumentContext {
+  readonly engine: string;
+}
+
+interface DateContext extends HostContext {
+  readonly lastUsed: Date;
+}
+
+const dialect = defineSqlDialect({ displayName: "DuckDB", id: "duckdb" });
+const service = createSqlLanguageService<HostContext>({ dialects: [dialect] });
+const session = service.openDocument({
+  context: { dialect: "duckdb", engine: "local" },
+  text: "",
+});
+const revision: SqlRevision = session.revision;
+
+// @ts-expect-error host service cannot be widened and fed a weaker context
+const widenedService: SqlLanguageService<SqlDocumentContext> = service;
+// @ts-expect-error host session cannot be widened and fed a weaker context
+const widenedSession: SqlDocumentSession<SqlDocumentContext> = session;
+
+session.update({
+  kind: "context",
+  baseRevision: revision,
+  context: { dialect: "duckdb", engine: "remote" },
+});
+session.update({
+  kind: "document",
+  baseRevision: session.revision,
+  document: { kind: "replace", text: "SELECT 1" },
+});
+session.update({
+  kind: "document",
+  baseRevision: session.revision,
+  context: { dialect: "duckdb", engine: "local" },
+  document: { kind: "changes", changes: [{ from: 0, insert: "SELECT 1", to: 0 }] },
+});
+
+const change: SqlTextChange = { from: 0, insert: "", to: 0 };
+
+// @ts-expect-error revisions are service-issued opaque values
+const objectRevision: SqlRevision = {};
+// @ts-expect-error revisions cannot be numbers
+const numberRevision: SqlRevision = 1;
+// @ts-expect-error updates require document or context
+session.update({ kind: "document", baseRevision: revision });
+// @ts-expect-error document mutation forms are mutually exclusive
+session.update({ kind: "document", baseRevision: revision, document: { kind: "changes", changes: [], text: "" } });
+// @ts-expect-error host context requires engine
+service.openDocument({ context: { dialect: "duckdb" }, text: "" });
+const dateService = createSqlLanguageService<DateContext>({ dialects: [dialect] });
+dateService.openDocument({
+  // @ts-expect-error Date is structured-cloneable but is not plain context data
+  context: { dialect: "duckdb", engine: "local", lastUsed: new Date() },
+  text: "",
+});
+// @ts-expect-error changes are readonly
+change.from = 1;
+// @ts-expect-error session revision is readonly
+session.revision = revision;
+
+void objectRevision;
+void numberRevision;
+void widenedService;
+void widenedSession;

--- a/test/vnext-types/session.test-d.ts
+++ b/test/vnext-types/session.test-d.ts
@@ -45,6 +45,13 @@ session.update({
   context: { dialect: "duckdb", engine: "local" },
   document: { kind: "changes", changes: [{ from: 0, insert: "SELECT 1", to: 0 }] },
 });
+// @ts-expect-error an explicitly undefined context is not an omitted context
+session.update({
+  kind: "document",
+  baseRevision: session.revision,
+  context: undefined,
+  document: { kind: "replace", text: "SELECT 1" },
+});
 
 const change: SqlTextChange = { from: 0, insert: "", to: 0 };
 

--- a/tsconfig.vnext-tests.json
+++ b/tsconfig.vnext-tests.json
@@ -1,11 +1,13 @@
 {
   "extends": "./tsconfig.tests.json",
   "compilerOptions": {
+    "exactOptionalPropertyTypes": true,
     "noUncheckedIndexedAccess": true,
     "noUnusedLocals": true
   },
   "include": [
     "./src/vnext/**/*.ts",
+    "./test/vnext-types/**/*.ts",
     "./vitest.browser.config.ts",
     "./vitest.config.ts"
   ]


### PR DESCRIPTION
## Summary

- add the framework-independent `@marimo-team/codemirror-sql/vnext` entry point
- implement immutable dialect registration, one session per document, opaque revision identity/metadata, discriminated atomic updates, and terminal disposal
- validate and own bounded plain-data contexts; normalize hostile JavaScript inputs and guard reentrant update/open lifecycle races
- add compile-only API tests, 83 runtime invariant tests, current-API documentation, and packed isolation smoke coverage without CodeMirror or node-sql-parser available

## Evidence

- `pnpm run typecheck`
- `pnpm exec oxlint`
- `pnpm run test:coverage` (670 passed, 1 governed expected failure)
- changed vNext runtime coverage: 99% statements, 98.47% branches, 100% functions, 98.99% lines
- `pnpm run test:browser`
- `pnpm run test:package`
- `pnpm run test:integrity`
- `pnpm run demo`

## Adversarial review

Two independent reviewers challenged correctness and API design. The first loop found and reproduced reentrant revision overwrite, service-open disposal, dialect TOCTOU, variance, and optional-property issues. The implementation and tests were redesigned; both reviewers now approve with no blocker/high findings.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds vNext atomic document sessions in `@marimo-team/codemirror-sql/vnext` with immutable dialects, per-document sessions, and strict revision/lifecycle invariants. Strengthens smoke tests with dependency isolation and rollback checks, and exports `./vnext` for consumers.

- **New Features**
  - Public service/session operations are exposed as readonly, bound function fields to remain safe when passed as callbacks or destructured.
  - Packaging/docs/tests: new session primitives guide, `package.json` `./vnext` subpath export, and smoke tests that run without `@codemirror` or `node-sql-parser`, verify `vnext` exports, revision identity, and validate isolation rollback.

- **Bug Fixes**
  - Hardened API invariants: reentrant-update guard, early stale-revision checks before context inspection, idempotent terminal disposal for session/service, stricter optional-field handling (`exactOptionalPropertyTypes`), and consistent `SqlSessionError` codes when normalizing accessors/proxies.

<sup>Written for commit ce6d09ab879078731a75b40add326218a266a297. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marimo-team/codemirror-sql/pull/172?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

