### PR TITLE
feat(vnext): add incremental statement indexing

### DIFF
--- a/SQL_EDITOR_RESEARCH.md
+++ b/SQL_EDITOR_RESEARCH.md
@@ -708,8 +708,12 @@ Features could degrade honestly based on capabilities instead of treating
 A dialect should be more than CodeMirror highlighting and a
 `node-sql-parser` database name:
 
+The stable API should expose a package-owned opaque dialect handle; the
+following is the kind of internal bundle that handle resolves to, not a
+caller-constructed public object:
+
 ```ts
-interface SqlDialectDefinition {
+interface InternalSqlDialectBundle {
   id: string;
   codeMirrorDialect: SQLDialect;
   parserDialect: string;

--- a/docs/adr/0001-language-service-and-session.md
+++ b/docs/adr/0001-language-service-and-session.md
@@ -110,9 +110,17 @@ interface SqlDocumentContext {
 
 The service resolves dialect IDs through its immutable registry and rejects
 unknown or duplicate IDs. Duplicate registration is rejected even when the
-definitions appear equivalent. Dialect identity includes an internal
-configuration revision; calling a dialect factory again does not change the
-identity of an already registered dialect.
+definitions appear equivalent. The built-in dialect factories return frozen
+opaque singletons backed by package-owned `WeakMap` metadata; repeated calls to
+one factory return the same handle and internal configuration identity. A
+copied, serialized, fabricated, or different-package-instance handle is
+rejected.
+
+Dialect handles are in-process service configuration and do not cross cloning,
+worker, or provider boundaries. Serializable context contains only the
+registered handle's string ID. Another realm or package instance reconstructs
+configuration with its own built-in factory. IDs perform registry lookup but
+never infer lexical behavior.
 
 Hosts can add fields such as engine or SQL mode. Contexts must be
 structured-cloneable plain data. On open/update, the session creates and owns a
@@ -213,8 +221,15 @@ validity, or AST data. It materializes at most 10,000 slots and collapses an
 unscanned remainder into an opaque slot on resource limits or unsupported
 delimiter/procedural constructs. Opaque slots cannot be passed to later parsing
 as exact source. Dialect lexical behavior uses internal configuration identity,
-never a caller-controlled dialect ID. Incremental reuse and session attachment
-remain a separate change tested against the full-scan oracle.
+never a caller-controlled dialect ID.
+
+The full scanner remains the correctness oracle. Incremental indexing restarts
+conservatively at the old slot at or to the left of the earliest trusted
+analysis-coordinate change and converges only at an exact terminated boundary
+mapped to an unchanged old suffix. It reuses the unchanged prefix and either
+reuses or shifts the suffix. Inconsistent metadata falls back to the full
+oracle; absent convergence scans through EOF, and resource or
+unsupported-syntax opacity remains fail-closed.
 
 ## Request outcomes
 
@@ -409,6 +424,12 @@ SPI. Sessions create a new source snapshot for document updates and reuse the
 existing snapshot for context-only updates. Non-identity generated/reordered
 source remains deferred until a concrete consumer validates the segment model.
 
+Current session edits use identity sources, so validated original-document
+changes are also trusted analysis-coordinate changes. A future transformed
+source must provide its own validated analysis-coordinate changes for
+incremental statement indexing. Without them, changed analysis text
+invalidates the index and is rebuilt lazily.
+
 Edits crossing an ambiguous or unmapped boundary are rejected. Mapping failure
 is unavailable analysis, not invalid SQL.
 
@@ -497,6 +518,15 @@ statement can be reused and remapped. Keys include content fingerprint,
 dialect, parser/configuration, and template identities. Catalog changes do not
 invalidate parsing. Renderer, theme, focus, and cursor changes do not invalidate
 semantic artifacts.
+
+The current statement-index cache is private, lazy, and per session. It stores
+only the current index, document sequence, and lexical-profile identity.
+Context-only updates reuse it for the same profile; equal analysis text reuses
+it across a new document revision; trusted identity-source changes update it
+incrementally. A changed replacement, profile change, or transformed source
+without trusted analysis changes clears it for a later full build. Invalid
+updates do not mutate it, disposal clears it, and it retains no source text or
+revision history.
 
 In-flight deduplication uses the same complete key. Cancelling one consumer
 detaches it; shared underlying work is aborted only when no consumers remain.

--- a/docs/vnext/session-primitives.md
+++ b/docs/vnext/session-primitives.md
@@ -16,7 +16,7 @@ contract and the internal immutable source-snapshot model.
 ```ts
 import {
   createSqlLanguageService,
-  defineSqlDialect,
+  duckdbDialect,
   type SqlDocumentContext,
 } from "@marimo-team/codemirror-sql/vnext";
 
@@ -24,15 +24,14 @@ interface AppSqlContext extends SqlDocumentContext {
   readonly engine: string;
 }
 
