### PR TITLE
feat(vnext): add source coordinate primitives

### DIFF
--- a/docs/adr/0001-language-service-and-session.md
+++ b/docs/adr/0001-language-service-and-session.md
@@ -389,6 +389,12 @@ adjacent SQL tokens. More complex transformers use a versioned map whose
 segments are ordered, non-overlapping, and validated for original/generated
 coverage.
 
+The initial internal source primitive implements identity snapshots and this
+length-preserving masking only. It does not expose a transformer or source-map
+SPI. Sessions create a new source snapshot for document updates and reuse the
+existing snapshot for context-only updates. Non-identity generated/reordered
+source remains deferred until a concrete consumer validates the segment model.
+
 Edits crossing an ambiguous or unmapped boundary are rejected. Mapping failure
 is unavailable analysis, not invalid SQL.
 

--- a/docs/vnext/session-primitives.md
+++ b/docs/vnext/session-primitives.md
@@ -8,6 +8,9 @@ updates, opaque revisions, dialect registration, and lifecycle management. It
 does not yet provide parsing, completion, diagnostics, hover, or navigation.
 Those methods will be added only with working vertical slices.
 
+See [source coordinates](./source-coordinates.md) for the shared UTF-16 range
+contract and the internal immutable source-snapshot model.
+
 ## Example
 
 ```ts

--- a/docs/vnext/source-coordinates.md
+++ b/docs/vnext/source-coordinates.md
@@ -1,0 +1,46 @@
+# vNext Source Coordinates
+
+Status: experimental core primitive
+
+`SqlTextRange` is the public coordinate primitive:
+
+```ts
+interface SqlTextRange {
+  readonly from: number;
+  readonly to: number;
+}
+```
+
+Ranges are half-open UTF-16 offsets. Both ends are safe integers and satisfy
+`0 <= from <= to <= document.length`. Empty ranges, including the range at EOF,
+are valid. `SqlTextChange` extends this shape with `insert` and continues to use
+pre-update document coordinates.
+
+The service internally owns an immutable source snapshot with separately named
+`originalText` and `analysisText`. A document update creates a new identity
+snapshot; a context-only update reuses the same source object. This separation
+allows later analysis transforms without making providers depend on editor
+state or ambiguous coordinate spaces.
+
+## Length-preserving masking
+
+The first internal transform masks explicit embedded regions:
+
+- Regions are non-empty, ordered, non-overlapping, and in bounds.
+- Region and range inputs are copied into fresh frozen values.
+- Each non-CR/LF UTF-16 code unit becomes one space.
+- Every CR and LF code unit stays at its exact offset.
+- Astral characters therefore become two spaces, while a lone surrogate becomes
+  one space.
+- `analysisText.length` always equals `originalText.length`, so range mapping is
+  identity-preserving while still returning a fresh validated range.
+
+At most 10,000 regions and 16 Mi UTF-16 code units are accepted. Masking uses
+bounded 64 Ki-code-unit chunks, including for newline-dense input, rather than
+a per-code-unit or per-newline array.
+
+The source snapshot, embedded-region model, masking factory, and mapping
+functions remain internal. This slice intentionally does not publish a source
+transformer or source-map SPI. Generated or reordered source requires a
+versioned segment-map design and evidence from real consumers before becoming
+public.

--- a/implementation.md
+++ b/implementation.md
@@ -590,8 +590,8 @@ disposition. Validate them through a protected reusable workflow from the base
 branch so a PR cannot approve itself. Maintainers approve classification
 overrides and rejected blocking findings.
 
-Request GitHub Copilot review on every medium or large PR after the head commit
-is ready for review:
+Request GitHub Copilot review exactly once on every medium or large PR, after
+the PR has a coherent head that is ready for review:
 
 ```bash
 gh pr edit <number> --add-reviewer @copilot
@@ -600,8 +600,9 @@ gh pr edit <number> --add-reviewer @copilot
 Copilot is an additional advisory review, not one of the two independent
 commit-bound adversarial attestations and not a substitute for human approval.
 Resolve or explicitly disposition its actionable comments in the finding
-ledger. Re-request review after a material rewrite when the prior comments no
-longer cover the current head.
+ledger. Do not re-request Copilot after later pushes or material rewrites; the
+commit-bound adversarial reviewers and required CI provide exact-head
+revalidation.
 
 ## CI architecture
 
@@ -814,7 +815,7 @@ Before semantic implementation:
 12. Add the invariant registry and test-suite integrity checks.
 13. Add PR risk template and review-packet generation.
 14. Add protected, commit-bound two-reviewer checks.
-15. Automate GitHub Copilot review requests for medium and large PRs.
+15. Automate one GitHub Copilot review request per medium or large PR.
 16. Add verified-artifact provenance to release CI.
 17. Add nightly mutation, fuzz, cross-browser, leak, and performance workflows.
 18. Add expiring scheduled-health and deduplicated failure issues.

--- a/scripts/package-smoke.mjs
+++ b/scripts/package-smoke.mjs
@@ -210,6 +210,7 @@ import {
   createSqlLanguageService,
   defineSqlDialect,
   type SqlDocumentContext,
+  type SqlTextRange,
 } from "@marimo-team/codemirror-sql/vnext";
 import commonKeywords from "@marimo-team/codemirror-sql/data/common-keywords.json" with { type: "json" };
 import duckdbKeywords from "@marimo-team/codemirror-sql/data/duckdb-keywords.json" with { type: "json" };
@@ -230,6 +231,7 @@ const session = service.openDocument({
   context: { dialect: "duckdb", engine: "local" },
   text: "SELECT 1",
 });