+const dialect = duckdbDialect();
 const service = createSqlLanguageService<AppSqlContext>({
-  dialects: [
-    defineSqlDialect({ id: "duckdb", displayName: "DuckDB" }),
-  ],
+  dialects: [dialect],
 });
 
 const session = service.openDocument({
   text: "SELECT * FROM users",
-  context: { dialect: "duckdb", engine: "local" },
+  context: { dialect: dialect.id, engine: "local" },
 });
 
 const revision = session.update({
@@ -55,6 +54,20 @@ service.dispose();
 Use `{ kind: "replace", text }` for full replacement and
 `{ kind: "context", baseRevision, context }` for a context-only update.
 
+## Dialect registration
+
+`duckdbDialect()`, `postgresDialect()`, `bigQueryDialect()`, and
+`dremioDialect()` return frozen, opaque built-in handles. Each factory returns
+the same singleton on repeated calls. The service resolves a handle through
+package-owned runtime metadata, so a copied, serialized, fabricated, or
+different-package-instance handle is rejected.
+
+Handles are local service configuration, not transport data. Document context
+contains only the handle's serializable string `id`; a worker or separate
+package instance must call its own built-in factory rather than receive a
+handle through cloning or messaging. The ID selects a registered handle but
+does not itself infer lexical behavior.
+
 ## Contract
 
 - Every accepted update creates a new frozen, service-issued revision.
@@ -71,6 +84,15 @@ Use `{ kind: "replace", text }` for full replacement and
 - Session and service disposal are idempotent and terminal.
 - Synchronous public failures use `SqlSessionError` and a stable `code`; caught
   platform errors are not exposed as causes.
+
+The internal statement index is built lazily per session. Context-only updates
+reuse it when the lexical-profile identity is unchanged. A no-op document
+update or same-text replacement advances the public revision and document
+sequence but can reuse the index. Trusted incremental identity-source changes
+update a populated cache; a changed replacement, profile change, or changed
+transformed source without analysis-coordinate changes clears it for a later
+full build. Invalid updates leave both the session snapshot and cache
+unchanged, and disposal clears the cache.
 
 The safety envelope currently permits at most 10,000 changes in one update, a
 16 Mi-code-unit document, 1,000 registered dialects, and bounded context graph

--- a/docs/vnext/source-coordinates.md
+++ b/docs/vnext/source-coordinates.md
@@ -48,3 +48,16 @@ public.
 The internal [statement index](./statement-index.md) scans `analysisText` and
 uses its length-preserving offsets without publishing analysis-coordinate
 ranges.
+
+Statement-index reuse depends on `analysisText` value and internal lexical
+profile identity, not source-object identity. A document update therefore
+still creates a fresh source snapshot and public revision even when equal
+analysis text permits reuse. The index does not retain either the old or
+current source text.
+
+Current sessions create identity sources, so their validated document changes
+are also trusted analysis-coordinate changes. The masking primitive is not yet
+attached to session updates. A future transformed-source pipeline must produce
+validated analysis-coordinate changes before it can use incremental indexing;
+otherwise a changed analysis document invalidates the cache and receives a
+fresh full build on demand.

--- a/docs/vnext/statement-index.md
+++ b/docs/vnext/statement-index.md
@@ -1,6 +1,6 @@
 # vNext Statement Index
 
-Status: internal full-scan correctness oracle
+Status: internal full-scan oracle with incremental session reuse
 
 The statement index is a synchronous, parser-free partition of
 `analysisText`. It does not classify, parse, validate, or copy statements, and
@@ -41,8 +41,9 @@ run-current-statement commands need different policies.
 ## Dialect profiles
 
 Lexical behavior is carried by immutable internal profile identity. It is never
-inferred from a caller-controlled dialect ID. This first oracle owns profiles
-for:
+inferred from a caller-controlled dialect ID. Frozen built-in dialect
+singletons select package-owned profiles through private runtime metadata. This
+first oracle owns profiles for:
 
 - PostgreSQL: doubled quotes, `E'...'`, dollar-quoted strings, and nested block
   comments, following the
@@ -66,7 +67,36 @@ Unterminated lexical constructs consume the remainder and report their opening
 offset. Regular BigQuery strings also fail closed at a line break, because only
 triple-quoted strings may span lines.
 
-## Complexity and sequencing
+## Incremental updates
+
+The full build remains the correctness oracle. When a session already has an
+index and receives trusted ordered changes in analysis coordinates, the
+incremental path restarts conservatively at the beginning of the old slot at or
+to the left of the earliest change. Slot starts are safe checkpoints because
+lexical and prefix state is normal there.
+
+Scanning continues until an exact terminated boundary maps to the start of an
+unchanged old suffix after the final change. The unchanged prefix is retained;
+the suffix is reused directly when its offset is unchanged or copied with
+shifted frozen ranges when the net edit length changes. Convergence is rejected
+if the combined result would violate the slot limit or make a prior
+resource-limit suffix unsafe to reuse.
+
+Inconsistent change metadata falls back to a fresh full build. If no safe
+boundary converges, scanning continues through EOF. Unsupported procedural or
+custom-delimiter syntax and resource limits remain scanner-produced opaque
+suffixes; the incremental layer never guesses a boundary or creates a new
+opacity reason.
+
+## Session cache and complexity
+
+The index cache is private, lazy, and per session. It retains only the current
+index, document sequence, and lexical-profile identity, not source text or
+history. Context-only updates reuse it for the same profile. Equal analysis
+text reuses it across a new document revision. Trusted identity-source changes
+update it incrementally; changed replacements, profile changes, and transformed
+sources without trusted analysis-coordinate changes invalidate it. Disposal
+clears it.
 
 A full build is linear in UTF-16 code units, retains only slot records and a
 bounded dollar delimiter, and creates no statement substrings. Point lookup is
@@ -74,6 +104,11 @@ logarithmic in slot count. The scanner operates on `analysisText`; the current
 length-preserving source transform makes its analysis ranges valid at the same
 offsets in `originalText`.
 
-This implementation remains the correctness oracle. Incremental rescanning,
-change mapping, cache reuse, and session attachment belong to a later slice and
-must be tested against a fresh full build after arbitrary edits.
+Incremental work is proportional to the rescanned region plus any shifted
+suffix records, with a worst case equal to a full linear scan. Randomized edit
+tests compare every incremental result with a fresh oracle build.
+
+`pnpm run bench:statement-index` measures full and incremental paths on a
+roughly 1 MiB, 1,000-statement document, including a local middle edit and a
+prefix insertion that shifts the reusable suffix. It also measures recovery
+from a resource-limited 10,000-slot index to guard the linear convergence path.

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "test:coverage:changed": "node ./scripts/changed-coverage.mjs",
     "test:browser": "vitest run --config vitest.browser.config.ts",
     "test:integrity": "node ./scripts/check-test-integrity.mjs",
+    "bench:statement-index": "vitest bench --run src/vnext/__tests__/statement-index.bench.ts",
     "test:package": "node ./scripts/clean.mjs && tsc && node ./scripts/package-smoke.mjs",
     "demo": "vite build",
     "build": "node ./scripts/clean.mjs && tsc",

--- a/scripts/package-smoke.mjs
+++ b/scripts/package-smoke.mjs
@@ -174,11 +174,11 @@ try {
     join(temporaryDirectory, "vnext-consumer.mjs"),
     `import {
   createSqlLanguageService,
-  defineSqlDialect,
+  duckdbDialect,
 } from "@marimo-team/codemirror-sql/vnext";
 
 const service = createSqlLanguageService({
-  dialects: [defineSqlDialect({ displayName: "DuckDB", id: "duckdb" })],
+  dialects: [duckdbDialect()],
 });
 const session = service.openDocument({
   context: { dialect: "duckdb" },
@@ -208,7 +208,7 @@ import {
 } from "@marimo-team/codemirror-sql/dialects";
 import {
   createSqlLanguageService,
-  defineSqlDialect,
+  duckdbDialect,
   type SqlDocumentContext,
   type SqlTextRange,
 } from "@marimo-team/codemirror-sql/vnext";
@@ -225,7 +225,7 @@ const extensions: Extension[] = [
 ];
 const parser = new NodeSqlParser();
 const service = createSqlLanguageService<HostContext>({
-  dialects: [defineSqlDialect({ displayName: "DuckDB", id: "duckdb" })],
+  dialects: [duckdbDialect()],
 });
 const session = service.openDocument({
   context: { dialect: "duckdb", engine: "local" },
@@ -266,7 +266,10 @@ if (!dialects.BigQueryDialect || !dialects.DremioDialect || !dialects.DuckDBDial
 }
 if (
   typeof vnext.createSqlLanguageService !== "function" ||
-  typeof vnext.defineSqlDialect !== "function"
+  typeof vnext.bigQueryDialect !== "function" ||
+  typeof vnext.dremioDialect !== "function" ||
+  typeof vnext.duckdbDialect !== "function" ||
+  typeof vnext.postgresDialect !== "function"
 ) {
   throw new Error("vNext package exports are incomplete");
 }
@@ -281,7 +284,7 @@ if (!parseResult.success || !parseResult.ast) {
 }
 
 const service = vnext.createSqlLanguageService({
-  dialects: [vnext.defineSqlDialect({ displayName: "DuckDB", id: "duckdb" })],
+  dialects: [vnext.duckdbDialect()],
 });
 const session = service.openDocument({
   context: { dialect: "duckdb" },

--- a/src/vnext/__tests__/incremental-statement-index.test.ts
+++ b/src/vnext/__tests__/incremental-statement-index.test.ts
@@ -1,0 +1,474 @@
+import { describe, expect, it } from "vitest";
+import {
+  BIGQUERY_SQL_LEXICAL_PROFILE,
+  buildSqlStatementIndex,
+  DREMIO_SQL_LEXICAL_PROFILE,
+  DUCKDB_SQL_LEXICAL_PROFILE,
+  MAX_SQL_STATEMENT_SLOTS,
+  POSTGRESQL_SQL_LEXICAL_PROFILE,
+  type SqlLexicalProfile,
+  type SqlStatementIndex,
+  type SqlStatementSlot,
+  updateSqlStatementIndex,
+} from "../statement-index.js";
+import type { SqlTextChange } from "../types.js";
+
+const PROFILES = [
+  { name: "PostgreSQL", profile: POSTGRESQL_SQL_LEXICAL_PROFILE },
+  { name: "DuckDB", profile: DUCKDB_SQL_LEXICAL_PROFILE },
+  { name: "BigQuery", profile: BIGQUERY_SQL_LEXICAL_PROFILE },
+  { name: "Dremio", profile: DREMIO_SQL_LEXICAL_PROFILE },
+] as const;
+
+function itemAt<Value>(items: readonly Value[], index: number): Value {
+  const item = items[index];
+  if (item === undefined) {
+    throw new Error(`Expected test item at index ${index}`);
+  }
+  return item;
+}
+
+function applyChanges(
+  text: string,
+  changes: readonly SqlTextChange[],
+): string {
+  let cursor = 0;
+  const output: string[] = [];
+  for (const change of changes) {
+    output.push(text.slice(cursor, change.from), change.insert);
+    cursor = change.to;
+  }
+  output.push(text.slice(cursor));
+  return output.join("");
+}
+
+function replaceFirst(
+  text: string,
+  search: string,
+  insert: string,
+): SqlTextChange {
+  const from = text.indexOf(search);
+  if (from < 0) {
+    throw new Error(`Expected ${JSON.stringify(search)} in test SQL`);
+  }
+  return { from, insert, to: from + search.length };
+}
+
+function replaceLast(
+  text: string,
+  search: string,
+  insert: string,
+): SqlTextChange {
+  const from = text.lastIndexOf(search);
+  if (from < 0) {
+    throw new Error(`Expected ${JSON.stringify(search)} in test SQL`);
+  }
+  return { from, insert, to: from + search.length };
+}
+
+function expectDeepFrozen(index: SqlStatementIndex): void {
+  expect(Object.isFrozen(index)).toBe(true);
+  expect(Object.isFrozen(index.slots)).toBe(true);
+  for (const slot of index.slots) {
+    expect(Object.isFrozen(slot)).toBe(true);
+    expect(Object.isFrozen(slot.extent)).toBe(true);
+    expect(Object.isFrozen(slot.endState)).toBe(true);
+    if (slot.boundaryQuality === "exact") {
+      expect(Object.isFrozen(slot.source)).toBe(true);
+      if (slot.terminator) {
+        expect(Object.isFrozen(slot.terminator)).toBe(true);
+      }
+    }
+  }
+}
+
+function expectIncrementalMatchesOracle(
+  previousText: string,
+  changes: readonly SqlTextChange[],
+  profile: SqlLexicalProfile,
+): {
+  readonly nextIndex: SqlStatementIndex;
+  readonly nextText: string;
+  readonly previousIndex: SqlStatementIndex;
+} {
+  const previousIndex = buildSqlStatementIndex(previousText, profile);
+  const nextText = applyChanges(previousText, changes);
+  const nextIndex = updateSqlStatementIndex(
+    previousIndex,
+    nextText,
+    changes,
+    profile,
+  );
+  expect(nextIndex).toEqual(buildSqlStatementIndex(nextText, profile));
+  expectDeepFrozen(nextIndex);
+  return { nextIndex, nextText, previousIndex };
+}
+
+function expectSlot(
+  slots: readonly SqlStatementSlot[],
+  index: number,
+): SqlStatementSlot {
+  return itemAt(slots, index);
+}
+
+describe("incremental statement index lexical transitions", () => {
+  const cases: readonly {
+    readonly change: (text: string) => SqlTextChange;
+    readonly name: string;
+    readonly previousText: string;
+    readonly profile: SqlLexicalProfile;
+  }[] = [
+    {
+      change: (text) => replaceFirst(text, "b;", "b';"),
+      name: "PostgreSQL closes an escape string",
+      previousText: "SELECT E'a;b; SELECT 2",
+      profile: POSTGRESQL_SQL_LEXICAL_PROFILE,
+    },
+    {
+      change: (text) => replaceLast(text, "$tag$", ""),
+      name: "PostgreSQL opens a tagged dollar quote",
+      previousText: "SELECT $tag$a;b$tag$; SELECT 2",
+      profile: POSTGRESQL_SQL_LEXICAL_PROFILE,
+    },
+    {
+      change: (text) => ({
+        from: text.length,
+        insert: " */; SELECT 3",
+        to: text.length,
+      }),
+      name: "DuckDB closes a nested block comment",
+      previousText: "SELECT 1 /* outer /* inner */ ; SELECT 2",
+      profile: DUCKDB_SQL_LEXICAL_PROFILE,
+    },
+    {
+      change: (text) => replaceFirst(text, "$d$", ""),
+      name: "DuckDB removes a dollar-quote opener",
+      previousText: "SELECT $d$a;b$d$; SELECT 2",
+      profile: DUCKDB_SQL_LEXICAL_PROFILE,
+    },
+    {
+      change: (text) => ({
+        from: text.length,
+        insert: '"""; SELECT 3',
+        to: text.length,
+      }),
+      name: "BigQuery closes a raw triple-quoted string",
+      previousText: 'SELECT r"""a;b; SELECT 2',
+      profile: BIGQUERY_SQL_LEXICAL_PROFILE,
+    },
+    {
+      change: (text) => replaceFirst(text, "#", ""),
+      name: "BigQuery removes a hash-comment opener",
+      previousText: "SELECT 1 # hidden; still hidden\nSELECT 2",
+      profile: BIGQUERY_SQL_LEXICAL_PROFILE,
+    },
+    {
+      change: (text) => replaceFirst(text, "b;", "b';"),
+      name: "Dremio closes a standard string",
+      previousText: "SELECT 'a;b; SELECT 2",
+      profile: DREMIO_SQL_LEXICAL_PROFILE,
+    },
+    {
+      change: (text) => replaceFirst(text, "/*", ""),
+      name: "Dremio removes a block-comment opener",
+      previousText: "SELECT 1 /* hidden; */ SELECT 2; SELECT 3",
+      profile: DREMIO_SQL_LEXICAL_PROFILE,
+    },
+  ];
+
+  it.each(cases)("$name", ({ change, previousText, profile }) => {
+    expectIncrementalMatchesOracle(previousText, [change(previousText)], profile);
+  });
+});
+
+describe("incremental statement index edit boundaries", () => {
+  it.each(PROFILES)(
+    "handles empty documents, statement boundaries, and EOF for $name",
+    ({ profile }) => {
+      let text = "";
+      let index = buildSqlStatementIndex(text, profile);
+      const edits: readonly SqlTextChange[][] = [
+        [{ from: 0, insert: ";", to: 0 }],
+        [{ from: 1, insert: "SELECT 1;", to: 1 }],
+        [{ from: 1, insert: "\n", to: 1 }],
+        [{ from: 10, insert: "", to: 11 }],
+        [{ from: 0, insert: "", to: 1 }],
+      ];
+
+      for (const changes of edits) {
+        const nextText = applyChanges(text, changes);
+        index = updateSqlStatementIndex(index, nextText, changes, profile);
+        expect(index).toEqual(buildSqlStatementIndex(nextText, profile));
+        text = nextText;
+      }
+    },
+  );
+
+  it.each(PROFILES)(
+    "matches a full scan after ordered multi-edits for $name",
+    ({ profile }) => {
+      const text = "SELECT 1; SELECT 2; SELECT 3;";
+      const changes: readonly SqlTextChange[] = [
+        { from: 0, insert: "-- lead\n", to: 0 },
+        {
+          from: text.indexOf("2"),
+          insert: "'x;y'",
+          to: text.indexOf("2") + 1,
+        },
+        { from: text.length - 1, insert: "", to: text.length },
+      ];
+      expectIncrementalMatchesOracle(text, changes, profile);
+    },
+  );
+
+  it("falls back to the oracle for inconsistent trusted-change metadata", () => {
+    const profile = DUCKDB_SQL_LEXICAL_PROFILE;
+    const previousText = "SELECT 1; SELECT 2";
+    const previousIndex = buildSqlStatementIndex(previousText, profile);
+    const nextText = "SELECT 10; SELECT 2";
+    const inconsistentChanges = [
+      { from: 7, insert: "10", to: 8 },
+      { from: 4, insert: "x", to: 4 },
+    ];
+    const nextIndex = updateSqlStatementIndex(
+      previousIndex,
+      nextText,
+      inconsistentChanges,
+      profile,
+    );
+    expect(nextIndex).toEqual(buildSqlStatementIndex(nextText, profile));
+  });
+});
+
+describe("incremental statement index opaque and bounded results", () => {
+  it("transitions from a BigQuery procedural opaque suffix to exact slots", () => {
+    const text = "SELECT 1; BEGIN WORK; SELECT 2";
+    const change = replaceFirst(text, "BEGIN WORK", "SELECT 0");
+    const { nextIndex, previousIndex } = expectIncrementalMatchesOracle(
+      text,
+      [change],
+      BIGQUERY_SQL_LEXICAL_PROFILE,
+    );
+    expect(previousIndex.quality).toBe("opaque");
+    expect(nextIndex.quality).toBe("exact");
+  });
+
+  it("transitions from exact PostgreSQL SQL to an opaque routine body", () => {
+    const text =
+      "CREATE FUNCTION f() RETURNS int LANGUAGE SQL RETURN 1; SELECT 2";
+    const change = replaceFirst(text, "RETURN 1", "BEGIN ATOMIC SELECT 1");
+    const { nextIndex, previousIndex } = expectIncrementalMatchesOracle(
+      text,
+      [change],
+      POSTGRESQL_SQL_LEXICAL_PROFILE,
+    );
+    expect(previousIndex.quality).toBe("exact");
+    expect(nextIndex.quality).toBe("opaque");
+    expect(nextIndex.endState).toMatchObject({
+      kind: "opaque",
+      reason: "procedural-block",
+    });
+  });
+
+  it("recomputes a BigQuery custom-delimiter opaque result", () => {
+    const text = "SELECT 1; DELIMITER $$\nSELECT 2$$";
+    const change = replaceFirst(text, "DELIMITER", "SELECT");
+    const { nextIndex, previousIndex } = expectIncrementalMatchesOracle(
+      text,
+      [change],
+      BIGQUERY_SQL_LEXICAL_PROFILE,
+    );
+    expect(previousIndex.quality).toBe("opaque");
+    expect(nextIndex).toEqual(
+      buildSqlStatementIndex(
+        applyChanges(text, [change]),
+        BIGQUERY_SQL_LEXICAL_PROFILE,
+      ),
+    );
+  });
+
+  it("matches the capped oracle when edits change a semicolon storm", () => {
+    const text = ";".repeat(MAX_SQL_STATEMENT_SLOTS + 100);
+    const changes = [
+      { from: 1, insert: "SELECT 1;", to: 1 },
+      {
+        from: MAX_SQL_STATEMENT_SLOTS - 2,
+        insert: "",
+        to: MAX_SQL_STATEMENT_SLOTS + 2,
+      },
+    ];
+    const { nextIndex, previousIndex } = expectIncrementalMatchesOracle(
+      text,
+      changes,
+      DUCKDB_SQL_LEXICAL_PROFILE,
+    );
+    expect(previousIndex.slots).toHaveLength(MAX_SQL_STATEMENT_SLOTS);
+    expect(nextIndex.slots).toHaveLength(MAX_SQL_STATEMENT_SLOTS);
+    expect(nextIndex.endState).toMatchObject({
+      kind: "opaque",
+      reason: "resource-limit",
+    });
+  });
+
+  it("recovers from a resource-limited suffix after separators are removed", () => {
+    const text = ";".repeat(MAX_SQL_STATEMENT_SLOTS + 5);
+    const changes = [
+      {
+        from: 0,
+        insert: "",
+        to: 10,
+      },
+    ];
+    const { nextIndex, previousIndex } = expectIncrementalMatchesOracle(
+      text,
+      changes,
+      DUCKDB_SQL_LEXICAL_PROFILE,
+    );
+    expect(previousIndex.quality).toBe("opaque");
+    expect(nextIndex.quality).toBe("exact");
+    expect(nextIndex.slots).toHaveLength(
+      MAX_SQL_STATEMENT_SLOTS - 4,
+    );
+  });
+
+  it("matches the resource-limited dollar-delimiter oracle", () => {
+    const text = `SELECT 1; $${"a".repeat(300)}$payload`;
+    const change = replaceFirst(text, "SELECT 1", "SELECT 100");
+    const { nextIndex } = expectIncrementalMatchesOracle(
+      text,
+      [change],
+      POSTGRESQL_SQL_LEXICAL_PROFILE,
+    );
+    expect(nextIndex.endState).toMatchObject({
+      kind: "opaque",
+      reason: "resource-limit",
+    });
+  });
+});
+
+describe("incremental statement index reuse", () => {
+  it.each(PROFILES)(
+    "returns the previous index for an unchanged $name document",
+    ({ profile }) => {
+      const text = "SELECT 1; SELECT 2";
+      const previousIndex = buildSqlStatementIndex(text, profile);
+      expect(updateSqlStatementIndex(previousIndex, text, [], profile)).toBe(
+        previousIndex,
+      );
+    },
+  );
+
+  it("reuses unchanged prefix and zero-delta suffix slot identities", () => {
+    const profile = DUCKDB_SQL_LEXICAL_PROFILE;
+    const text = "SELECT 1; SELECT 2; SELECT 3";
+    const change = replaceFirst(text, "2", "9");
+    const { nextIndex, previousIndex } = expectIncrementalMatchesOracle(
+      text,
+      [change],
+      profile,
+    );
+    expect(expectSlot(nextIndex.slots, 0)).toBe(
+      expectSlot(previousIndex.slots, 0),
+    );
+    expect(expectSlot(nextIndex.slots, 1)).not.toBe(
+      expectSlot(previousIndex.slots, 1),
+    );
+    expect(expectSlot(nextIndex.slots, 2)).toBe(
+      expectSlot(previousIndex.slots, 2),
+    );
+  });
+
+  it("creates deeply frozen shifted suffixes for non-zero deltas", () => {
+    const profile = POSTGRESQL_SQL_LEXICAL_PROFILE;
+    const text = "SELECT 1; SELECT 'unterminated";
+    const change = replaceFirst(text, "1", "1000");
+    const { nextIndex, previousIndex } = expectIncrementalMatchesOracle(
+      text,
+      [change],
+      profile,
+    );
+    const previousSuffix = expectSlot(previousIndex.slots, 1);
+    const nextSuffix = expectSlot(nextIndex.slots, 1);
+    expect(nextSuffix).not.toBe(previousSuffix);
+    expect(nextSuffix.extent.from).toBe(previousSuffix.extent.from + 3);
+    expect(nextSuffix.extent.to).toBe(previousSuffix.extent.to + 3);
+    expect(nextSuffix.endState).toMatchObject({
+      from:
+        previousSuffix.endState.kind === "unterminated"
+          ? previousSuffix.endState.from + 3
+          : undefined,
+      kind: "unterminated",
+    });
+    expectDeepFrozen(nextIndex);
+  });
+});
+
+describe("incremental statement index deterministic differential sequences", () => {
+  it.each(PROFILES)(
+    "matches the full oracle through randomized edits for $name",
+    ({ name, profile }) => {
+      let seed =
+        0x51_7a_2d_09 ^
+        Array.from(name).reduce(
+          (value, character) => value + character.charCodeAt(0),
+          0,
+        );
+      const next = (limit: number): number => {
+        seed = (Math.imul(seed, 1_664_525) + 1_013_904_223) >>> 0;
+        return seed % limit;
+      };
+      const fragments = [
+        "",
+        ";",
+        "'",
+        '"',
+        "`",
+        "$tag$",
+        "/*",
+        "*/",
+        "--",
+        "#",
+        "\n",
+        "\\",
+        "BEGIN",
+        " ATOMIC",
+        "DELIMITER $$",
+        "E'",
+        "r'''",
+        "𐐀",
+      ] as const;
+
+      let text =
+        "SELECT E'a;b'; SELECT $tag$c;d$tag$; SELECT r'''e;f'''; " +
+        "SELECT `g;h`; /* i;j */ SELECT 5";
+      let index = buildSqlStatementIndex(text, profile);
+
+      for (let iteration = 0; iteration < 120; iteration += 1) {
+        const changeCount = 1 + next(3);
+        const points = Array.from(
+          { length: changeCount * 2 },
+          () => next(text.length + 1),
+        ).sort((left, right) => left - right);
+        const changes: SqlTextChange[] = [];
+        for (let changeIndex = 0; changeIndex < changeCount; changeIndex += 1) {
+          const from = itemAt(points, changeIndex * 2);
+          const to = itemAt(points, changeIndex * 2 + 1);
+          const insert =
+            text.length > 500
+              ? ""
+              : itemAt(fragments, next(fragments.length));
+          changes.push({ from, insert, to });
+        }
+
+        const nextText = applyChanges(text, changes);
+        index = updateSqlStatementIndex(index, nextText, changes, profile);
+        expect(
+          index,
+          `${name} differential mismatch at iteration ${iteration}`,
+        ).toEqual(buildSqlStatementIndex(nextText, profile));
+        expectDeepFrozen(index);
+        text = nextText;
+      }
+    },
+  );
+});