+const range: SqlTextRange = { from: 0, to: 6 };
 session.update({
   kind: "document",
   baseRevision: session.revision,
@@ -238,6 +240,7 @@ session.update({
 
 void extensions;
 void parser;
+void range;
 void session;
 void BigQueryDialect;
 void DremioDialect;

--- a/src/vnext/__tests__/session.test.ts
+++ b/src/vnext/__tests__/session.test.ts
@@ -187,6 +187,28 @@ describe("document revisions", () => {
     });
     expect(second).not.toBe(first);
   });
+
+  it("reuses source snapshots only for context-only updates", () => {
+    const { session } = openSession("SELECT 1");
+    const initialSource = session.snapshotForTesting.source;
+    expect(Object.isFrozen(initialSource)).toBe(true);
+    expect(initialSource.analysisText).toBe(initialSource.originalText);
+
+    session.update({
+      kind: "context",
+      baseRevision: session.revision,
+      context: { dialect: "duckdb", engine: "remote" },
+    });
+    expect(session.snapshotForTesting.source).toBe(initialSource);
+
+    session.update({
+      kind: "document",
+      baseRevision: session.revision,
+      document: { kind: "changes", changes: [] },
+    });
+    expect(session.snapshotForTesting.source).not.toBe(initialSource);
+    expect(session.snapshotForTesting.source.originalText).toBe("SELECT 1");
+  });
 });
 
 describe("document changes", () => {
@@ -204,7 +226,7 @@ describe("document changes", () => {
       },
     });
 
-    expect(session.snapshotForTesting.text).toBe(
+    expect(session.snapshotForTesting.source.originalText).toBe(
       "SELECT customers.id FROM customers",
     );
   });
@@ -219,7 +241,7 @@ describe("document changes", () => {
         changes: [{ from: 1, insert: "X", to: 3 }],
       },
     });
-    expect(session.snapshotForTesting.text).toBe("AXB");
+    expect(session.snapshotForTesting.source.originalText).toBe("AXB");
   });
 
   it("keeps same-position insertions ordered", () => {
@@ -235,7 +257,7 @@ describe("document changes", () => {
         ],
       },
     });
-    expect(session.snapshotForTesting.text).toBe("A12B");
+    expect(session.snapshotForTesting.source.originalText).toBe("A12B");
   });
 
   it("supports adjacent replacements and document boundaries", () => {
@@ -253,7 +275,7 @@ describe("document changes", () => {
         ],
       },
     });
-    expect(session.snapshotForTesting.text).toBe("XYZ!");
+    expect(session.snapshotForTesting.source.originalText).toBe("XYZ!");
   });
 
   it("deletes the entire document", () => {
@@ -263,7 +285,7 @@ describe("document changes", () => {
       baseRevision: session.revision,
       document: { kind: "changes", changes: [{ from: 0, insert: "", to: 8 }] },
     });
-    expect(session.snapshotForTesting.text).toBe("");
+    expect(session.snapshotForTesting.source.originalText).toBe("");
   });
 
   it("allows edits at every UTF-16 boundary", () => {
@@ -280,7 +302,9 @@ describe("document changes", () => {
         ],
       },
     });
-    expect(session.snapshotForTesting.text).toBe("A\uD83DXe\u0301\nZ!\uD800");
+    expect(session.snapshotForTesting.source.originalText).toBe(
+      "A\uD83DXe\u0301\nZ!\uD800",
+    );
   });
 
   it.each([
@@ -305,7 +329,7 @@ describe("document changes", () => {
     });
 
     expect(session.revision).toBe(revision);
-    expect(session.snapshotForTesting.text).toBe("ABC");
+    expect(session.snapshotForTesting.source.originalText).toBe("ABC");
   });
 
   it("rejects unordered and overlapping changes atomically", () => {
@@ -325,7 +349,7 @@ describe("document changes", () => {
       });
     });
     expect(session.revision).toBe(revision);
-    expect(session.snapshotForTesting.text).toBe("ABCDE");
+    expect(session.snapshotForTesting.source.originalText).toBe("ABCDE");
   });
 
   it("rejects non-string inserts from JavaScript callers", () => {
@@ -356,7 +380,7 @@ describe("document changes", () => {
       session.update({ kind: "document", baseRevision: revision, document } as never);
     });
     expect(session.revision).toBe(revision);
-    expect(session.snapshotForTesting.text).toBe("ABC");
+    expect(session.snapshotForTesting.source.originalText).toBe("ABC");
   });
 
   it("rejects an empty JavaScript update", () => {
@@ -423,7 +447,7 @@ describe("document changes", () => {
       baseRevision: session.revision,
       document: { kind: "replace", text: "recovered" },
     });
-    expect(session.snapshotForTesting.text).toBe("recovered");
+    expect(session.snapshotForTesting.source.originalText).toBe("recovered");
   });
 
   it.each([null, "invalid", 42])(
@@ -454,7 +478,7 @@ describe("document changes", () => {
       session.update(accessor as never);
     });
     expect(invoked).toBe(false);
-    expect(session.snapshotForTesting.text).toBe("ABC");
+    expect(session.snapshotForTesting.source.originalText).toBe("ABC");
   });
 
   it("rejects undefined and accessor optional update fields", () => {
@@ -469,7 +493,7 @@ describe("document changes", () => {
       } as never);
     });
     expect(session.revision).toBe(revision);
-    expect(session.snapshotForTesting.text).toBe("ABC");
+    expect(session.snapshotForTesting.source.originalText).toBe("ABC");
 
     let invoked = false;
     const update = {
@@ -486,7 +510,7 @@ describe("document changes", () => {
     });
     expect(invoked).toBe(false);
     expect(session.revision).toBe(revision);
-    expect(session.snapshotForTesting.text).toBe("ABC");
+    expect(session.snapshotForTesting.source.originalText).toBe("ABC");
   });
 
   it("rejects accessor document fields without invoking them", () => {
@@ -571,7 +595,7 @@ describe("document changes", () => {
 
     expect(nestedError?.code).toBe("reentrant-update");
     expect(session.isCurrent(revision)).toBe(true);
-    expect(session.snapshotForTesting.text).toBe("outer");
+    expect(session.snapshotForTesting.source.originalText).toBe("outer");
   });
 
   it("cannot commit an update after reentrant disposal", () => {
@@ -600,7 +624,7 @@ describe("document changes", () => {
       });
     });
     expect(session.isCurrent(revision)).toBe(false);
-    expect(session.snapshotForTesting.text).toBe("ABC");
+    expect(session.snapshotForTesting.source.originalText).toBe("ABC");
   });
 
   it("bounds fragmented and oversized document updates", () => {
@@ -631,7 +655,7 @@ describe("document changes", () => {
         },
       });
     });
-    expect(session.snapshotForTesting.text).toBe("");
+    expect(session.snapshotForTesting.source.originalText).toBe("");
   });
 });
 