--- a/src/vnext/__tests__/session.test.ts
+++ b/src/vnext/__tests__/session.test.ts
@@ -1,10 +1,20 @@
 import { describe, expect, it } from "vitest";
 import {
+  bigQueryDialect,
   createSqlLanguageService,
-  defineSqlDialect,
+  dremioDialect,
+  duckdbDialect,
+  postgresDialect,
   SqlSessionError,
 } from "../index.js";
 import { DefaultSqlLanguageService } from "../session.js";
+import {
+  BIGQUERY_SQL_LEXICAL_PROFILE,
+  buildSqlStatementIndex,
+  DREMIO_SQL_LEXICAL_PROFILE,
+  DUCKDB_SQL_LEXICAL_PROFILE,
+  POSTGRESQL_SQL_LEXICAL_PROFILE,
+} from "../statement-index.js";
 import type {
   SqlDocumentContext,
   SqlDocumentReplacement,
@@ -17,14 +27,8 @@ interface TestContext extends SqlDocumentContext {
   };
 }
 
-const duckdb = defineSqlDialect({
-  displayName: "DuckDB",
-  id: "duckdb",
-});
-const postgres = defineSqlDialect({
-  displayName: "PostgreSQL",
-  id: "postgres",
-});
+const duckdb = duckdbDialect();
+const postgres = postgresDialect();
 
 function createService() {
   return new DefaultSqlLanguageService<TestContext>({
@@ -53,69 +57,220 @@ function expectSessionError(code: SqlSessionError["code"], callback: () => unkno
 }
 
 describe("dialect definitions", () => {
-  it("creates immutable definitions", () => {
-    expect(duckdb).toEqual({ displayName: "DuckDB", id: "duckdb" });
+  it("creates immutable singleton definitions", () => {
+    expect(duckdb).toEqual({
+      displayName: "DuckDB",
+      id: "duckdb",
+    });
     expect(Object.isFrozen(duckdb)).toBe(true);
-  });
-
-  it.each([
-    [{ displayName: "DuckDB", id: " " }, "SQL dialect id must contain 1 to 256"],
-    [
-      { displayName: " ", id: "duckdb" },
-      "SQL dialect display name must contain 1 to 1024",
-    ],
-  ])("rejects invalid definitions", (definition, message) => {
-    expect(() => defineSqlDialect(definition)).toThrow(message);
+    expect(duckdbDialect()).toBe(duckdb);
+    expect(postgresDialect()).toBe(postgres);
+    expect(bigQueryDialect()).toBe(bigQueryDialect());
+    expect(dremioDialect()).toBe(dremioDialect());
   });
 
   it("rejects duplicate IDs", () => {
     expectSessionError("duplicate-dialect", () => {
       createSqlLanguageService({
-        dialects: [duckdb, { displayName: "Other", id: "duckdb" }],
+        dialects: [duckdb, duckdbDialect()],
       });
     });
   });
 
-  it("normalizes malformed definitions without invoking accessors", () => {
+  it("rejects copied and fabricated definitions without invoking traps", () => {
     let invoked = false;
     expectSessionError("invalid-dialect", () => {
-      defineSqlDialect({
-        displayName: "DuckDB",
-        get id() {
-          invoked = true;
-          return "duckdb";
-        },
+      createSqlLanguageService({
+        dialects: [{ ...duckdb }],
       });
     });
-    expect(invoked).toBe(false);
     expectSessionError("invalid-dialect", () => {
-      defineSqlDialect({ displayName: "DuckDB", id: 42 } as never);
+      createSqlLanguageService({
+        dialects: [{ displayName: "DuckDB", id: "duckdb" } as never],
+      });
     });
     expectSessionError("invalid-dialect", () => {
-      defineSqlDialect(null as never);
+      createSqlLanguageService({ dialects: [null as never] });
     });
     expectSessionError("invalid-dialect", () => {
-      defineSqlDialect(
-        new Proxy(
-          {},
-          {
+      createSqlLanguageService({
+        dialects: [
+          new Proxy(duckdb, {
+            get() {
+              invoked = true;
+              throw new Error("hostile");
+            },
             getOwnPropertyDescriptor() {
+              invoked = true;
+              throw new Error("hostile");
+            },
+            ownKeys() {
+              invoked = true;
               throw new Error("hostile");
             },
           },
-        ) as never,
-      );
+          ) as never,
+        ],
+      });
     });
+    expect(invoked).toBe(false);
+  });
+});
+
+describe("statement-index session cache", () => {
+  it("binds lexical behavior through authentic dialect handles", () => {
+    const service = new DefaultSqlLanguageService<TestContext>({
+      dialects: [
+        bigQueryDialect(),
+        dremioDialect(),
+        duckdb,
+        postgres,
+      ],
+    });
+    const cases = [
+      {
+        dialect: "bigquery",
+        profile: BIGQUERY_SQL_LEXICAL_PROFILE,
+        text: "# hidden; still hidden\nSELECT r'''a;b''';",
+      },
+      {
+        dialect: "dremio",
+        profile: DREMIO_SQL_LEXICAL_PROFILE,
+        text: "# code; SELECT $$a;b$$;",
+      },
+      {
+        dialect: "duckdb",
+        profile: DUCKDB_SQL_LEXICAL_PROFILE,
+        text: "SELECT $$a;b$$; /* outer /* inner; */ done */",
+      },
+      {
+        dialect: "postgresql",
+        profile: POSTGRESQL_SQL_LEXICAL_PROFILE,
+        text: "SELECT E'a\\';b'; SELECT $tag$c;d$tag$;",
+      },
+    ] as const;
+
+    for (const testCase of cases) {
+      const session = service.openDocument({
+        context: {
+          dialect: testCase.dialect,
+          engine: "warehouse",
+        },
+        text: testCase.text,
+      });
+      expect(session.getStatementIndexForTesting()).toEqual(
+        buildSqlStatementIndex(testCase.text, testCase.profile),
+      );
+    }
   });
 
-  it("returns only normalized dialect fields", () => {
-    const extendedDefinition = {
-      displayName: "DuckDB",
-      id: "duckdb",
-      internal: true,
-    };
-    const definition = defineSqlDialect(extendedDefinition);
-    expect(definition).toEqual({ displayName: "DuckDB", id: "duckdb" });
+  it("builds lazily and reuses the current cache", () => {
+    const { session } = openSession("SELECT 1; SELECT 2");
+    expect(session.cachedStatementIndexForTesting).toBeNull();
+
+    const index = session.getStatementIndexForTesting();
+    expect(session.cachedStatementIndexForTesting).toBe(index);
+    expect(session.getStatementIndexForTesting()).toBe(index);
+  });
+
+  it("retains the index for unrelated context changes", () => {
+    const { session } = openSession("SELECT 1; SELECT 2");
+    const index = session.getStatementIndexForTesting();
+    session.update({
+      kind: "context",
+      baseRevision: session.revision,
+      context: { dialect: "duckdb", engine: "remote" },
+    });
+    expect(session.cachedStatementIndexForTesting).toBe(index);
+  });
+
+  it("invalidates the index when lexical profile identity changes", () => {
+    const { session } = openSession("SELECT $$a;b$$;");
+    const index = session.getStatementIndexForTesting();
+    session.update({
+      kind: "context",
+      baseRevision: session.revision,
+      context: { dialect: "postgresql", engine: "warehouse" },
+    });
+    expect(session.cachedStatementIndexForTesting).toBeNull();
+    expect(session.getStatementIndexForTesting()).not.toBe(index);
+  });
+
+  it("reuses the index across no-op document mutations", () => {
+    const { session } = openSession("SELECT 1");
+    const initialSource = session.snapshotForTesting.source;
+    const index = session.getStatementIndexForTesting();
+
+    session.update({
+      kind: "document",
+      baseRevision: session.revision,
+      document: { kind: "changes", changes: [] },
+    });
+    expect(session.snapshotForTesting.source).not.toBe(initialSource);
+    expect(session.cachedStatementIndexForTesting).toBe(index);
+
+    session.update({
+      kind: "document",
+      baseRevision: session.revision,
+      document: { kind: "replace", text: "SELECT 1" },
+    });
+    expect(session.cachedStatementIndexForTesting).toBe(index);
+  });
+
+  it("updates incrementally to the full-scan oracle", () => {
+    const { session } = openSession("SELECT 1; SELECT 2; SELECT 3");
+    const previous = session.getStatementIndexForTesting();
+    session.update({
+      kind: "document",
+      baseRevision: session.revision,
+      document: {
+        kind: "changes",
+        changes: [{ from: 17, insert: "20", to: 18 }],
+      },
+    });
+
+    const cached = session.cachedStatementIndexForTesting;
+    expect(cached).not.toBeNull();
+    expect(cached).toEqual(
+      buildSqlStatementIndex(
+        "SELECT 1; SELECT 20; SELECT 3",
+        DUCKDB_SQL_LEXICAL_PROFILE,
+      ),
+    );
+    expect(cached).not.toBe(previous);
+    expect(cached?.slots[0]).toBe(previous.slots[0]);
+  });
+
+  it("clears changed replacements and preserves the cache on failure", () => {
+    const { session } = openSession("SELECT 1");
+    const index = session.getStatementIndexForTesting();
+    const revision = session.revision;
+    expectSessionError("stale-revision", () => {
+      session.update({
+        kind: "document",
+        baseRevision: {} as never,
+        document: { kind: "replace", text: "SELECT 2" },
+      });
+    });
+    expect(session.revision).toBe(revision);
+    expect(session.cachedStatementIndexForTesting).toBe(index);
+
+    session.update({
+      kind: "document",
+      baseRevision: session.revision,
+      document: { kind: "replace", text: "SELECT 2" },
+    });
+    expect(session.cachedStatementIndexForTesting).toBeNull();
+  });
+
+  it("releases the cache on disposal", () => {
+    const { session } = openSession();
+    session.getStatementIndexForTesting();
+    session.dispose();
+    expect(session.cachedStatementIndexForTesting).toBeNull();
+    expectSessionError("session-disposed", () => {
+      session.getStatementIndexForTesting();
+    });
   });
 });
 
@@ -502,7 +657,7 @@ describe("document changes", () => {
       kind: "document",
       get context() {
         invoked = true;
-        return { dialect: "postgres", engine: "warehouse" };
+        return { dialect: "postgresql", engine: "warehouse" };
       },
     };
     expectSessionError("invalid-update", () => {
@@ -764,12 +919,12 @@ describe("document context", () => {
     session.update({
       kind: "document",
       baseRevision: session.revision,
-      context: { dialect: "postgres", engine: "warehouse" },
+      context: { dialect: "postgresql", engine: "warehouse" },
       document: { kind: "replace", text: "SELECT 2" },
     });
 
     expect(session.snapshotForTesting).toMatchObject({
-      context: { dialect: "postgres", engine: "warehouse" },
+      context: { dialect: "postgresql", engine: "warehouse" },
       source: { originalText: "SELECT 2" },
     });
 
@@ -790,10 +945,10 @@ describe("document context", () => {
     session.update({
       kind: "context",
       baseRevision: session.revision,
-      context: { dialect: "postgres", engine: "warehouse" },
+      context: { dialect: "postgresql", engine: "warehouse" },
     });
     expect(session.snapshotForTesting.source.originalText).toBe("SELECT 1");
-    expect(session.snapshotForTesting.context.dialect).toBe("postgres");
+    expect(session.snapshotForTesting.context.dialect).toBe("postgresql");
   });
 
   it("retains the owned context for document-only updates", () => {
@@ -1084,7 +1239,7 @@ describe("lifecycle", () => {
       text: "",
     });
     const second = service.openDocument({
-      context: { dialect: "postgres", engine: "two" },
+      context: { dialect: "postgresql", engine: "two" },
       text: "",
     });
 

--- a/src/vnext/__tests__/statement-index.bench.ts
+++ b/src/vnext/__tests__/statement-index.bench.ts
@@ -1,0 +1,74 @@
+import { bench, describe } from "vitest";
+import {
+  buildSqlStatementIndex,
+  DUCKDB_SQL_LEXICAL_PROFILE,
+  MAX_SQL_STATEMENT_SLOTS,
+  updateSqlStatementIndex,
+} from "../statement-index.js";
+
+const padding = "x".repeat(1_000);
+const oneMegabyteDocument = Array.from(
+  { length: 1_000 },
+  (_, index) => `SELECT ${index} AS value /* ${padding} */`,
+).join(";\n");
+const previousIndex = buildSqlStatementIndex(
+  oneMegabyteDocument,
+  DUCKDB_SQL_LEXICAL_PROFILE,
+);
+const middleFrom = oneMegabyteDocument.indexOf("500 AS value");
+const localChanges = [
+  {
+    from: middleFrom,
+    insert: "501",
+    to: middleFrom + 3,
+  },
+] as const;
+const localDocument =
+  oneMegabyteDocument.slice(0, middleFrom) +
+  "501" +
+  oneMegabyteDocument.slice(middleFrom + 3);
+const shiftedChanges = [{ from: 0, insert: "-- lead\n", to: 0 }] as const;
+const shiftedDocument = `-- lead\n${oneMegabyteDocument}`;
+const cappedDocument = ";".repeat(MAX_SQL_STATEMENT_SLOTS + 5);
+const cappedIndex = buildSqlStatementIndex(
+  cappedDocument,
+  DUCKDB_SQL_LEXICAL_PROFILE,
+);
+const capRecoveryChanges = [{ from: 0, insert: "", to: 10 }] as const;
+const recoveredDocument = cappedDocument.slice(10);
+
+describe("statement index", () => {
+  bench("full 1 MiB scan", () => {
+    buildSqlStatementIndex(
+      oneMegabyteDocument,
+      DUCKDB_SQL_LEXICAL_PROFILE,
+    );
+  });
+
+  bench("incremental 1 MiB middle edit", () => {
+    updateSqlStatementIndex(
+      previousIndex,
+      localDocument,
+      localChanges,
+      DUCKDB_SQL_LEXICAL_PROFILE,
+    );
+  });
+
+  bench("incremental 1 MiB prefix shift", () => {
+    updateSqlStatementIndex(
+      previousIndex,
+      shiftedDocument,
+      shiftedChanges,
+      DUCKDB_SQL_LEXICAL_PROFILE,
+    );
+  });
+
+  bench("incremental resource-cap recovery", () => {
+    updateSqlStatementIndex(
+      cappedIndex,
+      recoveredDocument,
+      capRecoveryChanges,
+      DUCKDB_SQL_LEXICAL_PROFILE,
+    );
+  });
+});

--- a/src/vnext/index.ts
+++ b/src/vnext/index.ts
@@ -1,12 +1,15 @@
 export {
+  bigQueryDialect,
   createSqlLanguageService,
-  defineSqlDialect,
+  dremioDialect,
+  duckdbDialect,
+  postgresDialect,
 } from "./session.js";
 export type {
   OpenSqlDocument,
   SqlCatalogContext,
   SqlContextInput,
-  SqlDialectDefinition,
+  SqlDialect,
   SqlDocumentChanges,
   SqlDocumentContext,
   SqlDocumentEdit,

--- a/src/vnext/session.ts
+++ b/src/vnext/session.ts
@@ -1,6 +1,5 @@
 import type {
   OpenSqlDocument,
-  SqlDialectDefinition,
   SqlDocumentContext,
   SqlDocumentSession,
   SqlDocumentUpdate,
@@ -11,13 +10,28 @@ import type {
   SqlTextRange,
 } from "./types.js";
 import {
+  BIGQUERY_SQL_LEXICAL_PROFILE,
+  buildSqlStatementIndex,
+  DREMIO_SQL_LEXICAL_PROFILE,
+  DUCKDB_SQL_LEXICAL_PROFILE,
+  POSTGRESQL_SQL_LEXICAL_PROFILE,
+  type SqlLexicalProfile,
+  type SqlStatementIndex,
+  updateSqlStatementIndex,
+} from "./statement-index.js";
+import {
   createIdentitySqlSource,
   isSqlSourceError,
   MAX_SQL_SOURCE_LENGTH,
   normalizeSqlTextRange,
   type SqlSourceSnapshot,
 } from "./source.js";
-import { createSqlRevisionToken, SqlSessionError } from "./types.js";
+import {
+  createSqlDialect,
+  createSqlRevisionToken,
+  type SqlDialect,
+  SqlSessionError,
+} from "./types.js";
 
 const MAX_CONTEXT_DEPTH = 100;
 const MAX_CONTEXT_NODES = 10_000;
@@ -27,8 +41,74 @@ const MAX_CONTEXT_STRING_LENGTH = 1_000_000;
 const MAX_CONTEXT_ARRAY_LENGTH = 50_000;
 const MAX_CHANGES_PER_UPDATE = 10_000;
 const MAX_DIALECTS = 1_000;
-const MAX_DIALECT_ID_LENGTH = 256;
-const MAX_DIALECT_DISPLAY_NAME_LENGTH = 1_024;
+
+interface SqlDialectRuntime {
+  readonly dialect: SqlDialect;
+  readonly lexicalProfile: SqlLexicalProfile;
+}
+
+const sqlDialectRuntimes = new WeakMap<object, SqlDialectRuntime>();
+
+function createBuiltinSqlDialect(
+  id: string,
+  displayName: string,
+  lexicalProfile: SqlLexicalProfile,
+): SqlDialect {
+  const dialect = createSqlDialect(id, displayName);
+  sqlDialectRuntimes.set(
+    dialect,
+    Object.freeze({ dialect, lexicalProfile }),
+  );
+  return dialect;
+}
+
+const BIGQUERY_DIALECT = createBuiltinSqlDialect(
+  "bigquery",
+  "BigQuery",
+  BIGQUERY_SQL_LEXICAL_PROFILE,
+);
+const DREMIO_DIALECT = createBuiltinSqlDialect(
+  "dremio",
+  "Dremio",
+  DREMIO_SQL_LEXICAL_PROFILE,
+);
+const DUCKDB_DIALECT = createBuiltinSqlDialect(
+  "duckdb",
+  "DuckDB",
+  DUCKDB_SQL_LEXICAL_PROFILE,
+);
+const POSTGRES_DIALECT = createBuiltinSqlDialect(
+  "postgresql",
+  "PostgreSQL",
+  POSTGRESQL_SQL_LEXICAL_PROFILE,
+);
+
+/** Returns the package-owned BigQuery dialect handle. */
+export function bigQueryDialect(): SqlDialect {
+  return BIGQUERY_DIALECT;
+}
+
+/** Returns the package-owned Dremio dialect handle. */
+export function dremioDialect(): SqlDialect {
+  return DREMIO_DIALECT;
+}
+
+/** Returns the package-owned DuckDB dialect handle. */
+export function duckdbDialect(): SqlDialect {
+  return DUCKDB_DIALECT;
+}
+
+/** Returns the package-owned PostgreSQL dialect handle. */
+export function postgresDialect(): SqlDialect {
+  return POSTGRES_DIALECT;
+}
+
+function getSqlDialectRuntime(candidate: unknown): SqlDialectRuntime | null {
+  if (typeof candidate !== "object" || candidate === null) {
+    return null;
+  }
+  return sqlDialectRuntimes.get(candidate) ?? null;
+}
 
 interface PendingContextValue {
   readonly depth: number;
@@ -222,17 +302,19 @@ function cloneContext<Context extends SqlDocumentContext>(context: Context): Con
   }
 }
 
-function validateDialect(
+function resolveDialectRuntime(
   context: SqlDocumentContext,
-  dialects: ReadonlySet<string>,
-): void {
+  dialects: ReadonlyMap<string, SqlDialectRuntime>,
+): SqlDialectRuntime {
   const dialect = readRequiredDataProperty(
     context,
     "dialect",
     "invalid-dialect",
     "SQL document context",
   );
-  if (typeof dialect !== "string" || !dialects.has(dialect)) {
+  const runtime =
+    typeof dialect === "string" ? dialects.get(dialect) : undefined;
+  if (!runtime) {
     throw new SqlSessionError(
       "invalid-dialect",
       typeof dialect === "string"
@@ -240,6 +322,7 @@ function validateDialect(
         : "SQL document context dialect must be a string",
     );
   }
+  return runtime;
 }
 
 interface MissingDataProperty {
@@ -427,25 +510,33 @@ function applyChanges(text: string, changes: readonly SqlTextChange[]): string {
 interface SessionSnapshot<Context extends SqlDocumentContext> {
   readonly contextSequence: number;
   readonly context: Context;
+  readonly dialect: SqlDialectRuntime;
   readonly documentSequence: number;
   readonly revision: SqlRevision;
   readonly sequence: number;
   readonly source: SqlSourceSnapshot;
 }
 
+interface StatementIndexCache {
+  readonly documentSequence: number;
+  readonly index: SqlStatementIndex;
+  readonly lexicalProfile: SqlLexicalProfile;
+}
+
 export class DefaultSqlDocumentSession<Context extends SqlDocumentContext>
   implements SqlDocumentSession<Context>
 {
-  readonly #dialects: ReadonlySet<string>;
+  readonly #dialects: ReadonlyMap<string, SqlDialectRuntime>;
   readonly #onDispose: () => void;
   #disposed = false;
   #snapshot: SessionSnapshot<Context>;
+  #statementIndexCache: StatementIndexCache | null = null;
   #updating = false;
 
   constructor(
     source: SqlSourceSnapshot,
     context: Context,
-    dialects: ReadonlySet<string>,
+    dialects: ReadonlyMap<string, SqlDialectRuntime>,
     onDispose: () => void,
   ) {
     this.#dialects = dialects;
@@ -453,9 +544,11 @@ export class DefaultSqlDocumentSession<Context extends SqlDocumentContext>
     const sequence = 0;
     const contextSequence = 0;
     const documentSequence = 0;
+    const dialect = resolveDialectRuntime(context, dialects);
     this.#snapshot = Object.freeze({
       contextSequence,
       context,
+      dialect,
       documentSequence,
       revision: createSqlRevisionToken(),
       sequence,
@@ -469,6 +562,37 @@ export class DefaultSqlDocumentSession<Context extends SqlDocumentContext>
 
   get snapshotForTesting(): SessionSnapshot<Context> {
     return this.#snapshot;
+  }
+
+  get cachedStatementIndexForTesting(): SqlStatementIndex | null {
+    return this.#statementIndexCache?.index ?? null;
+  }
+
+  getStatementIndexForTesting(): SqlStatementIndex {
+    if (this.#disposed) {
+      throw new SqlSessionError(
+        "session-disposed",
+        "SQL document session is disposed",
+      );
+    }
+    const cached = this.#statementIndexCache;
+    if (
+      cached &&
+      cached.documentSequence === this.#snapshot.documentSequence &&
+      cached.lexicalProfile === this.#snapshot.dialect.lexicalProfile
+    ) {
+      return cached.index;
+    }
+    const index = buildSqlStatementIndex(
+      this.#snapshot.source.analysisText,
+      this.#snapshot.dialect.lexicalProfile,
+    );
+    this.#statementIndexCache = Object.freeze({
+      documentSequence: this.#snapshot.documentSequence,
+      index,
+      lexicalProfile: this.#snapshot.dialect.lexicalProfile,
+    });
+    return index;
   }
 
   readonly update = (update: SqlDocumentUpdate<Context>): SqlRevision => {
@@ -530,6 +654,8 @@ export class DefaultSqlDocumentSession<Context extends SqlDocumentContext>
     let nextContext = this.#snapshot.context;
     let nextDocumentSequence = this.#snapshot.documentSequence;
     let nextSource = this.#snapshot.source;
+    let documentMutation: "changes" | "none" | "replace" = "none";
+    let trustedAnalysisChanges: readonly SqlTextChange[] | null = null;
 
     if (kind === "context") {
       if (
@@ -622,6 +748,7 @@ export class DefaultSqlDocumentSession<Context extends SqlDocumentContext>
         }
         validateDocumentLength(text);
         nextSource = createIdentitySqlSource(text);
+        documentMutation = "replace";
       } else if (documentKind === "changes") {
         if (
           readOwnDataProperty(
@@ -652,9 +779,11 @@ export class DefaultSqlDocumentSession<Context extends SqlDocumentContext>
           nextSource.originalText,
           changes,
         );
+        trustedAnalysisChanges = normalizedChanges;
         nextSource = createIdentitySqlSource(
           applyChanges(nextSource.originalText, normalizedChanges),
         );
+        documentMutation = "changes";
       } else {
         throw new SqlSessionError(
           "invalid-update",
@@ -664,7 +793,11 @@ export class DefaultSqlDocumentSession<Context extends SqlDocumentContext>
       nextDocumentSequence += 1;
     }
 
-    validateDialect(nextContext, this.#dialects);
+    const nextDialect = resolveDialectRuntime(
+      nextContext,
+      this.#dialects,
+    );
+    const nextLexicalProfile = nextDialect.lexicalProfile;
     if (this.#disposed) {
       throw new SqlSessionError(
         "session-disposed",
@@ -673,14 +806,48 @@ export class DefaultSqlDocumentSession<Context extends SqlDocumentContext>
     }
     const sequence = this.#snapshot.sequence + 1;
     const revision = createSqlRevisionToken();
-    this.#snapshot = Object.freeze({
+    const nextSnapshot = Object.freeze({
       contextSequence: nextContextSequence,
       context: nextContext,
+      dialect: nextDialect,
       documentSequence: nextDocumentSequence,
       revision,
       sequence,
       source: nextSource,
     });
+    let nextStatementIndexCache = this.#statementIndexCache;
+    if (
+      nextStatementIndexCache &&
+      nextLexicalProfile !== this.#snapshot.dialect.lexicalProfile
+    ) {
+      nextStatementIndexCache = null;
+    } else if (nextStatementIndexCache && documentMutation !== "none") {
+      let nextIndex: SqlStatementIndex | null = null;
+      if (
+        nextSource.analysisText === this.#snapshot.source.analysisText
+      ) {
+        nextIndex = nextStatementIndexCache.index;
+      } else if (
+        documentMutation === "changes" &&
+        trustedAnalysisChanges
+      ) {
+        nextIndex = updateSqlStatementIndex(
+          nextStatementIndexCache.index,
+          nextSource.analysisText,
+          trustedAnalysisChanges,
+          nextLexicalProfile,
+        );
+      }
+      nextStatementIndexCache = nextIndex
+        ? Object.freeze({
+            documentSequence: nextDocumentSequence,
+            index: nextIndex,
+            lexicalProfile: nextLexicalProfile,
+          })
+        : null;
+    }
+    this.#snapshot = nextSnapshot;
+    this.#statementIndexCache = nextStatementIndexCache;
     return revision;
   }
 
@@ -693,6 +860,7 @@ export class DefaultSqlDocumentSession<Context extends SqlDocumentContext>
       return;
     }
     this.#disposed = true;
+    this.#statementIndexCache = null;
     this.#onDispose();
   };
 }
@@ -700,7 +868,7 @@ export class DefaultSqlDocumentSession<Context extends SqlDocumentContext>
 export class DefaultSqlLanguageService<Context extends SqlDocumentContext>
   implements SqlLanguageService<Context>
 {
-  readonly #dialects: ReadonlySet<string>;
+  readonly #dialects: ReadonlyMap<string, SqlDialectRuntime>;
   readonly #sessions = new Set<DefaultSqlDocumentSession<Context>>();
   #disposed = false;
 
@@ -736,7 +904,7 @@ export class DefaultSqlLanguageService<Context extends SqlDocumentContext>
         );
       }
 
-      const dialects = new Set<string>();
+      const dialects = new Map<string, SqlDialectRuntime>();
       for (let index = 0; index < dialectCount; index += 1) {
         const dialect = readRequiredDataProperty(
           configuredDialects,
@@ -744,14 +912,20 @@ export class DefaultSqlLanguageService<Context extends SqlDocumentContext>
           "invalid-service-options",
           "SQL language service dialects",
         );
-        const definition = defineSqlDialect(dialect);
-        if (dialects.has(definition.id)) {
+        const runtime = getSqlDialectRuntime(dialect);
+        if (!runtime) {
           throw new SqlSessionError(
-            "duplicate-dialect",
-            `Duplicate SQL dialect: ${definition.id}`,
+            "invalid-dialect",
+            "SQL dialects must be created by a built-in dialect factory from this package instance",
           );
         }
-        dialects.add(definition.id);
+        if (dialects.has(runtime.dialect.id)) {
+          throw new SqlSessionError(
+            "duplicate-dialect",
+            `Duplicate SQL dialect: ${runtime.dialect.id}`,
+          );
+        }
+        dialects.set(runtime.dialect.id, runtime);
       }
       this.#dialects = dialects;
     } catch (error) {
@@ -806,7 +980,7 @@ export class DefaultSqlLanguageService<Context extends SqlDocumentContext>
         );
       }
       const context = cloneContext<Context>(candidateContext);
-      validateDialect(context, this.#dialects);
+      resolveDialectRuntime(context, this.#dialects);
 
       let session: DefaultSqlDocumentSession<Context>;
       session = new DefaultSqlDocumentSession(
@@ -853,63 +1027,6 @@ export class DefaultSqlLanguageService<Context extends SqlDocumentContext>
     }
     this.#sessions.clear();
   };
-}
-
-/** Validates and normalizes one immutable dialect registration. */
-export function defineSqlDialect(
-  definition: SqlDialectDefinition,
-): SqlDialectDefinition {
-  try {
-    if (definition === null || typeof definition !== "object") {
-      throw new SqlSessionError(
-        "invalid-dialect",
-        "SQL dialect definition must be an object",
-      );
-    }
-    const id = readRequiredDataProperty(
-      definition,
-      "id",
-      "invalid-dialect",
-      "SQL dialect definition",
-    );
-    const displayName = readRequiredDataProperty(
-      definition,
-      "displayName",
-      "invalid-dialect",
-      "SQL dialect definition",
-    );
-    if (
-      typeof id !== "string" ||
-      id.length === 0 ||
-      id.length > MAX_DIALECT_ID_LENGTH ||
-      id.trim().length === 0
-    ) {
-      throw new SqlSessionError(
-        "invalid-dialect",
-        `SQL dialect id must contain 1 to ${MAX_DIALECT_ID_LENGTH} code units`,
-      );
-    }
-    if (
-      typeof displayName !== "string" ||
-      displayName.length === 0 ||
-      displayName.length > MAX_DIALECT_DISPLAY_NAME_LENGTH ||
-      displayName.trim().length === 0
-    ) {
-      throw new SqlSessionError(
-        "invalid-dialect",
-        `SQL dialect display name must contain 1 to ${MAX_DIALECT_DISPLAY_NAME_LENGTH} code units`,
-      );
-    }
-    return Object.freeze({ displayName, id });
-  } catch (error) {
-    if (error instanceof SqlSessionError) {
-      throw error;
-    }
-    throw new SqlSessionError(
-      "invalid-dialect",
-      "SQL dialect definition could not be inspected safely",
-    );
-  }
 }
 
 /** Creates a framework-independent SQL service with an immutable dialect registry. */

--- a/src/vnext/statement-index.ts
+++ b/src/vnext/statement-index.ts
@@ -1,3 +1,5 @@
+import type { SqlTextChange } from "./types.js";
+
 const analysisRangeBrand: unique symbol = Symbol("SqlAnalysisRange");
 
 export const MAX_SQL_STATEMENT_SLOTS = 10_000;
@@ -645,16 +647,37 @@ function quoteConstruct(
     : "double-quoted-identifier";
 }
 
-/** Builds the bounded, parser-free statement partition for one analysis text. */
-export function buildSqlStatementIndex(
+interface SqlStatementScanOptions {
+  readonly from: number;
+  readonly prefixSlots: readonly SqlStatementSlot[];
+  readonly tryReuseSuffix?: (
+    boundary: number,
+    scannedSlots: readonly SqlStatementSlot[],
+  ) => SqlStatementIndex | null;
+}
+
+function createStatementIndex(
+  slots: SqlStatementSlot[],
+): SqlStatementIndex {
+  const finalSlot = getStatementSlot(slots, slots.length - 1);
+  return Object.freeze({
+    endState: finalSlot.endState,
+    quality:
+      finalSlot.boundaryQuality === "opaque" ? "opaque" : "exact",
+    slots: Object.freeze(slots),
+  });
+}
+
+function scanSqlStatementIndex(
   analysisText: string,
   profile: SqlLexicalProfile,
+  options: SqlStatementScanOptions,
 ): SqlStatementIndex {
-  const slots: SqlStatementSlot[] = [];
+  const slots: SqlStatementSlot[] = [...options.prefixSlots];
   const prefixGuard = new SqlPrefixGuard(profile.proceduralGuards);
-  let slotFrom = 0;
+  let slotFrom = options.from;
   let hasCode = false;
-  let cursor = 0;
+  let cursor = options.from;
   let finalEndState: ExactSqlStatementSlot["endState"] = NORMAL_END_STATE;
 
   const finishOpaque = (
@@ -668,11 +691,7 @@ export function buildSqlStatementIndex(
       detectedAt,
     );
     slots.push(slot);
-    return Object.freeze({
-      endState: slot.endState,
-      quality: "opaque",
-      slots: Object.freeze(slots),
-    });
+    return createStatementIndex(slots);
   };
 
   while (cursor < analysisText.length) {
@@ -850,6 +869,10 @@ export function buildSqlStatementIndex(
       finalEndState = NORMAL_END_STATE;
       prefixGuard.reset();
       cursor += 1;
+      const reused = options.tryReuseSuffix?.(slotFrom, slots);
+      if (reused) {
+        return reused;
+      }
       continue;
     }
 
@@ -866,10 +889,259 @@ export function buildSqlStatementIndex(
       finalEndState,
     ),
   );
+  return createStatementIndex(slots);
+}
+
+/** Builds the bounded, parser-free statement partition for one analysis text. */
+export function buildSqlStatementIndex(
+  analysisText: string,
+  profile: SqlLexicalProfile,
+): SqlStatementIndex {
+  return scanSqlStatementIndex(analysisText, profile, {
+    from: 0,
+    prefixSlots: [],
+  });
+}
+
+function statementSlotIndexAt(
+  slots: readonly SqlStatementSlot[],
+  position: number,
+  affinity: SqlCursorAffinity,
+): number {
+  let low = 0;
+  let high = slots.length;
+  while (low < high) {
+    const middle = low + Math.floor((high - low) / 2);
+    if (getStatementSlot(slots, middle).extent.from <= position) {
+      low = middle + 1;
+    } else {
+      high = middle;
+    }
+  }
+  let slotIndex = Math.max(0, low - 1);
+  if (
+    affinity === "left" &&
+    position > 0 &&
+    getStatementSlot(slots, slotIndex).extent.from === position
+  ) {
+    slotIndex -= 1;
+  }
+  return Math.max(0, slotIndex);
+}
+
+function statementSlotAtOrAfter(
+  slots: readonly SqlStatementSlot[],
+  position: number,
+): number {
+  let low = 0;
+  let high = slots.length;
+  while (low < high) {
+    const middle = low + Math.floor((high - low) / 2);
+    const from = getStatementSlot(slots, middle).extent.from;
+    if (from < position) {
+      low = middle + 1;
+    } else {
+      high = middle;
+    }
+  }
+  return low;
+}
+
+function shiftEndState(
+  endState: ExactSqlStatementSlot["endState"],
+  delta: number,
+): ExactSqlStatementSlot["endState"];
+function shiftEndState(
+  endState: OpaqueSqlStatementSlot["endState"],
+  delta: number,
+): OpaqueSqlStatementSlot["endState"];
+function shiftEndState(
+  endState: SqlLexicalEndState,
+  delta: number,
+): SqlLexicalEndState {
+  if (endState.kind === "normal") {
+    return endState;
+  }
+  return endState.kind === "opaque"
+    ? createOpaqueEndState(endState.reason, endState.from + delta)
+    : createUnterminatedEndState(
+        endState.construct,
+        endState.from + delta,
+      );
+}
+
+function shiftStatementSlot(
+  slot: SqlStatementSlot,
+  delta: number,
+): SqlStatementSlot {
+  if (slot.boundaryQuality === "opaque") {
+    return Object.freeze({
+      boundaryQuality: "opaque",
+      endState: shiftEndState(slot.endState, delta),
+      extent: createAnalysisRange(
+        slot.extent.from + delta,
+        slot.extent.to + delta,
+      ),
+    });
+  }
   return Object.freeze({
-    endState: finalEndState,
-    quality: "exact",
-    slots: Object.freeze(slots),
+    boundaryQuality: "exact",
+    endState: shiftEndState(slot.endState, delta),
+    extent: createAnalysisRange(
+      slot.extent.from + delta,
+      slot.extent.to + delta,
+    ),
+    hasCode: slot.hasCode,
+    source: createAnalysisRange(
+      slot.source.from + delta,
+      slot.source.to + delta,
+    ),
+    terminator: slot.terminator
+      ? createAnalysisRange(
+          slot.terminator.from + delta,
+          slot.terminator.to + delta,
+        )
+      : null,
+  });
+}
+
+function normalizeTrustedChanges(
+  changes: readonly SqlTextChange[],
+  previousLength: number,
+  nextLength: number,
+): {
+  readonly delta: number;
+  readonly first: SqlTextChange;
+  readonly oldStableFrom: number;
+} | null {
+  const first = changes[0];
+  if (!first) {
+    return null;
+  }
+  let previousEnd = 0;
+  let delta = 0;
+  for (const change of changes) {
+    if (
+      !Number.isSafeInteger(change.from) ||
+      !Number.isSafeInteger(change.to) ||
+      change.from < previousEnd ||
+      change.from < 0 ||
+      change.from > change.to ||
+      change.to > previousLength ||
+      typeof change.insert !== "string"
+    ) {
+      return null;
+    }
+    delta += change.insert.length - (change.to - change.from);
+    previousEnd = change.to;
+  }
+  const last = changes[changes.length - 1];
+  if (!last || previousLength + delta !== nextLength) {
+    return null;
+  }
+  return { delta, first, oldStableFrom: last.to };
+}
+
+/**
+ * Updates an index from trusted, normalized analysis-coordinate changes.
+ * Falls back to the full oracle whenever the change metadata is inconsistent.
+ */
+export function updateSqlStatementIndex(
+  previousIndex: SqlStatementIndex,
+  nextAnalysisText: string,
+  changes: readonly SqlTextChange[],
+  profile: SqlLexicalProfile,
+): SqlStatementIndex {
+  const previousSlots = previousIndex.slots;
+  const previousLength = getStatementSlot(
+    previousSlots,
+    previousSlots.length - 1,
+  ).extent.to;
+  if (changes.length === 0) {
+    return previousLength === nextAnalysisText.length
+      ? previousIndex
+      : buildSqlStatementIndex(nextAnalysisText, profile);
+  }
+  const normalized = normalizeTrustedChanges(
+    changes,
+    previousLength,
+    nextAnalysisText.length,
+  );
+  if (!normalized) {
+    return buildSqlStatementIndex(nextAnalysisText, profile);
+  }
+
+  const restartIndex = statementSlotIndexAt(
+    previousSlots,
+    normalized.first.from,
+    "left",
+  );
+  const restartFrom = getStatementSlot(
+    previousSlots,
+    restartIndex,
+  ).extent.from;
+  const prefixSlots = previousSlots.slice(0, restartIndex);
+  const newStableFrom = normalized.oldStableFrom + normalized.delta;
+  let oldSuffixCursor = statementSlotAtOrAfter(
+    previousSlots,
+    normalized.oldStableFrom,
+  );
+  const previousFinalSlot = getStatementSlot(
+    previousSlots,
+    previousSlots.length - 1,
+  );
+  const previousHasResourceLimit =
+    previousFinalSlot.boundaryQuality === "opaque" &&
+    previousFinalSlot.endState.reason === "resource-limit";
+
+  return scanSqlStatementIndex(nextAnalysisText, profile, {
+    from: restartFrom,
+    prefixSlots,
+    tryReuseSuffix: (newBoundary, scannedSlots) => {
+      if (newBoundary < newStableFrom) {
+        return null;
+      }
+      const oldBoundary = newBoundary - normalized.delta;
+      while (
+        oldSuffixCursor < previousSlots.length &&
+        getStatementSlot(
+          previousSlots,
+          oldSuffixCursor,
+        ).extent.from < oldBoundary
+      ) {
+        oldSuffixCursor += 1;
+      }
+      if (
+        oldSuffixCursor >= previousSlots.length ||
+        getStatementSlot(
+          previousSlots,
+          oldSuffixCursor,
+        ).extent.from !== oldBoundary
+      ) {
+        return null;
+      }
+      const oldSuffixLength = previousSlots.length - oldSuffixCursor;
+      if (
+        scannedSlots.length + oldSuffixLength >
+        MAX_SQL_STATEMENT_SLOTS
+      ) {
+        return null;
+      }
+      if (
+        previousHasResourceLimit &&
+        scannedSlots.length !== oldSuffixCursor
+      ) {
+        return null;
+      }
+      const oldSuffix = previousSlots.slice(oldSuffixCursor);
+      const suffix =
+        normalized.delta === 0
+          ? oldSuffix
+          : oldSuffix.map((slot) =>
+              shiftStatementSlot(slot, normalized.delta),
+            );
+      return createStatementIndex([...scannedSlots, ...suffix]);
+    },
   });
 }
 
@@ -892,25 +1164,10 @@ export function findSqlStatementSlot(
     throw new TypeError("SQL cursor affinity must be left or right");
   }
 
-  let low = 0;
-  let high = slots.length;
-  while (low < high) {
-    const middle = low + Math.floor((high - low) / 2);
-    if (getStatementSlot(slots, middle).extent.from <= position) {
-      low = middle + 1;
-    } else {
-      high = middle;
-    }
-  }
-  let slotIndex = Math.max(0, low - 1);
-  if (
-    affinity === "left" &&
-    position > 0 &&
-    getStatementSlot(slots, slotIndex).extent.from === position
-  ) {
-    slotIndex -= 1;
-  }
-  return getStatementSlot(slots, Math.max(0, slotIndex));
+  return getStatementSlot(
+    slots,
+    statementSlotIndexAt(slots, position, affinity),
+  );
 }
 
 function getStatementSlot(

--- a/src/vnext/types.ts
+++ b/src/vnext/types.ts
@@ -42,9 +42,28 @@ export type SqlPlainData<Value> =
 export type SqlContextInput<Context extends SqlDocumentContext> =
   Context & SqlPlainData<Context>;
 
-export interface SqlDialectDefinition {
+const sqlDialectBrand: unique symbol = Symbol("SqlDialect");
+
+/** Opaque in-process configuration for one built-in SQL dialect. */
+export interface SqlDialect {
+  readonly [sqlDialectBrand]: "SqlDialect";
   readonly id: string;
   readonly displayName: string;
+}
+
+export function createSqlDialect(
+  id: string,
+  displayName: string,
+): SqlDialect {
+  const dialect: SqlDialect = {
+    [sqlDialectBrand]: "SqlDialect",
+    displayName,
+    id,
+  };
+  Object.defineProperty(dialect, sqlDialectBrand, {
+    enumerable: false,
+  });
+  return Object.freeze(dialect);
 }
 
 /** One half-open UTF-16 range in document coordinates. */
@@ -106,7 +125,7 @@ export interface SqlLanguageService<Context extends SqlDocumentContext> {
 }
 
 export interface SqlLanguageServiceOptions {
-  readonly dialects: readonly SqlDialectDefinition[];
+  readonly dialects: readonly SqlDialect[];
 }
 
 export type SqlSessionErrorCode =

--- a/test/vnext-types/session.test-d.ts
+++ b/test/vnext-types/session.test-d.ts
@@ -1,6 +1,7 @@
 import {
   createSqlLanguageService,
-  defineSqlDialect,
+  duckdbDialect,
+  type SqlDialect,
   type SqlDocumentContext,
   type SqlDocumentSession,
   type SqlLanguageService,
@@ -17,7 +18,8 @@ interface DateContext extends HostContext {
   readonly lastUsed: Date;
 }
 
-const dialect = defineSqlDialect({ displayName: "DuckDB", id: "duckdb" });
+const dialect = duckdbDialect();
+const typedDialect: SqlDialect = dialect;
 const service = createSqlLanguageService<HostContext>({ dialects: [dialect] });
 const session = service.openDocument({
   context: { dialect: "duckdb", engine: "local" },
@@ -79,9 +81,16 @@ change.from = 1;
 range.to = 1;
 // @ts-expect-error session revision is readonly
 session.revision = revision;
+// @ts-expect-error statement indexes remain an internal session detail
+session.getStatementIndexForTesting();
+// @ts-expect-error dialect IDs are readonly
+dialect.id = "other";
+// @ts-expect-error structural dialect objects are not authentic handles
+createSqlLanguageService({ dialects: [{ id: "duckdb", displayName: "DuckDB" }] });
 
 void objectRevision;
 void numberRevision;
 void range;
+void typedDialect;
 void widenedService;
 void widenedSession;


### PR DESCRIPTION
## Summary

- update the dialect-aware statement index incrementally from trusted analysis-coordinate edits while preserving the full scan as the oracle
- add a private lazy per-session index cache with atomic invalidation/reuse rules
- replace structural dialect definitions with opaque built-in factory handles, keeping lexical profiles and indexes out of the public API

## Correctness and safety

- conservative restart at the old slot at or left of the earliest edit
- convergence only at an exact terminated boundary after the final edit
- exact full-oracle fallback for inconsistent metadata or absent convergence
- global 10,000-slot and opaque-suffix behavior preserved
- monotonic convergence cursor keeps resource-cap recovery linear
- no source text or history retained by the cache

## Validation

- 833 unit tests passed; 1 governed expected failure
- 33 incremental tests with deterministic differential sequences across all four profiles
- 80,000 additional adversarial differential edits matched the full oracle
- changed coverage: 98.78% statements, 97.00% branches, 100% functions, 98.77% lines
- typecheck, oxlint, integrity, browser, demo, and packed-package smoke passed
- 1 MiB benchmark: full scan about 2.2-2.5 ms, middle edit about 0.028 ms, prefix shift about 0.11 ms
- resource-cap recovery about 1.35-1.46 ms after fixing the reviewed quadratic path

## Review

Two independent exact-SHA reviewers approve 2e83d17ad1decf91cc731f3bcaf657cbc6f75327 with no unresolved blocker, high, or medium findings.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds incremental statement indexing with a lazy, per-session cache so edits update indexes in microseconds, while a full scan remains the correctness fallback. Replaces caller-defined dialect objects with built-in opaque dialect handles that bind lexical behavior internally.

- New Features
  - Incremental updates from trusted analysis-coordinate edits; reuse unchanged prefix and reuse/shift suffix at exact terminated boundaries, with full-oracle fallback.
  - Private per-session statement-index cache: reused on context-only updates (same profile) and same-text replacements; incrementally updated on trusted identity-source changes; cleared on profile change or changed replacements; no source text or history retained.
  - Built-in dialect factories return frozen opaque singletons: `duckdbDialect()`, `postgresDialect()`, `bigQueryDialect()`, `dremioDialect()`; handles are validated, local to the package instance, and don’t cross workers/processes.
  - Bench and tests: `pnpm run bench:statement-index`; extensive unit, randomized differential, and session cache tests.

- Migration
  - Replace `defineSqlDialect(...)` and `SqlDialectDefinition` with built-in handles and `SqlDialect`.
    - Before: `createSqlLanguageService({ dialects: [defineSqlDialect({ id: "duckdb", displayName: "DuckDB" })] })`
    - After: `createSqlLanguageService({ dialects: [duckdbDialect()] })`
  - Keep using the handle’s `.id` string in document context: `{ dialect: dialect.id }`.
  - Do not copy/serialize/fabricate dialects; pass authentic handles from the same `@marimo-team/codemirror-sql/vnext` instance (handles don’t cross workers/processes).

<sup>Written for commit ce9417634c5c00a10bd379e68f045a24ecd83f13. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marimo-team/codemirror-sql/pull/175?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