@@ -746,7 +770,7 @@ describe("document context", () => {
 
     expect(session.snapshotForTesting).toMatchObject({
       context: { dialect: "postgres", engine: "warehouse" },
-      text: "SELECT 2",
+      source: { originalText: "SELECT 2" },
     });
 
     const snapshot = session.snapshotForTesting;
@@ -768,7 +792,7 @@ describe("document context", () => {
       baseRevision: session.revision,
       context: { dialect: "postgres", engine: "warehouse" },
     });
-    expect(session.snapshotForTesting.text).toBe("SELECT 1");
+    expect(session.snapshotForTesting.source.originalText).toBe("SELECT 1");
     expect(session.snapshotForTesting.context.dialect).toBe("postgres");
   });
 
@@ -821,7 +845,7 @@ describe("document context", () => {
       } as never);
     });
     expect(session.revision).toBe(revision);
-    expect(session.snapshotForTesting.text).toBe("SELECT 1");
+    expect(session.snapshotForTesting.source.originalText).toBe("SELECT 1");
   });
 
   it("rejects accessors without invoking them", () => {

--- a/src/vnext/__tests__/source.test.ts
+++ b/src/vnext/__tests__/source.test.ts
@@ -1,0 +1,427 @@
+import { describe, expect, it } from "vitest";
+import {
+  createIdentitySqlSource,
+  createMaskedSqlSource,
+  mapAnalysisRangeToOriginal,
+  mapOriginalRangeToAnalysis,
+  MAX_SQL_EMBEDDED_REGIONS,
+  MAX_SQL_SOURCE_LENGTH,
+  normalizeSqlTextRange,
+  SqlSourceError,
+} from "../source.js";
+
+function expectSourceError(
+  code: SqlSourceError["code"],
+  operation: () => unknown,
+): void {
+  try {
+    operation();
+  } catch (error) {
+    if (!(error instanceof SqlSourceError)) {
+      throw error;
+    }
+    expect(error.code).toBe(code);
+    return;
+  }
+  throw new Error(`Expected SqlSourceError with code ${code}`);
+}
+
+describe("SQL text ranges", () => {
+  it("normalizes frozen half-open UTF-16 ranges", () => {
+    const input = { from: 1, to: 3 };
+    const range = normalizeSqlTextRange(input, 3);
+
+    expect(range).toEqual(input);
+    expect(range).not.toBe(input);
+    expect(Object.isFrozen(range)).toBe(true);
+    expect(normalizeSqlTextRange({ from: 3, to: 3 }, 3)).toEqual({
+      from: 3,
+      to: 3,
+    });
+  });
+
+  it.each([
+    null,
+    "",
+    {},
+    { from: 0 },
+    { from: -1, to: 0 },
+    { from: 1, to: 0 },
+    { from: 0.5, to: 1 },
+    { from: 0, to: 2 },
+    { from: Number.NaN, to: 0 },
+    { from: 0, to: Number.POSITIVE_INFINITY },
+  ])("rejects malformed ranges %#", (range) => {
+    expectSourceError("invalid-range", () => {
+      normalizeSqlTextRange(range, 1);
+    });
+  });
+
+  it.each([-1, 0.5, Number.NaN, MAX_SQL_SOURCE_LENGTH + 1])(
+    "rejects invalid source length %s",
+    (sourceLength) => {
+      expectSourceError("invalid-range", () => {
+        normalizeSqlTextRange({ from: 0, to: 0 }, sourceLength);
+      });
+    },
+  );
+
+  it("does not invoke accessors or proxy get traps", () => {
+    let accessorInvoked = false;
+    expectSourceError("invalid-source", () => {
+      normalizeSqlTextRange(
+        {
+          get from() {
+            accessorInvoked = true;
+            return 0;
+          },
+          to: 0,
+        },
+        0,
+      );
+    });
+    expect(accessorInvoked).toBe(false);
+
+    let getInvoked = false;
+    const range = new Proxy(
+      { from: 0, to: 0 },
+      {
+        get(target, property, receiver) {
+          getInvoked = true;
+          return Reflect.get(target, property, receiver);
+        },
+      },
+    );
+    expect(normalizeSqlTextRange(range, 0)).toEqual({ from: 0, to: 0 });
+    expect(getInvoked).toBe(false);
+  });
+
+  it("normalizes hostile proxy failures", () => {
+    expectSourceError("invalid-source", () => {
+      normalizeSqlTextRange(
+        new Proxy(
+          {},
+          {
+            getOwnPropertyDescriptor() {
+              throw new Error("hostile");
+            },
+          },
+        ),
+        0,
+      );
+    });
+  });
+
+  it("does not inspect arbitrary values thrown by proxies", () => {
+    const hostileError = new Proxy(
+      {},
+      {
+        getPrototypeOf() {
+          throw new Error("secondary");
+        },
+      },
+    );
+    expectSourceError("invalid-source", () => {
+      normalizeSqlTextRange(
+        new Proxy(
+          {},
+          {
+            getOwnPropertyDescriptor() {
+              throw hostileError;
+            },
+          },
+        ),
+        0,
+      );
+    });
+  });
+});
+
+describe("SQL source snapshots", () => {
+  it("creates frozen identity snapshots", () => {
+    const source = createIdentitySqlSource("SELECT 😀");
+
+    expect(source.originalText).toBe("SELECT 😀");
+    expect(source.analysisText).toBe(source.originalText);
+    expect(source.embeddedRegions).toEqual([]);
+    expect(Object.isFrozen(source)).toBe(true);
+    expect(Object.isFrozen(source.embeddedRegions)).toBe(true);
+  });
+
+  it("bounds and validates source text", () => {
+    expectSourceError("invalid-source", () => {
+      createIdentitySqlSource(42);
+    });
+    expectSourceError("invalid-source", () => {
+      createIdentitySqlSource("x".repeat(MAX_SQL_SOURCE_LENGTH + 1));
+    });
+  });
+
+  it("masks every non-newline UTF-16 code unit", () => {
+    const originalText = "a😀\r\nb\uD800c";
+    const source = createMaskedSqlSource(originalText, [
+      { from: 1, language: "python", to: 7 },
+    ]);
+
+    expect(source.originalText).toBe(originalText);
+    expect(source.analysisText).toBe("a  \r\n  c");
+    expect(source.analysisText.length).toBe(originalText.length);
+    expect(source.embeddedRegions).toEqual([
+      { from: 1, language: "python", to: 7 },
+    ]);
+    expect(Object.isFrozen(source)).toBe(true);
+    expect(Object.isFrozen(source.embeddedRegions)).toBe(true);
+    expect(Object.isFrozen(source.embeddedRegions[0])).toBe(true);
+  });
+
+  it("owns normalized embedded regions", () => {
+    const first = { from: 0, language: "python", to: 1 };
+    const regions = [first, { from: 2, language: "jinja", to: 3 }];
+    const source = createMaskedSqlSource("abc", regions);
+
+    first.from = 1;
+    regions.push({ from: 1, language: "other", to: 2 });
+    expect(source.embeddedRegions).toEqual([
+      { from: 0, language: "python", to: 1 },
+      { from: 2, language: "jinja", to: 3 },
+    ]);
+    expect(source.analysisText).toBe(" b ");
+  });
+
+  it.each([
+    null,
+    {},
+    [42],
+    [{ from: 0, language: "python", to: 0 }],
+    [{ from: -1, language: "python", to: 1 }],
+    [{ from: 0, language: "", to: 1 }],
+    [{ from: 0, language: "x".repeat(257), to: 1 }],
+    [
+      { from: 1, language: "python", to: 2 },
+      { from: 0, language: "python", to: 1 },
+    ],
+    [
+      { from: 0, language: "python", to: 2 },
+      { from: 1, language: "python", to: 3 },
+    ],
+  ])("rejects malformed embedded regions %#", (regions) => {
+    expectSourceError("invalid-region", () => {
+      createMaskedSqlSource("abc", regions);
+    });
+  });
+
+  it("rejects sparse, oversized, and extended region arrays", () => {
+    const sparse: unknown[] = [];
+    sparse.length = 1;
+    expectSourceError("invalid-source", () => {
+      createMaskedSqlSource("a", sparse);
+    });
+
+    const oversized: unknown[] = [];
+    oversized.length = MAX_SQL_EMBEDDED_REGIONS + 1;
+    expectSourceError("invalid-region", () => {
+      createMaskedSqlSource("a", oversized);
+    });
+
+    const extended = [{ from: 0, language: "python", to: 1 }];
+    Object.defineProperty(extended, "custom", { value: true });
+    expectSourceError("invalid-region", () => {
+      createMaskedSqlSource("a", extended);
+    });
+  });
+
+  it("does not invoke region accessors or array get traps", () => {
+    let accessorInvoked = false;
+    expectSourceError("invalid-source", () => {
+      createMaskedSqlSource("a", [
+        {
+          get from() {
+            accessorInvoked = true;
+            return 0;
+          },
+          language: "python",
+          to: 1,
+        },
+      ]);
+    });
+    expect(accessorInvoked).toBe(false);
+
+    expectSourceError("invalid-source", () => {
+      createMaskedSqlSource("a", [
+        {
+          from: 0,
+          get language() {
+            accessorInvoked = true;
+            return "python";
+          },
+          to: 1,
+        },
+      ]);
+    });
+    expect(accessorInvoked).toBe(false);
+
+    let getInvoked = false;
+    const regions = new Proxy([{ from: 0, language: "python", to: 1 }], {
+      get(target, property, receiver) {
+        getInvoked = true;
+        return Reflect.get(target, property, receiver);
+      },
+    });
+    expect(createMaskedSqlSource("a", regions).analysisText).toBe(" ");
+    expect(getInvoked).toBe(false);
+  });
+
+  it("normalizes hostile region proxy failures", () => {
+    expectSourceError("invalid-source", () => {
+      createMaskedSqlSource(
+        "a",
+        new Proxy(
+          [],
+          {
+            ownKeys() {
+              throw new Error("hostile");
+            },
+          },
+        ),
+      );
+    });
+  });
+
+  it("normalizes hostile values thrown while inspecting regions", () => {
+    const hostileError = new Proxy(
+      {},
+      {
+        getPrototypeOf() {
+          throw new Error("secondary");
+        },
+      },
+    );
+    expectSourceError("invalid-source", () => {
+      createMaskedSqlSource(
+        "a",
+        new Proxy(
+          [],
+          {
+            ownKeys() {
+              throw hostileError;
+            },
+          },
+        ),
+      );
+    });
+  });
+
+  it("maps ranges with fresh frozen values", () => {
+    const source = createMaskedSqlSource("a😀b", [
+      { from: 1, language: "python", to: 3 },
+    ]);
+    const originalRange = { from: 1, to: 3 };
+    const analysisRange = mapOriginalRangeToAnalysis(source, originalRange);
+    const roundTrip = mapAnalysisRangeToOriginal(source, analysisRange);
+
+    expect(analysisRange).toEqual(originalRange);
+    expect(analysisRange).not.toBe(originalRange);
+    expect(roundTrip).toEqual(originalRange);
+    expect(roundTrip).not.toBe(analysisRange);
+    expect(Object.isFrozen(analysisRange)).toBe(true);
+    expect(Object.isFrozen(roundTrip)).toBe(true);
+  });
+
+  it("preserves masking invariants across deterministic random cases", () => {
+    let state = 0x51_0f_aa_7d;
+    const next = (limit: number): number => {
+      state = (Math.imul(state, 1_664_525) + 1_013_904_223) >>> 0;
+      return state % limit;
+    };
+    const tokens = ["a", " ", "\r", "\n", "😀", "\uD800"];
+
+    for (let iteration = 0; iteration < 250; iteration += 1) {
+      let text = "";
+      const tokenCount = next(50) + 1;
+      for (let index = 0; index < tokenCount; index += 1) {
+        const token = tokens[next(tokens.length)];
+        if (token === undefined) {
+          throw new Error("Random token index was out of bounds");
+        }
+        text += token;
+      }
+
+      const regions: Array<{
+        from: number;
+        language: string;
+        to: number;
+      }> = [];
+      let cursor = 0;
+      while (cursor < text.length) {
+        cursor += next(4);
+        if (cursor >= text.length) {
+          break;
+        }
+        const to = Math.min(text.length, cursor + next(5) + 1);
+        regions.push({ from: cursor, language: "embedded", to });
+        cursor = to + next(3);
+      }
+
+      const source = createMaskedSqlSource(text, regions);
+      expect(source.analysisText.length).toBe(text.length);
+      for (let offset = 0; offset < text.length; offset += 1) {
+        const masked = regions.some(
+          (region) => region.from <= offset && offset < region.to,
+        );
+        const original = text.slice(offset, offset + 1);
+        const expected =
+          masked && original !== "\r" && original !== "\n" ? " " : original;
+        expect(source.analysisText.slice(offset, offset + 1)).toBe(expected);
+      }
+
+      const from = next(text.length + 1);
+      const to = from + next(text.length - from + 1);
+      expect(
+        mapAnalysisRangeToOriginal(
+          source,
+          mapOriginalRangeToAnalysis(source, { from, to }),
+        ),
+      ).toEqual({ from, to });
+    }
+  });
+
+  it("masks newline-dense text at the source limit", () => {
+    const text = "\r\n".repeat(MAX_SQL_SOURCE_LENGTH / 2);
+    const start = performance.now();
+    const source = createMaskedSqlSource(text, [
+      { from: 0, language: "embedded", to: text.length },
+    ]);
+    const duration = performance.now() - start;
+
+    expect(source.analysisText).toBe(text);
+    expect(source.analysisText.length).toBe(text.length);
+    expect(duration).toBeLessThan(2_000);
+  });
+
+  it("masks alternating text and the maximum region count", () => {
+    const alternatingText = "x\n".repeat(512 * 1024);
+    const alternatingStart = performance.now();
+    const alternating = createMaskedSqlSource(alternatingText, [
+      { from: 0, language: "embedded", to: alternatingText.length },
+    ]);
+    const alternatingDuration = performance.now() - alternatingStart;
+    expect(alternating.analysisText).toBe(" \n".repeat(512 * 1024));
+
+    const fragmentedText = "xy".repeat(MAX_SQL_EMBEDDED_REGIONS);
+    const regions = Array.from(
+      { length: MAX_SQL_EMBEDDED_REGIONS },
+      (_, index) => ({
+        from: index * 2,
+        language: "embedded",
+        to: index * 2 + 1,
+      }),
+    );
+    const fragmentedStart = performance.now();
+    const fragmented = createMaskedSqlSource(fragmentedText, regions);
+    const fragmentedDuration = performance.now() - fragmentedStart;
+    expect(fragmented.analysisText).toBe(" y".repeat(MAX_SQL_EMBEDDED_REGIONS));
+
+    expect(alternatingDuration).toBeLessThan(2_000);
+    expect(fragmentedDuration).toBeLessThan(2_000);
+  });
+});

--- a/src/vnext/index.ts
+++ b/src/vnext/index.ts
@@ -19,5 +19,6 @@ export type {
   SqlRevision,
   SqlSessionErrorCode,
   SqlTextChange,
+  SqlTextRange,
 } from "./types.js";
 export { SqlSessionError } from "./types.js";

--- a/src/vnext/session.ts
+++ b/src/vnext/session.ts
@@ -8,7 +8,15 @@ import type {
   SqlLanguageServiceOptions,
   SqlRevision,
   SqlTextChange,
+  SqlTextRange,
 } from "./types.js";
+import {
+  createIdentitySqlSource,
+  isSqlSourceError,
+  MAX_SQL_SOURCE_LENGTH,
+  normalizeSqlTextRange,
+  type SqlSourceSnapshot,
+} from "./source.js";
 import { createSqlRevisionToken, SqlSessionError } from "./types.js";
 
 const MAX_CONTEXT_DEPTH = 100;
@@ -17,7 +25,6 @@ const MAX_CONTEXT_PROPERTIES = 50_000;
 const MAX_CONTEXT_KEY_LENGTH = 1_000_000;
 const MAX_CONTEXT_STRING_LENGTH = 1_000_000;
 const MAX_CONTEXT_ARRAY_LENGTH = 50_000;
-const MAX_DOCUMENT_LENGTH = 16 * 1024 * 1024;
 const MAX_CHANGES_PER_UPDATE = 10_000;
 const MAX_DIALECTS = 1_000;
 const MAX_DIALECT_ID_LENGTH = 256;
@@ -306,10 +313,10 @@ function readRequiredDataProperty(
 }
 
 function validateDocumentLength(text: string): void {
-  if (text.length > MAX_DOCUMENT_LENGTH) {
+  if (text.length > MAX_SQL_SOURCE_LENGTH) {
     throw new SqlSessionError(
       "invalid-document",
-      `SQL documents cannot exceed ${MAX_DOCUMENT_LENGTH} UTF-16 code units`,
+      `SQL documents cannot exceed ${MAX_SQL_SOURCE_LENGTH} UTF-16 code units`,
     );
   }
 }
@@ -355,39 +362,29 @@ function normalizeChanges(text: string, changes: readonly unknown[]): SqlTextCha
         `SQL change ${index} must be an object`,
       );
     }
-    const from = readRequiredDataProperty(
-      change,
-      "from",
-      "invalid-change",
-      `SQL change ${index}`,
-    );
-    const to = readRequiredDataProperty(
-      change,
-      "to",
-      "invalid-change",
-      `SQL change ${index}`,
-    );
+    let range: SqlTextRange;
+    try {
+      range = normalizeSqlTextRange(
+        change,
+        text.length,
+        `SQL change ${index}`,
+      );
+    } catch (error) {
+      if (!isSqlSourceError(error)) {
+        throw error;
+      }
+      throw new SqlSessionError(
+        "invalid-change",
+        `Invalid UTF-16 range in SQL change ${index}`,
+      );
+    }
     const insert = readRequiredDataProperty(
       change,
       "insert",
       "invalid-change",
       `SQL change ${index}`,
     );
-    if (
-      typeof from !== "number" ||
-      typeof to !== "number" ||
-      !Number.isSafeInteger(from) ||
-      !Number.isSafeInteger(to) ||
-      from < 0 ||
-      from > to ||
-      to > text.length
-    ) {
-      throw new SqlSessionError(
-        "invalid-change",
-        `Invalid UTF-16 range in SQL change ${index}`,
-      );
-    }
-    if (from < previousEnd) {
+    if (range.from < previousEnd) {
       throw new SqlSessionError(
         "invalid-change",
         "SQL document changes must be ordered and non-overlapping",
@@ -396,21 +393,21 @@ function normalizeChanges(text: string, changes: readonly unknown[]): SqlTextCha
     if (typeof insert !== "string") {
       throw new SqlSessionError("invalid-change", "SQL change insert must be a string");
     }
-    nextLength += insert.length - (to - from);
-    if (nextLength > MAX_DOCUMENT_LENGTH) {
+    nextLength += insert.length - (range.to - range.from);
+    if (nextLength > MAX_SQL_SOURCE_LENGTH) {
       throw new SqlSessionError(
         "invalid-document",
-        `SQL documents cannot exceed ${MAX_DOCUMENT_LENGTH} UTF-16 code units`,
+        `SQL documents cannot exceed ${MAX_SQL_SOURCE_LENGTH} UTF-16 code units`,
       );
     }
     normalized.push(
       Object.freeze({
-        from,
+        from: range.from,
         insert,
-        to,
+        to: range.to,
       }),
     );
-    previousEnd = to;
+    previousEnd = range.to;
   }
 
   return normalized;
@@ -433,7 +430,7 @@ interface SessionSnapshot<Context extends SqlDocumentContext> {
   readonly documentSequence: number;
   readonly revision: SqlRevision;
   readonly sequence: number;
-  readonly text: string;
+  readonly source: SqlSourceSnapshot;
 }
 
 export class DefaultSqlDocumentSession<Context extends SqlDocumentContext>
@@ -446,7 +443,7 @@ export class DefaultSqlDocumentSession<Context extends SqlDocumentContext>
   #updating = false;
 
   constructor(
-    text: string,
+    source: SqlSourceSnapshot,
     context: Context,
     dialects: ReadonlySet<string>,
     onDispose: () => void,
@@ -462,7 +459,7 @@ export class DefaultSqlDocumentSession<Context extends SqlDocumentContext>
       documentSequence,
       revision: createSqlRevisionToken(),
       sequence,
-      text,
+      source,
     });
   }
 
@@ -532,7 +529,7 @@ export class DefaultSqlDocumentSession<Context extends SqlDocumentContext>
     let nextContextSequence = this.#snapshot.contextSequence;
     let nextContext = this.#snapshot.context;
     let nextDocumentSequence = this.#snapshot.documentSequence;
-    let nextText = this.#snapshot.text;
+    let nextSource = this.#snapshot.source;
 
     if (kind === "context") {
       if (
@@ -624,7 +621,7 @@ export class DefaultSqlDocumentSession<Context extends SqlDocumentContext>
           );
         }
         validateDocumentLength(text);
-        nextText = text;
+        nextSource = createIdentitySqlSource(text);
       } else if (documentKind === "changes") {
         if (
           readOwnDataProperty(
@@ -651,8 +648,13 @@ export class DefaultSqlDocumentSession<Context extends SqlDocumentContext>
             "SQL document changes must be an array",
           );
         }
-        const normalizedChanges = normalizeChanges(nextText, changes);
-        nextText = applyChanges(nextText, normalizedChanges);
+        const normalizedChanges = normalizeChanges(
+          nextSource.originalText,
+          changes,
+        );
+        nextSource = createIdentitySqlSource(
+          applyChanges(nextSource.originalText, normalizedChanges),
+        );
       } else {
         throw new SqlSessionError(
           "invalid-update",
@@ -677,7 +679,7 @@ export class DefaultSqlDocumentSession<Context extends SqlDocumentContext>
       documentSequence: nextDocumentSequence,
       revision,
       sequence,
-      text: nextText,
+      source: nextSource,
     });
     return revision;
   }
@@ -790,6 +792,7 @@ export class DefaultSqlLanguageService<Context extends SqlDocumentContext>
         );
       }
       validateDocumentLength(text);
+      const source = createIdentitySqlSource(text);
       const candidateContext = readRequiredDataProperty(
         input,
         "context",
@@ -807,7 +810,7 @@ export class DefaultSqlLanguageService<Context extends SqlDocumentContext>
 
       let session: DefaultSqlDocumentSession<Context>;
       session = new DefaultSqlDocumentSession(
-        text,
+        source,
         context,
         this.#dialects,
         () => {

--- a/src/vnext/source.ts
+++ b/src/vnext/source.ts
@@ -1,0 +1,362 @@
+import type { SqlTextRange } from "./types.js";
+
+export const MAX_SQL_SOURCE_LENGTH = 16 * 1024 * 1024;
+export const MAX_SQL_EMBEDDED_REGIONS = 10_000;
+
+const MAX_EMBEDDED_LANGUAGE_LENGTH = 256;
+const MASK_CHUNK_LENGTH = 64 * 1024;
+const EMPTY_EMBEDDED_REGIONS: readonly SqlEmbeddedRegion[] = Object.freeze([]);
+const sourceErrors = new WeakSet<object>();
+
+export type SqlSourceErrorCode =
+  | "invalid-source"
+  | "invalid-range"
+  | "invalid-region";
+
+export class SqlSourceError extends Error {
+  readonly code: SqlSourceErrorCode;
+
+  constructor(code: SqlSourceErrorCode, message: string) {
+    super(message);
+    this.name = "SqlSourceError";
+    this.code = code;
+    sourceErrors.add(this);
+  }
+}
+
+export function isSqlSourceError(error: unknown): error is SqlSourceError {
+  return (
+    error !== null &&
+    typeof error === "object" &&
+    sourceErrors.has(error)
+  );
+}
+
+export interface SqlEmbeddedRegion extends SqlTextRange {
+  readonly language: string;
+}
+
+export interface SqlSourceSnapshot {
+  readonly analysisText: string;
+  readonly embeddedRegions: readonly SqlEmbeddedRegion[];
+  readonly originalText: string;
+}
+
+interface MissingDataProperty {
+  readonly found: false;
+}
+
+interface FoundDataProperty {
+  readonly found: true;
+  readonly value: unknown;
+}
+
+type DataProperty = MissingDataProperty | FoundDataProperty;
+
+function readOwnDataProperty(
+  value: object,
+  key: PropertyKey,
+  subject: string,
+): DataProperty {
+  const descriptor = Object.getOwnPropertyDescriptor(value, key);
+  if (!descriptor) {
+    return { found: false };
+  }
+  if (!("value" in descriptor)) {
+    throw new SqlSourceError(
+      "invalid-source",
+      `${subject} property ${String(key)} cannot be an accessor`,
+    );
+  }
+  return { found: true, value: descriptor.value };
+}
+
+function readRequiredDataProperty(
+  value: object,
+  key: PropertyKey,
+  subject: string,
+  missingCode: SqlSourceErrorCode = "invalid-source",
+): unknown {
+  const property = readOwnDataProperty(value, key, subject);
+  if (!property.found) {
+    throw new SqlSourceError(
+      missingCode,
+      `${subject} requires a data property named ${String(key)}`,
+    );
+  }
+  return property.value;
+}
+
+function normalizeSourceError(error: unknown, message: string): never {
+  if (isSqlSourceError(error)) {
+    throw error;
+  }
+  throw new SqlSourceError("invalid-source", message);
+}
+
+function normalizeSourceText(text: unknown): string {
+  if (typeof text !== "string") {
+    throw new SqlSourceError("invalid-source", "SQL source text must be a string");
+  }
+  if (text.length > MAX_SQL_SOURCE_LENGTH) {
+    throw new SqlSourceError(
+      "invalid-source",
+      `SQL source cannot exceed ${MAX_SQL_SOURCE_LENGTH} UTF-16 code units`,
+    );
+  }
+  return text;
+}
+
+export function normalizeSqlTextRange(
+  range: unknown,
+  sourceLength: number,
+  subject = "SQL text range",
+): SqlTextRange {
+  try {
+    if (
+      !Number.isSafeInteger(sourceLength) ||
+      sourceLength < 0 ||
+      sourceLength > MAX_SQL_SOURCE_LENGTH
+    ) {
+      throw new SqlSourceError(
+        "invalid-range",
+        "SQL range source length is invalid",
+      );
+    }
+    if (range === null || typeof range !== "object") {
+      throw new SqlSourceError(
+        "invalid-range",
+        `${subject} must be an object`,
+      );
+    }
+    const from = readRequiredDataProperty(
+      range,
+      "from",
+      subject,
+      "invalid-range",
+    );
+    const to = readRequiredDataProperty(range, "to", subject, "invalid-range");
+    if (
+      typeof from !== "number" ||
+      typeof to !== "number" ||
+      !Number.isSafeInteger(from) ||
+      !Number.isSafeInteger(to) ||
+      from < 0 ||
+      from > to ||
+      to > sourceLength
+    ) {
+      throw new SqlSourceError(
+        "invalid-range",
+        `${subject} must be an in-bounds half-open UTF-16 range`,
+      );
+    }
+    return Object.freeze({ from, to });
+  } catch (error) {
+    return normalizeSourceError(error, `${subject} could not be inspected safely`);
+  }
+}
+
+function readArrayLength(value: readonly unknown[]): number {
+  const length = readRequiredDataProperty(
+    value,
+    "length",
+    "SQL embedded regions",
+  );
+  if (typeof length !== "number" || !Number.isSafeInteger(length) || length < 0) {
+    throw new SqlSourceError(
+      "invalid-region",
+      "SQL embedded regions have an invalid length",
+    );
+  }
+  return length;
+}
+
+function validateRegionArrayKeys(
+  regions: readonly unknown[],
+  length: number,
+): void {
+  for (const key of Reflect.ownKeys(regions)) {
+    if (key === "length") {
+      continue;
+    }
+    if (
+      typeof key !== "string" ||
+      !/^(0|[1-9]\d*)$/.test(key) ||
+      Number(key) >= length
+    ) {
+      throw new SqlSourceError(
+        "invalid-region",
+        "SQL embedded regions cannot contain custom properties",
+      );
+    }
+  }
+}
+
+function normalizeEmbeddedRegions(
+  regions: unknown,
+  sourceLength: number,
+): readonly SqlEmbeddedRegion[] {
+  try {
+    if (!Array.isArray(regions)) {
+      throw new SqlSourceError(
+        "invalid-region",
+        "SQL embedded regions must be an array",
+      );
+    }
+    const length = readArrayLength(regions);
+    if (length > MAX_SQL_EMBEDDED_REGIONS) {
+      throw new SqlSourceError(
+        "invalid-region",
+        `SQL source cannot contain more than ${MAX_SQL_EMBEDDED_REGIONS} embedded regions`,
+      );
+    }
+    validateRegionArrayKeys(regions, length);
+
+    const normalized: SqlEmbeddedRegion[] = [];
+    let previousEnd = 0;
+    for (let index = 0; index < length; index += 1) {
+      const candidate = readRequiredDataProperty(
+        regions,
+        index,
+        `SQL embedded region ${index}`,
+      );
+      if (candidate === null || typeof candidate !== "object") {
+        throw new SqlSourceError(
+          "invalid-region",
+          `SQL embedded region ${index} must be an object`,
+        );
+      }
+      let range: SqlTextRange;
+      try {
+        range = normalizeSqlTextRange(
+          candidate,
+          sourceLength,
+          `SQL embedded region ${index}`,
+        );
+      } catch (error) {
+        if (
+          !isSqlSourceError(error) ||
+          error.code !== "invalid-range"
+        ) {
+          throw error;
+        }
+        throw new SqlSourceError(
+          "invalid-region",
+          `SQL embedded region ${index} has an invalid range`,
+        );
+      }
+      if (range.from === range.to) {
+        throw new SqlSourceError(
+          "invalid-region",
+          `SQL embedded region ${index} cannot be empty`,
+        );
+      }
+      if (range.from < previousEnd) {
+        throw new SqlSourceError(
+          "invalid-region",
+          "SQL embedded regions must be ordered and non-overlapping",
+        );
+      }
+      const language = readRequiredDataProperty(
+        candidate,
+        "language",
+        `SQL embedded region ${index}`,
+      );
+      if (
+        typeof language !== "string" ||
+        language.length === 0 ||
+        language.length > MAX_EMBEDDED_LANGUAGE_LENGTH
+      ) {
+        throw new SqlSourceError(
+          "invalid-region",
+          `SQL embedded region ${index} has an invalid language`,
+        );
+      }
+      normalized.push(
+        Object.freeze({
+          from: range.from,
+          language,
+          to: range.to,
+        }),
+      );
+      previousEnd = range.to;
+    }
+    return Object.freeze(normalized);
+  } catch (error) {
+    return normalizeSourceError(
+      error,
+      "SQL embedded regions could not be inspected safely",
+    );
+  }
+}
+
+function maskRegion(text: string, from: number, to: number): string {
+  let output = "";
+  for (let cursor = from; cursor < to; cursor += MASK_CHUNK_LENGTH) {
+    const chunk = text.slice(cursor, Math.min(to, cursor + MASK_CHUNK_LENGTH));
+    output += chunk.replace(/[^\r\n]+/g, (value) => " ".repeat(value.length));
+  }
+  return output;
+}
+
+export function createIdentitySqlSource(text: unknown): SqlSourceSnapshot {
+  const originalText = normalizeSourceText(text);
+  return Object.freeze({
+    analysisText: originalText,
+    embeddedRegions: EMPTY_EMBEDDED_REGIONS,
+    originalText,
+  });
+}
+
+export function createMaskedSqlSource(
+  text: unknown,
+  regions: unknown,
+): SqlSourceSnapshot {
+  const originalText = normalizeSourceText(text);
+  const embeddedRegions = normalizeEmbeddedRegions(
+    regions,
+    originalText.length,
+  );
+  if (embeddedRegions.length === 0) {
+    return createIdentitySqlSource(originalText);
+  }
+
+  const output: string[] = [];
+  let cursor = 0;
+  for (const region of embeddedRegions) {
+    output.push(
+      originalText.slice(cursor, region.from),
+      maskRegion(originalText, region.from, region.to),
+    );
+    cursor = region.to;
+  }
+  output.push(originalText.slice(cursor));
+  const analysisText = output.join("");
+  return Object.freeze({
+    analysisText,
+    embeddedRegions,
+    originalText,
+  });
+}
+
+export function mapAnalysisRangeToOriginal(
+  source: SqlSourceSnapshot,
+  range: unknown,
+): SqlTextRange {
+  return normalizeSqlTextRange(
+    range,
+    source.analysisText.length,
+    "SQL analysis range",
+  );
+}
+
+export function mapOriginalRangeToAnalysis(
+  source: SqlSourceSnapshot,
+  range: unknown,
+): SqlTextRange {
+  return normalizeSqlTextRange(
+    range,
+    source.originalText.length,
+    "SQL original range",
+  );
+}

--- a/src/vnext/types.ts
+++ b/src/vnext/types.ts
@@ -47,10 +47,14 @@ export interface SqlDialectDefinition {
   readonly displayName: string;
 }
 
-/** One half-open UTF-16 edit in pre-update document coordinates. */
-export interface SqlTextChange {
+/** One half-open UTF-16 range in document coordinates. */
+export interface SqlTextRange {
   readonly from: number;
   readonly to: number;
+}
+
+/** One half-open UTF-16 edit in pre-update document coordinates. */
+export interface SqlTextChange extends SqlTextRange {
   readonly insert: string;
 }
 

--- a/test/vnext-types/session.test-d.ts
+++ b/test/vnext-types/session.test-d.ts
@@ -6,6 +6,7 @@ import {
   type SqlLanguageService,
   type SqlRevision,
   type SqlTextChange,
+  type SqlTextRange,
 } from "../../src/vnext/index.js";
 
 interface HostContext extends SqlDocumentContext {
@@ -54,6 +55,7 @@ session.update({
 });
 
 const change: SqlTextChange = { from: 0, insert: "", to: 0 };
+const range: SqlTextRange = change;
 
 // @ts-expect-error revisions are service-issued opaque values
 const objectRevision: SqlRevision = {};
@@ -73,10 +75,13 @@ dateService.openDocument({
 });
 // @ts-expect-error changes are readonly
 change.from = 1;
+// @ts-expect-error ranges are readonly
+range.to = 1;
 // @ts-expect-error session revision is readonly
 session.revision = revision;
 
 void objectRevision;
 void numberRevision;
+void range;
 void widenedService;
 void widenedSession;


### PR DESCRIPTION
## Summary

- publish the minimal `SqlTextRange` UTF-16 contract and make `SqlTextChange` extend it
- add internal immutable identity/masked source snapshots with explicit `originalText` and `analysisText`
- validate and freeze bounded embedded regions without invoking accessors or Proxy `get` traps
- preserve length and every CR/LF offset while masking every other UTF-16 code unit
- store source snapshots in document sessions, reusing them only for context-only updates
- document the intentional boundary: no public transformer or source-map SPI yet
- request Copilot once per PR, without later re-requests

## Invariants and risk

- ranges are safe-integer, in-bounds, half-open UTF-16 offsets
- embedded regions are non-empty, ordered, non-overlapping, and capped at 10,000
- source text is capped at 16 Mi UTF-16 code units
- masking uses bounded 64 Ki-code-unit chunks and cannot allocate per newline
- arbitrary values thrown by hostile Proxy traps are normalized without inspecting them
- document updates create a new source snapshot; context-only updates retain the exact source identity

## Evidence

- `pnpm run typecheck`
- `pnpm exec oxlint`
- `pnpm run test:coverage` (713 passed, 1 governed expected failure)
- changed runtime coverage: 98.78% statements, 97.75% branches, 100% functions, 98.76% lines
- deterministic randomized UTF-16 masking/range round trips
- full 16,777,216-code-unit CRLF mask and 10,000-region smoke cases
- full-limit newline mask succeeds under `node --max-old-space-size=128`
- `pnpm run test:browser`
- `pnpm run test:package`
- `pnpm run test:integrity`
- `pnpm run demo`

## Adversarial review

Two independent exact-head reviewers challenged correctness and performance/API design. The first loop found a newline-density memory amplification and hostile thrown-Proxy escape. Both were redesigned and regression-tested. Both reviewers approve exact SHA `1993a6cdca85ec9d3b8a1ddaab5dda0188b85fab` with no blocker, high, or medium findings.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add internal source coordinate primitives and length-preserving masking to support safe UTF-16 ranges and embedded-region analysis. Export `SqlTextRange` and update sessions to use immutable source snapshots, reusing them for context-only updates.

- New Features
  - Export `SqlTextRange`; make `SqlTextChange` extend it.
  - Add immutable source snapshots with `originalText` and `analysisText`, plus length-preserving masking of embedded regions (CR/LF offsets preserved). No transformer or source-map SPI yet.
  - Validate and freeze inputs with strict caps (16 Mi code units, 10k regions) and accessor-safe normalization.
  - Store source snapshots in document sessions and reuse them on context-only updates.

<sup>Written for commit 1993a6cdca85ec9d3b8a1ddaab5dda0188b85fab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marimo-team/codemirror-sql/pull/173?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

