### PR TITLE
feat(vnext): define normalized syntax contract

### DIFF
--- a/docs/adr/0001-language-service-and-session.md
+++ b/docs/adr/0001-language-service-and-session.md
@@ -91,7 +91,8 @@ service.dispose();
 `syntax` is an opaque module accepted by the stable service factory. Its parser
 and semantic-model SPI is not stable in this ADR. Official adapters can use an
 experimental subpath until two materially different backends validate the
-normalized artifacts.
+normalized artifacts. The first internal boundary is specified by
+[ADR 0002](./0002-normalized-syntax-contract.md).
 
 ## Document context
 

--- a/docs/adr/0002-normalized-syntax-contract.md
+++ b/docs/adr/0002-normalized-syntax-contract.md
@@ -35,6 +35,13 @@ Parser outcomes never contain `empty`, `incomplete`, `opaque`, `cancelled`, or
 being mistaken for invalid SQL and prevents an incomplete lexical construct
 from being sent to a backend.
 
+The parser runner transports cancellation without classifying it: a
+pre-aborted request does not invoke the backend, and an in-flight abort rejects
+with the signal's exact reason if it wins the race with backend completion.
+Late backend rejection remains handled. The session decides whether that
+rejection represents cancellation, supersession, disposal, or another request
+lifecycle event.
+
 ### Eligibility
 
 | State | Meaning | Parser invoked |

--- a/docs/adr/0002-normalized-syntax-contract.md
+++ b/docs/adr/0002-normalized-syntax-contract.md
@@ -1,0 +1,188 @@
+# ADR 0002: Internal Normalized Syntax Contract
+
+Status: accepted
+Date: 2026-07-24
+
+## Context
+
+The legacy parser API accepts a complete CodeMirror `EditorState`, mutates
+offset bookkeeping, exposes backend-specific AST shapes, and can report success
+without a usable tree. Dialect support and location quality are also easy to
+overstate: a compatibility grammar rejecting input is not evidence that the
+target dialect is invalid.
+
+The vNext statement index already separates exact, incomplete, and opaque
+lexical boundaries. The next layer needs a narrow parser boundary that can
+support multiple backends without making the first backend's AST public or
+mixing lexical eligibility, parser evidence, and request cancellation into one
+ambiguous result.
+
+This contract is internal. It must be exercised by a real adapter and semantic
+consumer before any part is considered for the stable `/vnext` API.
+
+## Decision
+
+Syntax processing has three separate state machines:
+
+1. Lexical eligibility decides whether a statement is empty, incomplete,
+   opaque, unavailable, or eligible for an analyzed result.
+2. Parser analysis reports parsed, invalid, unsupported, or failed evidence.
+3. The session request lifecycle owns caller cancellation, supersession,
+   disposal, revision applicability, and timeouts.
+
+Parser outcomes never contain `empty`, `incomplete`, `opaque`, `cancelled`, or
+`superseded`. Keeping those layers separate prevents a parser failure from
+being mistaken for invalid SQL and prevents an incomplete lexical construct
+from being sent to a backend.
+
+### Eligibility
+
+| State | Meaning | Parser invoked |
+| --- | --- | --- |
+| `empty` | Exact slot has no code | No |
+| `incomplete` | Exact slot ends inside a known lexical construct | No |
+| `opaque` | Statement boundaries are not trustworthy | No |
+| `unavailable` | No parser is configured for the resolved dialect | No |
+| `analyzed` | The parser returned authenticated normalized evidence | Yes |
+
+Incomplete and opaque states preserve the scanner's closed construct/reason
+unions and a statement-relative location. They do not accept arbitrary strings.
+
+### Parser analysis
+
+`parsed` has two mutually exclusive modes:
+
+- `direct` carries a conformance identity. The backend is configured for the
+  target grammar and may make authoritative syntax claims within that grammar.
+- `compatibility` carries one or more explicit limitations. It may provide a
+  useful artifact, but it does not claim target-dialect conformance.
+
+`invalid` requires a direct conformance identity and at least one normalized
+syntax diagnostic. Compatibility rejection is therefore `unsupported` with
+reason `compatibility-rejected`, never `invalid`.
+
+`unsupported` is an expected capability boundary: backend capability,
+compatibility rejection, uncovered construct, or resource limit. `failed`
+means the backend failed or violated its output contract; it carries a bounded
+safe message and explicit retryability.
+
+Parser-reported locations are either an exact statement-relative range or
+explicitly `unavailable/not-reported`. An adapter that claims a malformed
+location returns `failed/malformed-output`; it must not erase the defect by
+turning the location into `unavailable`.
+
+### Coordinates and input
+
+The parser receives only:
+
+- The exact code-bearing normal slot's `source` slice
+- An `AbortSignal`
+
+The slice excludes the statement terminator and is not trimmed. It contains no
+editor state, document offsets, cursor, catalog, focus, or host context.
+Parser requests are package-created and frozen. Input is bounded to 1 MiB; a
+larger statement is an explicit coordinator resource limit and is not passed to
+the backend. Abort signals are checked by their cross-realm-compatible
+`AbortSignal` surface instead of `instanceof`; adapters may safely use every
+member declared by that interface.
+
+All artifact and diagnostic ranges are branded half-open UTF-16 offsets
+relative to that exact slice:
+
+```text
+0 <= from <= to <= statementText.length
+```
+
+Absolute document ranges and statement-relative ranges are not assignable.
+This lets an unchanged statement artifact move with an edited prefix without
+rewriting its coordinates.
+
+### Artifacts and identity
+
+The normalized artifact initially exposes only a closed statement kind and its
+full statement-relative range. It exposes no generic AST, facts bag, backend
+node, source text, or mutable payload.
+
+Package-private metadata binds every artifact, diagnostic, and analysis to its
+exact immutable statement text. This text is not exposed or copied into the
+artifact, but exact equality provides collision-free reuse for identical
+statements and prevents same-length text from sharing evidence.
+
+Artifacts, diagnostics, analyses, states, ranges, and identities are created by
+package constructors, frozen, and authenticated through package-owned weak
+identity sets. Structural copies and fabricated objects are rejected at
+runtime. Future official adapters may key private `WeakMap` payloads by the
+artifact so relation extraction can reuse a parse without exposing backend
+data.
+
+Cache authority requires three distinct package-owned identities:
+
+- Backend/module identity
+- Parser-configuration identity
+- Dialect-syntax identity
+
+One frozen package-owned parser-authority handle captures that exact tuple.
+Parsers, artifacts, diagnostics, analyses, and future private backend payloads
+all retain the handle in private metadata. The runner rejects every outcome
+whose handle differs from its parser, including compatibility, unsupported, and
+failed outcomes. A conformance identity is scoped to the same handle, so direct
+or invalid evidence cannot pair one backend's artifact with another backend's
+authority.
+
+Direct validity also carries a conformance identity. String dialect IDs never
+substitute for these authorities. A conformance identity is created for and
+retains the exact backend, parser-configuration, and dialect-syntax identity
+tuple; a parser cannot use another tuple's conformance to make an authoritative
+claim.
+
+Parsers are also package-created frozen descriptors. Their callback stays in
+private metadata and can be invoked only through the contract runner. The
+runner:
+
+- Accepts only authentic parser and request objects
+- Normalizes synchronous throws and rejected promises without retaining raw
+  errors
+- Rejects fabricated results
+- Verifies that every authentic artifact or diagnostic was constructed for the
+  exact request text
+- Verifies direct/invalid conformance against the parser's exact authority
+  tuple
+
+The runner returns the authenticated `analyzed` lexical state directly; there
+is no separately callable analyzed-state constructor. This prevents authentic
+evidence created for one statement from being replayed against another.
+
+Compatibility limitations are a unique, non-empty subset of the three closed
+values and are capped accordingly. Diagnostic collections, messages, parser
+input, and retained strings are likewise bounded before backend-controlled work
+can cause unbounded copying.
+
+## Consequences
+
+- Impossible result combinations are rejected by TypeScript and constructor
+  validation.
+- Backends can be changed without exposing their AST as API.
+- Unsupported dialect coverage remains honest.
+- Parser artifacts can be cached independently of catalog generations.
+- The contract has more explicit result variants, but consumers narrow on
+  stable discriminants instead of interpreting nullable fields or exceptions.
+
+The initial `node-sql-parser` adapter will lazy-load dialect-specific builds,
+request locations, retain backend data privately, and normalize every boundary
+before constructing these results. Cache/session wiring follows only after the
+adapter passes the contract suite.
+
+## Non-goals
+
+This decision does not define:
+
+- A public parser plugin SPI
+- A universal SQL AST
+- Semantic relations, scopes, types, or catalog lookup
+- Recovery-node semantics
+- Document-level validation
+- Session cancellation or stale-result publication
+- Parser cache sizing and eviction
+
+Those layers depend on this contract but remain independently reviewable
+decisions.

--- a/src/vnext/__tests__/syntax.test.ts
+++ b/src/vnext/__tests__/syntax.test.ts
@@ -777,31 +777,156 @@ describe("parser request boundary", () => {
     expect(result.analysis).toBe(expected);
   });
 
-  it("passes an already-aborted signal to the parser callback", async () => {
+  it("rejects pre-aborted requests without invoking the callback", async () => {
     const authority = createParserAuthority();
     const controller = new AbortController();
     const reason = new Error("superseded");
     controller.abort(reason);
+    let invoked = false;
+    const parser = createSqlStatementParser(
+      authority.authority,
+      async () => {
+        invoked = true;
+        return createUnsupportedParserAnalysis(
+          "backend-capability",
+          "SELECT 1",
+          authority.authority,
+        );
+      },
+    );
+
+    await expect(
+      runSqlStatementParser(
+        parser,
+        createSqlStatementParseRequest("SELECT 1", controller.signal),
+      ),
+    ).rejects.toBe(reason);
+    expect(invoked).toBe(false);
+  });
+
+  it("rejects in-flight requests with the exact abort reason", async () => {
+    const authority = createParserAuthority();
+    const controller = new AbortController();
+    const reason = { kind: "superseded" };
+    let rejectCallback: ((reason: unknown) => void) | undefined;
+    const parser = createSqlStatementParser(
+      authority.authority,
+      () =>
+        new Promise((_, reject) => {
+          rejectCallback = reject;
+        }),
+    );
+    const result = runSqlStatementParser(
+      parser,
+      createSqlStatementParseRequest("SELECT 1", controller.signal),
+    );
+
+    controller.abort(reason);
+    await expect(result).rejects.toBe(reason);
+    rejectCallback?.(new Error("late backend rejection"));
+    await Promise.resolve();
+  });
+
+  it("keeps backend success that settles before a later abort", async () => {
+    const authority = createParserAuthority();
+    const controller = new AbortController();
     const expected = createUnsupportedParserAnalysis(
       "backend-capability",
       "SELECT 1",
       authority.authority,
     );
+    let resolveCallback:
+      | ((analysis: typeof expected) => void)
+      | undefined;
     const parser = createSqlStatementParser(
       authority.authority,
-      async (request) => {
-        expect(request.signal).toBe(controller.signal);
-        expect(request.signal.aborted).toBe(true);
-        expect(request.signal.reason).toBe(reason);
-        return expected;
-      },
+      () =>
+        new Promise((resolve) => {
+          resolveCallback = resolve;
+        }),
     );
-
-    const result = await runSqlStatementParser(
+    const result = runSqlStatementParser(
       parser,
       createSqlStatementParseRequest("SELECT 1", controller.signal),
     );
-    expect(result.analysis).toBe(expected);
+
+    resolveCallback?.(expected);
+    controller.abort(new Error("late cancellation"));
+    expect((await result).analysis).toBe(expected);
+  });
+
+  it("keeps backend failure that settles before a later abort", async () => {
+    const authority = createParserAuthority();
+    const controller = new AbortController();
+    const backendError = new Error("backend failure");
+    let rejectCallback: ((reason: unknown) => void) | undefined;
+    const parser = createSqlStatementParser(
+      authority.authority,
+      () =>
+        new Promise((_, reject) => {
+          rejectCallback = reject;
+        }),
+    );
+    const result = runSqlStatementParser(
+      parser,
+      createSqlStatementParseRequest("SELECT 1", controller.signal),
+    );
+
+    rejectCallback?.(backendError);
+    controller.abort(backendError);
+    expect((await result).analysis).toMatchObject({
+      reason: "backend-failure",
+      status: "failed",
+    });
+  });
+
+  it("lets cancellation win when the callback also throws", async () => {
+    const authority = createParserAuthority();
+    const controller = new AbortController();
+    const reason = new SqlSyntaxContractError(
+      "invalid-analysis",
+      "superseded",
+    );
+    const parser = createSqlStatementParser(
+      authority.authority,
+      () => {
+        controller.abort(reason);
+        throw new Error("backend failed after cancellation");
+      },
+    );
+
+    await expect(
+      runSqlStatementParser(
+        parser,
+        createSqlStatementParseRequest("SELECT 1", controller.signal),
+      ),
+    ).rejects.toBe(reason);
+  });
+
+  it("preserves falsy abort reasons", async () => {
+    const authority = createParserAuthority();
+    const controller = new AbortController();
+    controller.abort(0);
+    const parser = createSqlStatementParser(
+      authority.authority,
+      async () =>
+        createUnsupportedParserAnalysis(
+          "backend-capability",
+          "SELECT 1",
+          authority.authority,
+        ),
+    );
+    let caught: unknown = Symbol("not rejected");
+
+    try {
+      await runSqlStatementParser(
+        parser,
+        createSqlStatementParseRequest("SELECT 1", controller.signal),
+      );
+    } catch (error: unknown) {
+      caught = error;
+    }
+    expect(Object.is(caught, 0)).toBe(true);
   });
 
   it("rejects malformed requests", () => {
@@ -833,6 +958,17 @@ describe("parser request boundary", () => {
         addEventListener() {},
         removeEventListener() {},
       },
+      {
+        aborted: false,
+        addEventListener() {},
+        dispatchEvent() {
+          return true;
+        },
+        onabort: null,
+        reason: undefined,
+        removeEventListener() {},
+        throwIfAborted() {},
+      },
     ]) {
       expectContractError(
         () =>
@@ -852,6 +988,67 @@ describe("parser request boundary", () => {
       () => createSqlStatementParseRequest("SELECT 1", hostileSignal),
       "invalid-request",
     );
+    const hostileTag = Object.defineProperty(
+      {},
+      Symbol.toStringTag,
+      {
+        get() {
+          throw new Error("hostile identity");
+        },
+      },
+    );
+    expectContractError(
+      () => createSqlStatementParseRequest("SELECT 1", hostileTag),
+      "invalid-request",
+    );
+  });
+
+  it("accepts genuine cross-realm abort signals", async () => {
+    const iframe = document.createElement("iframe");
+    document.body.append(iframe);
+    try {
+      const foreignWindow = iframe.contentWindow;
+      expect(foreignWindow).not.toBeNull();
+      if (foreignWindow === null) {
+        throw new Error("iframe window unavailable");
+      }
+      const ForeignAbortController = Reflect.get(
+        foreignWindow,
+        "AbortController",
+      );
+      expect(typeof ForeignAbortController).toBe("function");
+      if (typeof ForeignAbortController !== "function") {
+        throw new Error("foreign AbortController unavailable");
+      }
+      const controller: unknown = Reflect.construct(
+        ForeignAbortController,
+        [],
+      );
+      if (controller === null || typeof controller !== "object") {
+        throw new Error("foreign AbortController is invalid");
+      }
+      const signal = Reflect.get(controller, "signal");
+      const request = createSqlStatementParseRequest(
+        "SELECT 1",
+        signal,
+      );
+      const authority = createParserAuthority();
+      const expected = createUnsupportedParserAnalysis(
+        "backend-capability",
+        "SELECT 1",
+        authority.authority,
+      );
+      const parser = createSqlStatementParser(
+        authority.authority,
+        async () => expected,
+      );
+      expect(request.signal).toBe(signal);
+      expect((await runSqlStatementParser(parser, request)).analysis).toBe(
+        expected,
+      );
+    } finally {
+      iframe.remove();
+    }
   });
 
   it("rejects fabricated parser identities and callbacks", () => {

--- a/src/vnext/__tests__/syntax.test.ts
+++ b/src/vnext/__tests__/syntax.test.ts
@@ -1,0 +1,1158 @@
+import { describe, expect, it } from "vitest";
+import {
+  createCompatibilityParsedAnalysis,
+  createDirectParsedAnalysis,
+  createEmptySyntaxState,
+  createFailedParserAnalysis,
+  createIncompleteSyntaxState,
+  createInvalidParserAnalysis,
+  createOpaqueSyntaxState,
+  createSqlConformanceIdentity,
+  createSqlDialectSyntaxIdentity,
+  createSqlParserDiagnostic,
+  createSqlParserAuthority,
+  createSqlStatementParseRequest,
+  createSqlStatementParser,
+  createSqlStatementRelativeRange,
+  createSqlSyntaxArtifact,
+  createSqlSyntaxBackendIdentity,
+  createSqlSyntaxConfigurationIdentity,
+  createUnavailableSyntaxState,
+  createUnsupportedParserAnalysis,
+  isSqlParserAnalysis,
+  isSqlStatementSyntaxState,
+  MAX_SQL_SYNTAX_DIAGNOSTICS,
+  MAX_SQL_SYNTAX_MESSAGE_INPUT_LENGTH,
+  MAX_SQL_SYNTAX_MESSAGE_LENGTH,
+  MAX_SQL_STATEMENT_PARSE_LENGTH,
+  runSqlStatementParser,
+  SqlSyntaxContractError,
+  type SqlStatementKind,
+} from "../syntax.js";
+
+function invokeWithUnknown(
+  callback: (...values: never[]) => unknown,
+  ...values: unknown[]
+): unknown {
+  return Reflect.apply(callback, undefined, values);
+}
+
+function expectContractError(
+  callback: () => unknown,
+  code: SqlSyntaxContractError["code"],
+): void {
+  try {
+    callback();
+  } catch (error: unknown) {
+    expect(error).toBeInstanceOf(SqlSyntaxContractError);
+    if (error instanceof SqlSyntaxContractError) {
+      expect(error.code).toBe(code);
+      expect(error.name).toBe("SqlSyntaxContractError");
+    }
+    return;
+  }
+  throw new Error(`Expected ${code}`);
+}
+
+function createParserAuthority() {
+  const backendIdentity = createSqlSyntaxBackendIdentity();
+  const configurationIdentity =
+    createSqlSyntaxConfigurationIdentity();
+  const dialectIdentity = createSqlDialectSyntaxIdentity();
+  const authority = createSqlParserAuthority(
+    backendIdentity,
+    configurationIdentity,
+    dialectIdentity,
+  );
+  const conformance = createSqlConformanceIdentity(authority);
+  return {
+    authority,
+    backendIdentity,
+    configurationIdentity,
+    conformance,
+    dialectIdentity,
+  };
+}
+
+describe("statement-relative ranges", () => {
+  it("creates frozen half-open UTF-16 ranges, including empty ranges", () => {
+    const astralText = "a🦆\ud800";
+    const full = createSqlStatementRelativeRange(
+      0,
+      astralText.length,
+      astralText.length,
+    );
+    const atEnd = createSqlStatementRelativeRange(
+      astralText.length,
+      astralText.length,
+      astralText.length,
+    );
+
+    expect(full).toMatchObject({ from: 0, to: 4 });
+    expect(atEnd).toMatchObject({ from: 4, to: 4 });
+    expect(Object.isFrozen(full)).toBe(true);
+  });
+
+  it.each([
+    [-1, 0, 0],
+    [1, 0, 1],
+    [0, 2, 1],
+    [0.5, 1, 1],
+    [0, Number.NaN, 1],
+    [0, 1, Number.POSITIVE_INFINITY],
+    [0, 0, -1],
+    [0, 0, 0.5],
+  ])("rejects invalid range (%j, %j, %j)", (from, to, length) => {
+    expectContractError(
+      () => createSqlStatementRelativeRange(from, to, length),
+      "invalid-range",
+    );
+  });
+});
+
+describe("opaque identities", () => {
+  it("creates frozen, distinct identities for each authority boundary", () => {
+    const backend = createSqlSyntaxBackendIdentity();
+    const configuration = createSqlSyntaxConfigurationIdentity();
+    const dialect = createSqlDialectSyntaxIdentity();
+    const authority = createSqlParserAuthority(
+      backend,
+      configuration,
+      dialect,
+    );
+    const conformance = createSqlConformanceIdentity(authority);
+
+    expect(Object.isFrozen(backend)).toBe(true);
+    expect(Object.isFrozen(configuration)).toBe(true);
+    expect(Object.isFrozen(dialect)).toBe(true);
+    expect(Object.isFrozen(authority)).toBe(true);
+    expect(authority).toMatchObject({
+      backendIdentity: backend,
+      configurationIdentity: configuration,
+      dialectIdentity: dialect,
+    });
+    expect(Object.isFrozen(conformance)).toBe(true);
+    expect(createSqlSyntaxBackendIdentity()).not.toBe(backend);
+    expect(createSqlSyntaxConfigurationIdentity()).not.toBe(configuration);
+    expect(createSqlDialectSyntaxIdentity()).not.toBe(dialect);
+    expect(createSqlConformanceIdentity(authority)).not.toBe(
+      conformance,
+    );
+  });
+
+  it("rejects fabricated authority inputs", () => {
+    const backend = createSqlSyntaxBackendIdentity();
+    const configuration = createSqlSyntaxConfigurationIdentity();
+    const dialect = createSqlDialectSyntaxIdentity();
+    expectContractError(
+      () =>
+        invokeWithUnknown(
+          createSqlParserAuthority,
+          {},
+          configuration,
+          dialect,
+        ),
+      "invalid-identity",
+    );
+    expectContractError(
+      () =>
+        invokeWithUnknown(
+          createSqlParserAuthority,
+          backend,
+          {},
+          dialect,
+        ),
+      "invalid-identity",
+    );
+    expectContractError(
+      () =>
+        invokeWithUnknown(
+          createSqlParserAuthority,
+          backend,
+          configuration,
+          {},
+        ),
+      "invalid-identity",
+    );
+    expectContractError(
+      () => invokeWithUnknown(createSqlConformanceIdentity, {}),
+      "invalid-identity",
+    );
+  });
+});
+
+describe("syntax artifacts and diagnostics", () => {
+  const { authority } = createParserAuthority();
+  const kinds: readonly SqlStatementKind[] = [
+    "alter",
+    "create",
+    "delete",
+    "drop",
+    "insert",
+    "merge",
+    "other",
+    "query",
+    "transaction",
+    "update",
+  ];
+
+  it.each(kinds)("creates an authentic frozen %s artifact", (kind) => {
+    const artifact = createSqlSyntaxArtifact(
+      kind,
+      "x".repeat(12),
+      authority,
+    );
+    expect(artifact.kind).toBe(kind);
+    expect(artifact.range).toMatchObject({ from: 0, to: 12 });
+    expect(Object.isFrozen(artifact)).toBe(true);
+    expect(Object.isFrozen(artifact.range)).toBe(true);
+  });
+
+  it("rejects unknown kinds and invalid lengths", () => {
+    expectContractError(
+      () => createSqlSyntaxArtifact("select", "abc", authority),
+      "invalid-artifact",
+    );
+    expectContractError(
+      () => createSqlSyntaxArtifact("query", -1, authority),
+      "invalid-artifact",
+    );
+  });
+
+  it("normalizes exact and unavailable diagnostic locations", () => {
+    const range = createSqlStatementRelativeRange(2, 5, 8);
+    const exact = createSqlParserDiagnostic(
+      "  bad token  ",
+      range,
+      "12345678",
+      authority,
+    );
+    const unavailable = createSqlParserDiagnostic(
+      "bad",
+      null,
+      "12345678",
+      authority,
+    );
+
+    expect(exact).toMatchObject({
+      code: "syntax-error",
+      location: { availability: "exact", range },
+      message: "bad token",
+      severity: "error",
+    });
+    expect(unavailable.location).toEqual({
+      availability: "unavailable",
+      reason: "not-reported",
+    });
+    expect(Object.isFrozen(exact)).toBe(true);
+    expect(Object.isFrozen(exact.location)).toBe(true);
+    expect(Object.isFrozen(unavailable.location)).toBe(true);
+  });
+
+  it("bounds messages and rejects malformed diagnostics", () => {
+    const longMessage = "x".repeat(MAX_SQL_SYNTAX_MESSAGE_LENGTH + 10);
+    expect(
+      createSqlParserDiagnostic(
+        longMessage,
+        null,
+        "",
+        authority,
+      ).message,
+    ).toHaveLength(MAX_SQL_SYNTAX_MESSAGE_LENGTH);
+
+    for (const message of ["", " \n "]) {
+      expectContractError(
+        () =>
+          createSqlParserDiagnostic(message, null, "", authority),
+        "invalid-diagnostic",
+      );
+    }
+    for (const location of [false, 0, "", undefined, Number.NaN]) {
+      expectContractError(
+        () =>
+          createSqlParserDiagnostic(
+            "bad",
+            location,
+            "x",
+            authority,
+          ),
+        "invalid-diagnostic",
+      );
+    }
+    expectContractError(
+      () =>
+        invokeWithUnknown(
+          createSqlParserDiagnostic,
+          12,
+          null,
+          "",
+          authority,
+        ),
+      "invalid-diagnostic",
+    );
+    expectContractError(
+      () =>
+        createSqlParserDiagnostic(
+          "x".repeat(MAX_SQL_SYNTAX_MESSAGE_INPUT_LENGTH + 1),
+          null,
+          "",
+          authority,
+        ),
+      "invalid-diagnostic",
+    );
+    const outside = createSqlStatementRelativeRange(0, 4, 4);
+    expectContractError(
+      () =>
+        createSqlParserDiagnostic(
+          "bad",
+          outside,
+          "abc",
+          authority,
+        ),
+      "invalid-diagnostic",
+    );
+    expectContractError(
+      () =>
+        invokeWithUnknown(
+          createSqlParserDiagnostic,
+          "bad",
+          { from: 0, to: 1 },
+          "x",
+          authority,
+        ),
+      "invalid-diagnostic",
+    );
+  });
+});
+
+describe("parser analyses", () => {
+  const { authority, conformance } = createParserAuthority();
+  const artifact = createSqlSyntaxArtifact(
+    "query",
+    "SELECT 1",
+    authority,
+  );
+  const diagnostic = createSqlParserDiagnostic(
+    "bad",
+    null,
+    "SELECT 1",
+    authority,
+  );
+
+  it("constructs direct and compatibility success without raw AST data", () => {
+    const direct = createDirectParsedAnalysis(conformance, artifact);
+    const input = ["dialect-compatibility", "recovered"] as const;
+    const compatibility = createCompatibilityParsedAnalysis(artifact, input);
+
+    expect(direct).toMatchObject({
+      artifact,
+      conformance,
+      mode: "direct",
+      status: "parsed",
+    });
+    expect(compatibility).toMatchObject({
+      artifact,
+      limitations: input,
+      mode: "compatibility",
+      status: "parsed",
+    });
+    expect(compatibility.limitations).not.toBe(input);
+    expect(Object.isFrozen(compatibility.limitations)).toBe(true);
+    expect(isSqlParserAnalysis(direct)).toBe(true);
+    expect(isSqlParserAnalysis(compatibility)).toBe(true);
+  });
+
+  it("constructs authoritative invalid analyses with bounded diagnostics", () => {
+    const input = [diagnostic] as const;
+    const invalid = createInvalidParserAnalysis(conformance, input);
+
+    expect(invalid).toMatchObject({
+      conformance,
+      diagnostics: input,
+      status: "invalid",
+    });
+    expect(invalid.diagnostics).not.toBe(input);
+    expect(Object.isFrozen(invalid.diagnostics)).toBe(true);
+  });
+
+  it("constructs every closed unsupported and failure reason", () => {
+    for (const reason of [
+      "backend-capability",
+      "compatibility-rejected",
+      "resource-limit",
+      "uncovered-construct",
+    ] as const) {
+      expect(
+        createUnsupportedParserAnalysis(
+          reason,
+          "SELECT 1",
+          authority,
+        ),
+      ).toMatchObject({
+        reason,
+        status: "unsupported",
+      });
+    }
+    for (const reason of [
+      "backend-failure",
+      "malformed-output",
+    ] as const) {
+      expect(
+        createFailedParserAnalysis(
+          reason,
+          "  unavailable  ",
+          true,
+          "SELECT 1",
+          authority,
+        ),
+      ).toMatchObject({
+        message: "unavailable",
+        reason,
+        retryable: true,
+        status: "failed",
+      });
+    }
+  });
+
+  it("rejects fabricated identities, artifacts, and diagnostics", () => {
+    expectContractError(
+      () =>
+        invokeWithUnknown(
+          createDirectParsedAnalysis,
+          {},
+          artifact,
+        ),
+      "invalid-identity",
+    );
+    expectContractError(
+      () =>
+        invokeWithUnknown(
+          createDirectParsedAnalysis,
+          conformance,
+          {},
+        ),
+      "invalid-artifact",
+    );
+    expectContractError(
+      () =>
+        invokeWithUnknown(
+          createInvalidParserAnalysis,
+          conformance,
+          [{}],
+        ),
+      "invalid-analysis",
+    );
+    expectContractError(
+      () =>
+        createCompatibilityParsedAnalysis(artifact, [
+          "recovered",
+          "recovered",
+        ]),
+      "invalid-analysis",
+    );
+    expectContractError(
+      () =>
+        createCompatibilityParsedAnalysis(artifact, [
+          "dialect-compatibility",
+          "partial-artifact",
+          "recovered",
+          "recovered",
+        ]),
+      "invalid-analysis",
+    );
+    const hostileDiagnostics = [diagnostic];
+    Object.defineProperty(hostileDiagnostics, Symbol.iterator, {
+      value: function* hostileIterator() {
+        for (
+          let index = 0;
+          index <= MAX_SQL_SYNTAX_DIAGNOSTICS;
+          index += 1
+        ) {
+          yield diagnostic;
+        }
+      },
+    });
+    expect(
+      createInvalidParserAnalysis(
+        conformance,
+        hostileDiagnostics,
+      ).diagnostics,
+    ).toHaveLength(1);
+
+    const hostileLimitations: Array<"recovered"> = ["recovered"];
+    Object.defineProperty(hostileLimitations, Symbol.iterator, {
+      value: function* hostileIterator() {
+        while (true) {
+          yield "recovered";
+        }
+      },
+    });
+    expect(
+      createCompatibilityParsedAnalysis(
+        artifact,
+        hostileLimitations,
+      ).limitations,
+    ).toEqual(["recovered"]);
+  });
+
+  it("rejects empty, invalid, and oversized collections", () => {
+    expectContractError(
+      () => createCompatibilityParsedAnalysis(artifact, []),
+      "invalid-analysis",
+    );
+    expectContractError(
+      () =>
+        invokeWithUnknown(
+          createCompatibilityParsedAnalysis,
+          artifact,
+          ["unknown"],
+        ),
+      "invalid-analysis",
+    );
+    expectContractError(
+      () => createInvalidParserAnalysis(conformance, []),
+      "invalid-analysis",
+    );
+    expectContractError(
+      () =>
+        createInvalidParserAnalysis(
+          conformance,
+          Array.from(
+            { length: MAX_SQL_SYNTAX_DIAGNOSTICS + 1 },
+            () => diagnostic,
+          ),
+        ),
+      "invalid-analysis",
+    );
+    const wrongSource = createSqlParserDiagnostic(
+      "bad",
+      null,
+      "SELECT 2",
+      authority,
+    );
+    expectContractError(
+      () =>
+        createInvalidParserAnalysis(conformance, [
+          diagnostic,
+          wrongSource,
+        ]),
+      "invalid-analysis",
+    );
+    const other = createParserAuthority();
+    const otherDiagnostic = createSqlParserDiagnostic(
+      "bad",
+      null,
+      "SELECT 1",
+      other.authority,
+    );
+    expectContractError(
+      () =>
+        createInvalidParserAnalysis(conformance, [
+          diagnostic,
+          otherDiagnostic,
+        ]),
+      "invalid-analysis",
+    );
+    expectContractError(
+      () =>
+        createInvalidParserAnalysis(conformance, [
+          otherDiagnostic,
+        ]),
+      "invalid-analysis",
+    );
+    expectContractError(
+      () =>
+        invokeWithUnknown(
+          createInvalidParserAnalysis,
+          conformance,
+          "not-an-array",
+        ),
+      "invalid-analysis",
+    );
+  });
+
+  it("rejects invalid reason, message, and retryability values", () => {
+    expectContractError(
+      () =>
+        invokeWithUnknown(
+          createUnsupportedParserAnalysis,
+          "unknown",
+          "x",
+          authority,
+        ),
+      "invalid-analysis",
+    );
+    expectContractError(
+      () =>
+        invokeWithUnknown(
+          createFailedParserAnalysis,
+          "unknown",
+          "bad",
+          false,
+          "x",
+          authority,
+        ),
+      "invalid-analysis",
+    );
+    expectContractError(
+      () =>
+        invokeWithUnknown(
+          createFailedParserAnalysis,
+          "backend-failure",
+          "bad",
+          "yes",
+          "x",
+          authority,
+        ),
+      "invalid-analysis",
+    );
+    expectContractError(
+      () =>
+        createFailedParserAnalysis(
+          "backend-failure",
+          " ",
+          false,
+          "x",
+          authority,
+        ),
+      "invalid-analysis",
+    );
+  });
+
+  it("recognizes only package-created analyses", () => {
+    expect(isSqlParserAnalysis(null)).toBe(false);
+    expect(isSqlParserAnalysis("parsed")).toBe(false);
+    expect(
+      isSqlParserAnalysis(
+        Object.freeze({ mode: "direct", status: "parsed" }),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("lexical eligibility states", () => {
+  it("keeps lexical eligibility distinct from parser analysis", async () => {
+    const empty = createEmptySyntaxState();
+    const opening = createSqlStatementRelativeRange(7, 7, 8);
+    const incomplete = createIncompleteSyntaxState(
+      "single-quoted-string",
+      opening,
+      8,
+    );
+    const opaque = createOpaqueSyntaxState(
+      "procedural-block",
+      opening,
+      8,
+    );
+    const unavailable = createUnavailableSyntaxState(
+      "parser-not-configured",
+    );
+    const authority = createParserAuthority();
+    const unvalidatedAnalysis = createUnsupportedParserAnalysis(
+      "backend-capability",
+      "SELECT 1",
+      authority.authority,
+    );
+    const parser = createSqlStatementParser(
+      authority.authority,
+      async () => unvalidatedAnalysis,
+    );
+    const request = createSqlStatementParseRequest(
+      "SELECT 1",
+      new AbortController().signal,
+    );
+    const analyzed = await runSqlStatementParser(parser, request);
+    const analysis = analyzed.analysis;
+
+    expect(empty).toMatchObject({ state: "empty" });
+    expect(incomplete).toMatchObject({
+      construct: "single-quoted-string",
+      opening,
+      state: "incomplete",
+    });
+    expect(opaque).toMatchObject({
+      at: opening,
+      reason: "procedural-block",
+      state: "opaque",
+    });
+    expect(unavailable).toMatchObject({
+      reason: "parser-not-configured",
+      state: "unavailable",
+    });
+    expect(analyzed).toMatchObject({ analysis, state: "analyzed" });
+    for (const state of [
+      empty,
+      incomplete,
+      opaque,
+      unavailable,
+      analyzed,
+    ]) {
+      expect(Object.isFrozen(state)).toBe(true);
+      expect(isSqlStatementSyntaxState(state)).toBe(true);
+    }
+  });
+
+  it("accepts every closed lexical and unavailability reason", () => {
+    const point = createSqlStatementRelativeRange(0, 0, 0);
+    for (const construct of [
+      "backtick-quoted-identifier",
+      "block-comment",
+      "dollar-quoted-string",
+      "double-quoted-identifier",
+      "double-quoted-string",
+      "single-quoted-string",
+      "triple-double-quoted-string",
+      "triple-single-quoted-string",
+    ] as const) {
+      expect(
+        createIncompleteSyntaxState(construct, point, 0).construct,
+      ).toBe(construct);
+    }
+    for (const reason of [
+      "custom-delimiter",
+      "procedural-block",
+      "resource-limit",
+    ] as const) {
+      expect(createOpaqueSyntaxState(reason, point, 0).reason).toBe(
+        reason,
+      );
+    }
+    for (const reason of [
+      "dialect-not-supported",
+      "parser-not-configured",
+    ] as const) {
+      expect(createUnavailableSyntaxState(reason).reason).toBe(reason);
+    }
+  });
+
+  it("rejects invalid and fabricated lexical state inputs", () => {
+    const point = createSqlStatementRelativeRange(0, 0, 0);
+    expectContractError(
+      () => createIncompleteSyntaxState("quote", point, 0),
+      "invalid-analysis",
+    );
+    expectContractError(
+      () => createOpaqueSyntaxState("guess", point, 0),
+      "invalid-analysis",
+    );
+    expectContractError(
+      () => createUnavailableSyntaxState("offline"),
+      "invalid-analysis",
+    );
+    expect(isSqlStatementSyntaxState({ state: "empty" })).toBe(false);
+    expect(isSqlStatementSyntaxState(null)).toBe(false);
+    expect(isSqlStatementSyntaxState("empty")).toBe(false);
+  });
+});
+
+describe("parser request boundary", () => {
+  it("runs an authentic parser with exact text and cancellation", async () => {
+    const authority = createParserAuthority();
+    const controller = new AbortController();
+    const expected = createUnsupportedParserAnalysis(
+      "backend-capability",
+      " SELECT 1 ",
+      authority.authority,
+    );
+    const parser = createSqlStatementParser(
+      authority.authority,
+      async (request) => {
+        request.signal.throwIfAborted();
+        expect(request).toMatchObject({
+          signal: controller.signal,
+          text: " SELECT 1 ",
+        });
+        expect(Object.isFrozen(request)).toBe(true);
+        return expected;
+      },
+    );
+
+    const request = createSqlStatementParseRequest(
+      " SELECT 1 ",
+      controller.signal,
+    );
+    expect(Object.isFrozen(parser)).toBe(true);
+    const result = await runSqlStatementParser(parser, request);
+    expect(result.state).toBe("analyzed");
+    expect(result.analysis).toBe(expected);
+  });
+
+  it("rejects malformed requests", () => {
+    const signal = new AbortController().signal;
+    expectContractError(
+      () => createSqlStatementParseRequest(1, signal),
+      "invalid-request",
+    );
+    expectContractError(
+      () =>
+        createSqlStatementParseRequest(
+          "x".repeat(MAX_SQL_STATEMENT_PARSE_LENGTH + 1),
+          signal,
+        ),
+      "invalid-request",
+    );
+    for (const malformedSignal of [
+      null,
+      {},
+      [],
+      new Date(),
+      { aborted: false },
+      {
+        aborted: false,
+        addEventListener() {},
+      },
+      {
+        aborted: false,
+        addEventListener() {},
+        removeEventListener() {},
+      },
+    ]) {
+      expectContractError(
+        () =>
+          createSqlStatementParseRequest(
+            "SELECT 1",
+            malformedSignal,
+          ),
+        "invalid-request",
+      );
+    }
+    const hostileSignal = Object.defineProperty({}, "aborted", {
+      get() {
+        throw new Error("hostile getter");
+      },
+    });
+    expectContractError(
+      () => createSqlStatementParseRequest("SELECT 1", hostileSignal),
+      "invalid-request",
+    );
+  });
+
+  it("rejects fabricated parser identities and callbacks", () => {
+    const authority = createParserAuthority();
+    const parseStatement = async () =>
+      createUnsupportedParserAnalysis(
+        "backend-capability",
+        "x",
+        authority.authority,
+      );
+
+    expectContractError(
+      () =>
+        invokeWithUnknown(
+          createSqlStatementParser,
+          {},
+          parseStatement,
+        ),
+      "invalid-identity",
+    );
+    expectContractError(
+      () =>
+        invokeWithUnknown(
+          createSqlStatementParser,
+          authority.authority,
+          "parse",
+        ),
+      "invalid-request",
+    );
+  });
+
+  it("rejects fabricated parsers, requests, and parser output", async () => {
+    const authority = createParserAuthority();
+    const request = createSqlStatementParseRequest(
+      "x",
+      new AbortController().signal,
+    );
+    const malformedParser = invokeWithUnknown(
+      createSqlStatementParser,
+      authority.authority,
+      async () => ({ status: "parsed" }),
+    );
+    const malformedResult = await Promise.resolve(
+      invokeWithUnknown(
+        runSqlStatementParser,
+        malformedParser,
+        request,
+      ),
+    );
+    expect(malformedResult).toMatchObject({
+      analysis: {
+        reason: "malformed-output",
+        retryable: false,
+        status: "failed",
+      },
+      state: "analyzed",
+    });
+
+    const validParser = createSqlStatementParser(
+      authority.authority,
+      async () =>
+        createUnsupportedParserAnalysis(
+          "backend-capability",
+          "x",
+          authority.authority,
+        ),
+    );
+    await expect(
+      Promise.resolve(
+        invokeWithUnknown(
+          runSqlStatementParser,
+          {},
+          request,
+        ),
+      ),
+    ).rejects.toMatchObject({ code: "invalid-request" });
+    await expect(
+      Promise.resolve(
+        invokeWithUnknown(
+          runSqlStatementParser,
+          validParser,
+          { signal: new AbortController().signal, text: "x" },
+        ),
+      ),
+    ).rejects.toMatchObject({ code: "invalid-request" });
+  });
+
+  it("rejects authentic evidence for different statement text", async () => {
+    const authority = createParserAuthority();
+    const request = createSqlStatementParseRequest(
+      "x",
+      new AbortController().signal,
+    );
+    const analyses = [
+      createDirectParsedAnalysis(
+        authority.conformance,
+        createSqlSyntaxArtifact(
+          "query",
+          "xx",
+          authority.authority,
+        ),
+      ),
+      createCompatibilityParsedAnalysis(
+        createSqlSyntaxArtifact(
+          "query",
+          "xx",
+          authority.authority,
+        ),
+        ["dialect-compatibility"],
+      ),
+      createInvalidParserAnalysis(authority.conformance, [
+        createSqlParserDiagnostic(
+          "bad",
+          null,
+          "xx",
+          authority.authority,
+        ),
+      ]),
+      createDirectParsedAnalysis(
+        authority.conformance,
+        createSqlSyntaxArtifact(
+          "query",
+          "y",
+          authority.authority,
+        ),
+      ),
+      createCompatibilityParsedAnalysis(
+        createSqlSyntaxArtifact(
+          "query",
+          "y",
+          authority.authority,
+        ),
+        ["dialect-compatibility"],
+      ),
+      createInvalidParserAnalysis(authority.conformance, [
+        createSqlParserDiagnostic(
+          "bad",
+          null,
+          "y",
+          authority.authority,
+        ),
+      ]),
+    ];
+
+    for (const analysis of analyses) {
+      const parser = createSqlStatementParser(
+        authority.authority,
+        async () => analysis,
+      );
+      expect(await runSqlStatementParser(parser, request)).toMatchObject({
+        analysis: {
+          reason: "malformed-output",
+          retryable: false,
+          status: "failed",
+        },
+        state: "analyzed",
+      });
+    }
+  });
+
+  it("rejects conformance from another parser authority", async () => {
+    const parserAuthority = createParserAuthority();
+    const otherAuthority = createParserAuthority();
+    const request = createSqlStatementParseRequest(
+      "x",
+      new AbortController().signal,
+    );
+    const analyses = [
+      createDirectParsedAnalysis(
+        otherAuthority.conformance,
+        createSqlSyntaxArtifact(
+          "query",
+          "x",
+          otherAuthority.authority,
+        ),
+      ),
+      createCompatibilityParsedAnalysis(
+        createSqlSyntaxArtifact(
+          "query",
+          "x",
+          otherAuthority.authority,
+        ),
+        ["dialect-compatibility"],
+      ),
+      createInvalidParserAnalysis(otherAuthority.conformance, [
+        createSqlParserDiagnostic(
+          "bad",
+          null,
+          "x",
+          otherAuthority.authority,
+        ),
+      ]),
+      createUnsupportedParserAnalysis(
+        "compatibility-rejected",
+        "x",
+        otherAuthority.authority,
+      ),
+      createFailedParserAnalysis(
+        "backend-failure",
+        "failed",
+        true,
+        "x",
+        otherAuthority.authority,
+      ),
+    ];
+
+    expectContractError(
+      () =>
+        createDirectParsedAnalysis(
+          parserAuthority.conformance,
+          createSqlSyntaxArtifact(
+            "query",
+            "x",
+            otherAuthority.authority,
+          ),
+        ),
+      "invalid-analysis",
+    );
+
+    for (const analysis of analyses) {
+      const parser = createSqlStatementParser(
+        parserAuthority.authority,
+        async () => analysis,
+      );
+      expect(await runSqlStatementParser(parser, request)).toMatchObject({
+        analysis: {
+          reason: "malformed-output",
+          status: "failed",
+        },
+        state: "analyzed",
+      });
+    }
+  });
+
+  it("accepts matching direct, compatibility, and invalid evidence", async () => {
+    const authority = createParserAuthority();
+    const request = createSqlStatementParseRequest(
+      "x",
+      new AbortController().signal,
+    );
+    const analyses = [
+      createDirectParsedAnalysis(
+        authority.conformance,
+        createSqlSyntaxArtifact(
+          "query",
+          "x",
+          authority.authority,
+        ),
+      ),
+      createCompatibilityParsedAnalysis(
+        createSqlSyntaxArtifact(
+          "query",
+          "x",
+          authority.authority,
+        ),
+        ["dialect-compatibility"],
+      ),
+      createInvalidParserAnalysis(authority.conformance, [
+        createSqlParserDiagnostic(
+          "bad",
+          null,
+          "x",
+          authority.authority,
+        ),
+      ]),
+    ];
+
+    for (const analysis of analyses) {
+      const parser = createSqlStatementParser(
+        authority.authority,
+        async () => analysis,
+      );
+      expect(
+        (await runSqlStatementParser(parser, request)).analysis,
+      ).toBe(analysis);
+    }
+  });
+
+  it("normalizes synchronous throws and rejections without raw errors", async () => {
+    const authority = createParserAuthority();
+    const request = createSqlStatementParseRequest(
+      "x",
+      new AbortController().signal,
+    );
+    const callbacks = [
+      () => {
+        throw new Error("secret sync error");
+      },
+      async () => {
+        throw new Error("secret async error");
+      },
+    ];
+
+    for (const callback of callbacks) {
+      const parser = createSqlStatementParser(
+        authority.authority,
+        callback,
+      );
+      const state = await runSqlStatementParser(parser, request);
+      expect(state.analysis).toMatchObject({
+        message: "SQL parser backend failed",
+        reason: "backend-failure",
+        retryable: true,
+        status: "failed",
+      });
+      if (state.analysis.status === "failed") {
+        expect(state.analysis.message).not.toContain("secret");
+      }
+    }
+
+    const malformedParser = createSqlStatementParser(
+      authority.authority,
+      async () => {
+        throw new SqlSyntaxContractError(
+          "invalid-analysis",
+          "secret malformed output",
+        );
+      },
+    );
+    const malformed = await runSqlStatementParser(
+      malformedParser,
+      request,
+    );
+    expect(malformed.analysis).toMatchObject({
+      message: "SQL parser returned malformed normalized output",
+      reason: "malformed-output",
+      retryable: false,
+      status: "failed",
+    });
+  });
+});

--- a/src/vnext/__tests__/syntax.test.ts
+++ b/src/vnext/__tests__/syntax.test.ts
@@ -746,7 +746,7 @@ describe("lexical eligibility states", () => {
 });
 
 describe("parser request boundary", () => {
-  it("runs an authentic parser with exact text and cancellation", async () => {
+  it("runs an authentic parser with exact text and signal", async () => {
     const authority = createParserAuthority();
     const controller = new AbortController();
     const expected = createUnsupportedParserAnalysis(
@@ -774,6 +774,33 @@ describe("parser request boundary", () => {
     expect(Object.isFrozen(parser)).toBe(true);
     const result = await runSqlStatementParser(parser, request);
     expect(result.state).toBe("analyzed");
+    expect(result.analysis).toBe(expected);
+  });
+
+  it("passes an already-aborted signal to the parser callback", async () => {
+    const authority = createParserAuthority();
+    const controller = new AbortController();
+    const reason = new Error("superseded");
+    controller.abort(reason);
+    const expected = createUnsupportedParserAnalysis(
+      "backend-capability",
+      "SELECT 1",
+      authority.authority,
+    );
+    const parser = createSqlStatementParser(
+      authority.authority,
+      async (request) => {
+        expect(request.signal).toBe(controller.signal);
+        expect(request.signal.aborted).toBe(true);
+        expect(request.signal.reason).toBe(reason);
+        return expected;
+      },
+    );
+
+    const result = await runSqlStatementParser(
+      parser,
+      createSqlStatementParseRequest("SELECT 1", controller.signal),
+    );
     expect(result.analysis).toBe(expected);
   });
 

--- a/src/vnext/syntax.ts
+++ b/src/vnext/syntax.ts
@@ -1,0 +1,1168 @@
+import type {
+  SqlOpaqueBoundaryReason,
+  SqlUnterminatedConstruct,
+} from "./statement-index.js";
+
+const statementRangeBrand: unique symbol = Symbol(
+  "SqlStatementRelativeRange",
+);
+const syntaxArtifactBrand: unique symbol = Symbol("SqlSyntaxArtifact");
+const parserDiagnosticBrand: unique symbol = Symbol(
+  "SqlParserDiagnostic",
+);
+const parserAnalysisBrand: unique symbol = Symbol("SqlParserAnalysis");
+const syntaxStateBrand: unique symbol = Symbol(
+  "SqlStatementSyntaxState",
+);
+const parserRequestBrand: unique symbol = Symbol(
+  "SqlStatementParseRequest",
+);
+const statementParserBrand: unique symbol = Symbol(
+  "SqlStatementParser",
+);
+const backendIdentityBrand: unique symbol = Symbol(
+  "SqlSyntaxBackendIdentity",
+);
+const configurationIdentityBrand: unique symbol = Symbol(
+  "SqlSyntaxConfigurationIdentity",
+);
+const dialectIdentityBrand: unique symbol = Symbol(
+  "SqlDialectSyntaxIdentity",
+);
+const conformanceIdentityBrand: unique symbol = Symbol(
+  "SqlConformanceIdentity",
+);
+const parserAuthorityBrand: unique symbol = Symbol(
+  "SqlParserAuthority",
+);
+
+export const MAX_SQL_SYNTAX_DIAGNOSTICS = 64;
+export const MAX_SQL_SYNTAX_MESSAGE_LENGTH = 2_048;
+export const MAX_SQL_SYNTAX_MESSAGE_INPUT_LENGTH = 8_192;
+export const MAX_SQL_STATEMENT_PARSE_LENGTH = 1024 * 1024;
+export const MAX_SQL_COMPATIBILITY_LIMITATIONS = 3;
+
+const statementRanges = new WeakSet<object>();
+const syntaxArtifacts = new WeakSet<object>();
+const parserDiagnostics = new WeakSet<object>();
+const parserAnalyses = new WeakSet<object>();
+const statementSyntaxStates = new WeakSet<object>();
+const parserRequests = new WeakSet<object>();
+const statementParsers = new WeakSet<object>();
+const backendIdentities = new WeakSet<object>();
+const configurationIdentities = new WeakSet<object>();
+const dialectIdentities = new WeakSet<object>();
+const conformanceIdentities = new WeakSet<object>();
+const parserAuthorities = new WeakSet<object>();
+const conformanceAuthorities = new WeakMap<
+  SqlConformanceIdentity,
+  SqlParserAuthority
+>();
+const artifactSources = new WeakMap<SqlSyntaxArtifact, string>();
+const artifactAuthorities = new WeakMap<
+  SqlSyntaxArtifact,
+  SqlParserAuthority
+>();
+const diagnosticSources = new WeakMap<
+  SqlParserDiagnostic,
+  string
+>();
+const diagnosticAuthorities = new WeakMap<
+  SqlParserDiagnostic,
+  SqlParserAuthority
+>();
+const analysisSources = new WeakMap<
+  SqlParserAnalysis,
+  string
+>();
+const analysisAuthorities = new WeakMap<
+  SqlParserAnalysis,
+  SqlParserAuthority
+>();
+const parserCallbacks = new WeakMap<
+  SqlStatementParser,
+  SqlStatementParserCallback
+>();
+
+export type SqlSyntaxContractErrorCode =
+  | "invalid-analysis"
+  | "invalid-artifact"
+  | "invalid-diagnostic"
+  | "invalid-identity"
+  | "invalid-range"
+  | "invalid-request";
+
+export class SqlSyntaxContractError extends Error {
+  readonly code: SqlSyntaxContractErrorCode;
+
+  constructor(code: SqlSyntaxContractErrorCode, message: string) {
+    super(message);
+    this.name = "SqlSyntaxContractError";
+    this.code = code;
+  }
+}
+
+export interface SqlStatementRelativeRange {
+  readonly [statementRangeBrand]: "SqlStatementRelativeRange";
+  readonly from: number;
+  readonly to: number;
+}
+
+function requireStatementLength(
+  value: unknown,
+  code: SqlSyntaxContractErrorCode,
+): number {
+  if (!Number.isSafeInteger(value) || Number(value) < 0) {
+    throw new SqlSyntaxContractError(
+      code,
+      "SQL statement length must be a non-negative safe integer",
+    );
+  }
+  return Number(value);
+}
+
+function requireStatementText(
+  value: unknown,
+  code: SqlSyntaxContractErrorCode,
+): string {
+  if (typeof value !== "string") {
+    throw new SqlSyntaxContractError(
+      code,
+      "SQL statement text must be a string",
+    );
+  }
+  if (value.length > MAX_SQL_STATEMENT_PARSE_LENGTH) {
+    throw new SqlSyntaxContractError(
+      code,
+      "SQL statement text exceeds the parser input limit",
+    );
+  }
+  return value;
+}
+
+export function createSqlStatementRelativeRange(
+  from: unknown,
+  to: unknown,
+  statementLength: unknown,
+): SqlStatementRelativeRange {
+  const length = requireStatementLength(statementLength, "invalid-range");
+  if (
+    !Number.isSafeInteger(from) ||
+    !Number.isSafeInteger(to) ||
+    Number(from) < 0 ||
+    Number(from) > Number(to) ||
+    Number(to) > length
+  ) {
+    throw new SqlSyntaxContractError(
+      "invalid-range",
+      "SQL statement range must be an in-bounds half-open UTF-16 range",
+    );
+  }
+  const range: SqlStatementRelativeRange = {
+    [statementRangeBrand]: "SqlStatementRelativeRange",
+    from: Number(from),
+    to: Number(to),
+  };
+  Object.freeze(range);
+  statementRanges.add(range);
+  return range;
+}
+
+function isAuthenticStatementRange(
+  value: unknown,
+): value is SqlStatementRelativeRange {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    statementRanges.has(value)
+  );
+}
+
+function requireStatementRange(
+  range: unknown,
+  statementLength: number,
+  code: SqlSyntaxContractErrorCode,
+): SqlStatementRelativeRange {
+  if (!isAuthenticStatementRange(range)) {
+    throw new SqlSyntaxContractError(
+      code,
+      "SQL statement range must be created by this syntax contract",
+    );
+  }
+  if (range.to > statementLength) {
+    throw new SqlSyntaxContractError(
+      code,
+      "SQL statement range exceeds the current statement",
+    );
+  }
+  return range;
+}
+
+export interface SqlSyntaxBackendIdentity {
+  readonly [backendIdentityBrand]: "SqlSyntaxBackendIdentity";
+}
+
+export interface SqlSyntaxConfigurationIdentity {
+  readonly [configurationIdentityBrand]: "SqlSyntaxConfigurationIdentity";
+}
+
+export interface SqlDialectSyntaxIdentity {
+  readonly [dialectIdentityBrand]: "SqlDialectSyntaxIdentity";
+}
+
+export interface SqlConformanceIdentity {
+  readonly [conformanceIdentityBrand]: "SqlConformanceIdentity";
+}
+
+export interface SqlParserAuthority {
+  readonly [parserAuthorityBrand]: "SqlParserAuthority";
+  readonly backendIdentity: SqlSyntaxBackendIdentity;
+  readonly configurationIdentity: SqlSyntaxConfigurationIdentity;
+  readonly dialectIdentity: SqlDialectSyntaxIdentity;
+}
+
+export function createSqlSyntaxBackendIdentity(): SqlSyntaxBackendIdentity {
+  const identity: SqlSyntaxBackendIdentity = {
+    [backendIdentityBrand]: "SqlSyntaxBackendIdentity",
+  };
+  Object.freeze(identity);
+  backendIdentities.add(identity);
+  return identity;
+}
+
+export function createSqlSyntaxConfigurationIdentity(): SqlSyntaxConfigurationIdentity {
+  const identity: SqlSyntaxConfigurationIdentity = {
+    [configurationIdentityBrand]: "SqlSyntaxConfigurationIdentity",
+  };
+  Object.freeze(identity);
+  configurationIdentities.add(identity);
+  return identity;
+}
+
+export function createSqlDialectSyntaxIdentity(): SqlDialectSyntaxIdentity {
+  const identity: SqlDialectSyntaxIdentity = {
+    [dialectIdentityBrand]: "SqlDialectSyntaxIdentity",
+  };
+  Object.freeze(identity);
+  dialectIdentities.add(identity);
+  return identity;
+}
+
+export function createSqlParserAuthority(
+  backendIdentity: SqlSyntaxBackendIdentity,
+  configurationIdentity: SqlSyntaxConfigurationIdentity,
+  dialectIdentity: SqlDialectSyntaxIdentity,
+): SqlParserAuthority {
+  requireIdentity(backendIdentity, backendIdentities);
+  requireIdentity(configurationIdentity, configurationIdentities);
+  requireIdentity(dialectIdentity, dialectIdentities);
+  const authority: SqlParserAuthority = {
+    [parserAuthorityBrand]: "SqlParserAuthority",
+    backendIdentity,
+    configurationIdentity,
+    dialectIdentity,
+  };
+  Object.freeze(authority);
+  parserAuthorities.add(authority);
+  return authority;
+}
+
+export function createSqlConformanceIdentity(
+  authority: SqlParserAuthority,
+): SqlConformanceIdentity {
+  requireIdentity(authority, parserAuthorities);
+  const identity: SqlConformanceIdentity = {
+    [conformanceIdentityBrand]: "SqlConformanceIdentity",
+  };
+  Object.freeze(identity);
+  conformanceIdentities.add(identity);
+  conformanceAuthorities.set(identity, authority);
+  return identity;
+}
+
+function requireIdentity(
+  identity: object,
+  identities: WeakSet<object>,
+): void {
+  if (!identities.has(identity)) {
+    throw new SqlSyntaxContractError(
+      "invalid-identity",
+      "SQL syntax identity must be created by this syntax contract",
+    );
+  }
+}
+
+export type SqlStatementKind =
+  | "alter"
+  | "create"
+  | "delete"
+  | "drop"
+  | "insert"
+  | "merge"
+  | "other"
+  | "query"
+  | "transaction"
+  | "update";
+
+function isStatementKind(value: unknown): value is SqlStatementKind {
+  switch (value) {
+    case "alter":
+    case "create":
+    case "delete":
+    case "drop":
+    case "insert":
+    case "merge":
+    case "other":
+    case "query":
+    case "transaction":
+    case "update":
+      return true;
+    default:
+      return false;
+  }
+}
+
+export interface SqlSyntaxArtifact {
+  readonly [syntaxArtifactBrand]: "SqlSyntaxArtifact";
+  readonly kind: SqlStatementKind;
+  readonly range: SqlStatementRelativeRange;
+}
+
+export function createSqlSyntaxArtifact(
+  kind: unknown,
+  statementText: unknown,
+  authority: SqlParserAuthority,
+): SqlSyntaxArtifact {
+  requireIdentity(authority, parserAuthorities);
+  const text = requireStatementText(
+    statementText,
+    "invalid-artifact",
+  );
+  if (!isStatementKind(kind)) {
+    throw new SqlSyntaxContractError(
+      "invalid-artifact",
+      "SQL statement kind is not supported by the syntax contract",
+    );
+  }
+  const artifact: SqlSyntaxArtifact = {
+    [syntaxArtifactBrand]: "SqlSyntaxArtifact",
+    kind,
+    range: createSqlStatementRelativeRange(
+      0,
+      text.length,
+      text.length,
+    ),
+  };
+  Object.freeze(artifact);
+  syntaxArtifacts.add(artifact);
+  artifactSources.set(artifact, text);
+  artifactAuthorities.set(artifact, authority);
+  return artifact;
+}
+
+interface SqlArtifactMetadata {
+  readonly authority: SqlParserAuthority;
+  readonly source: string;
+}
+
+function requireSyntaxArtifact(
+  artifact: SqlSyntaxArtifact,
+): SqlArtifactMetadata {
+  const source = artifactSources.get(artifact);
+  const authority = artifactAuthorities.get(artifact);
+  if (
+    !syntaxArtifacts.has(artifact) ||
+    source === undefined ||
+    authority === undefined
+  ) {
+    throw new SqlSyntaxContractError(
+      "invalid-artifact",
+      "SQL syntax artifact must be created by this syntax contract",
+    );
+  }
+  return { authority, source };
+}
+
+export type SqlParserLocation =
+  | {
+      readonly availability: "exact";
+      readonly range: SqlStatementRelativeRange;
+    }
+  | {
+      readonly availability: "unavailable";
+      readonly reason: "not-reported";
+    };
+
+const LOCATION_NOT_REPORTED: Extract<
+  SqlParserLocation,
+  { readonly availability: "unavailable" }
+> = Object.freeze({
+  availability: "unavailable",
+  reason: "not-reported",
+});
+
+export interface SqlParserDiagnostic {
+  readonly [parserDiagnosticBrand]: "SqlParserDiagnostic";
+  readonly code: "syntax-error";
+  readonly location: SqlParserLocation;
+  readonly message: string;
+  readonly severity: "error";
+}
+
+function normalizeMessage(
+  value: unknown,
+  code: SqlSyntaxContractErrorCode,
+): string {
+  if (typeof value !== "string") {
+    throw new SqlSyntaxContractError(
+      code,
+      "SQL syntax message must be a string",
+    );
+  }
+  if (value.length > MAX_SQL_SYNTAX_MESSAGE_INPUT_LENGTH) {
+    throw new SqlSyntaxContractError(
+      code,
+      "SQL syntax message exceeds the contract input limit",
+    );
+  }
+  const message = value.trim();
+  if (message.length === 0) {
+    throw new SqlSyntaxContractError(
+      code,
+      "SQL syntax message cannot be empty",
+    );
+  }
+  return message.slice(0, MAX_SQL_SYNTAX_MESSAGE_LENGTH);
+}
+
+export function createSqlParserDiagnostic(
+  message: unknown,
+  location: unknown,
+  statementText: unknown,
+  authority: SqlParserAuthority,
+): SqlParserDiagnostic {
+  requireIdentity(authority, parserAuthorities);
+  const text = requireStatementText(
+    statementText,
+    "invalid-diagnostic",
+  );
+  const normalizedLocation: SqlParserLocation =
+    location === null
+      ? LOCATION_NOT_REPORTED
+      : Object.freeze({
+        availability: "exact",
+        range: requireStatementRange(
+          location,
+          text.length,
+          "invalid-diagnostic",
+        ),
+      });
+  const diagnostic: SqlParserDiagnostic = {
+    [parserDiagnosticBrand]: "SqlParserDiagnostic",
+    code: "syntax-error",
+    location: normalizedLocation,
+    message: normalizeMessage(message, "invalid-diagnostic"),
+    severity: "error",
+  };
+  Object.freeze(diagnostic);
+  parserDiagnostics.add(diagnostic);
+  diagnosticSources.set(diagnostic, text);
+  diagnosticAuthorities.set(diagnostic, authority);
+  return diagnostic;
+}
+
+function copyDiagnostics(
+  diagnostics: readonly SqlParserDiagnostic[],
+  requireNonEmpty: boolean,
+): readonly SqlParserDiagnostic[] {
+  const count = Array.isArray(diagnostics)
+    ? diagnostics.length
+    : -1;
+  if (
+    count < 0 ||
+    count > MAX_SQL_SYNTAX_DIAGNOSTICS ||
+    (requireNonEmpty && count === 0)
+  ) {
+    throw new SqlSyntaxContractError(
+      "invalid-analysis",
+      requireNonEmpty
+        ? "SQL invalid analysis requires bounded non-empty diagnostics"
+        : "SQL syntax diagnostics exceed the contract limit",
+    );
+  }
+  const copy: SqlParserDiagnostic[] = [];
+  for (let index = 0; index < count; index += 1) {
+    const diagnostic = diagnostics[index];
+    if (
+      diagnostic === undefined ||
+      !parserDiagnostics.has(diagnostic)
+    ) {
+      throw new SqlSyntaxContractError(
+        "invalid-analysis",
+        "SQL parser diagnostic must be created by this syntax contract",
+      );
+    }
+    copy.push(diagnostic);
+  }
+  return Object.freeze(copy);
+}
+
+export type SqlCompatibilityLimitation =
+  | "dialect-compatibility"
+  | "partial-artifact"
+  | "recovered";
+
+export type SqlParserUnsupportedReason =
+  | "backend-capability"
+  | "compatibility-rejected"
+  | "resource-limit"
+  | "uncovered-construct";
+
+export type SqlParserFailureReason =
+  | "backend-failure"
+  | "malformed-output";
+
+interface SqlParserAnalysisIdentity {
+  readonly [parserAnalysisBrand]: "SqlParserAnalysis";
+}
+
+export type SqlParserAnalysis = SqlParserAnalysisIdentity &
+  (
+    | {
+      readonly status: "parsed";
+      readonly mode: "direct";
+      readonly conformance: SqlConformanceIdentity;
+      readonly artifact: SqlSyntaxArtifact;
+    }
+    | {
+      readonly status: "parsed";
+      readonly mode: "compatibility";
+      readonly artifact: SqlSyntaxArtifact;
+      readonly limitations: readonly [
+        SqlCompatibilityLimitation,
+        ...SqlCompatibilityLimitation[],
+      ];
+    }
+    | {
+      readonly status: "invalid";
+      readonly conformance: SqlConformanceIdentity;
+      readonly diagnostics: readonly [
+        SqlParserDiagnostic,
+        ...SqlParserDiagnostic[],
+      ];
+    }
+    | {
+      readonly status: "unsupported";
+      readonly reason: SqlParserUnsupportedReason;
+    }
+    | {
+      readonly status: "failed";
+      readonly reason: SqlParserFailureReason;
+      readonly message: string;
+      readonly retryable: boolean;
+    }
+  );
+
+function recordAnalysis<Analysis extends SqlParserAnalysis>(
+  analysis: Analysis,
+  source: string,
+  authority: SqlParserAuthority,
+): Analysis {
+  Object.freeze(analysis);
+  parserAnalyses.add(analysis);
+  analysisSources.set(analysis, source);
+  analysisAuthorities.set(analysis, authority);
+  return analysis;
+}
+
+export function createDirectParsedAnalysis(
+  conformance: SqlConformanceIdentity,
+  artifact: SqlSyntaxArtifact,
+): Extract<
+  SqlParserAnalysis,
+  { readonly mode: "direct"; readonly status: "parsed" }
+> {
+  requireIdentity(conformance, conformanceIdentities);
+  const metadata = requireSyntaxArtifact(artifact);
+  if (conformanceAuthorities.get(conformance) !== metadata.authority) {
+    throw new SqlSyntaxContractError(
+      "invalid-analysis",
+      "SQL conformance and artifact authority must match",
+    );
+  }
+  return recordAnalysis(
+    {
+      [parserAnalysisBrand]: "SqlParserAnalysis",
+      artifact,
+      conformance,
+      mode: "direct",
+      status: "parsed",
+    },
+    metadata.source,
+    metadata.authority,
+  );
+}
+
+export function createCompatibilityParsedAnalysis(
+  artifact: SqlSyntaxArtifact,
+  limitations: readonly SqlCompatibilityLimitation[],
+): Extract<
+  SqlParserAnalysis,
+  { readonly mode: "compatibility"; readonly status: "parsed" }
+> {
+  const metadata = requireSyntaxArtifact(artifact);
+  if (
+    !Array.isArray(limitations) ||
+    limitations.length === 0 ||
+    limitations.length > MAX_SQL_COMPATIBILITY_LIMITATIONS
+  ) {
+    throw new SqlSyntaxContractError(
+      "invalid-analysis",
+      "SQL compatibility analysis requires bounded non-empty limitations",
+    );
+  }
+  const copy: SqlCompatibilityLimitation[] = [];
+  const seen = new Set<SqlCompatibilityLimitation>();
+  const limitationCount = limitations.length;
+  for (let index = 0; index < limitationCount; index += 1) {
+    const limitation = limitations[index];
+    if (
+      limitation !== "dialect-compatibility" &&
+      limitation !== "partial-artifact" &&
+      limitation !== "recovered"
+    ) {
+      throw new SqlSyntaxContractError(
+        "invalid-analysis",
+        "SQL compatibility limitation is invalid",
+      );
+    }
+    if (seen.has(limitation)) {
+      throw new SqlSyntaxContractError(
+        "invalid-analysis",
+        "SQL compatibility limitations cannot contain duplicates",
+      );
+    }
+    seen.add(limitation);
+    copy.push(limitation);
+  }
+  const first = copy[0];
+  if (first === undefined) {
+    throw new SqlSyntaxContractError(
+      "invalid-analysis",
+      "SQL compatibility analysis requires at least one limitation",
+    );
+  }
+  const nonEmpty: [
+    SqlCompatibilityLimitation,
+    ...SqlCompatibilityLimitation[],
+  ] = [first, ...copy.slice(1)];
+  return recordAnalysis(
+    {
+      [parserAnalysisBrand]: "SqlParserAnalysis",
+      artifact,
+      limitations: Object.freeze(nonEmpty),
+      mode: "compatibility",
+      status: "parsed",
+    },
+    metadata.source,
+    metadata.authority,
+  );
+}
+
+export function createInvalidParserAnalysis(
+  conformance: SqlConformanceIdentity,
+  diagnostics: readonly SqlParserDiagnostic[],
+): Extract<SqlParserAnalysis, { readonly status: "invalid" }> {
+  requireIdentity(conformance, conformanceIdentities);
+  const copy = copyDiagnostics(diagnostics, true);
+  const first = copy[0];
+  if (first === undefined) {
+    throw new SqlSyntaxContractError(
+      "invalid-analysis",
+      "SQL invalid analysis requires at least one diagnostic",
+    );
+  }
+  const source = diagnosticSources.get(first);
+  const authority = diagnosticAuthorities.get(first);
+  if (source === undefined || authority === undefined) {
+    throw new SqlSyntaxContractError(
+      "invalid-analysis",
+      "SQL parser diagnostic is missing statement metadata",
+    );
+  }
+  for (const diagnostic of copy) {
+    if (diagnosticSources.get(diagnostic) !== source) {
+      throw new SqlSyntaxContractError(
+        "invalid-analysis",
+        "SQL parser diagnostics must describe the same statement text",
+      );
+    }
+    if (diagnosticAuthorities.get(diagnostic) !== authority) {
+      throw new SqlSyntaxContractError(
+        "invalid-analysis",
+        "SQL parser diagnostics must share parser authority",
+      );
+    }
+  }
+  if (conformanceAuthorities.get(conformance) !== authority) {
+    throw new SqlSyntaxContractError(
+      "invalid-analysis",
+      "SQL conformance and diagnostic authority must match",
+    );
+  }
+  const nonEmpty: [
+    SqlParserDiagnostic,
+    ...SqlParserDiagnostic[],
+  ] = [first, ...copy.slice(1)];
+  return recordAnalysis(
+    {
+      [parserAnalysisBrand]: "SqlParserAnalysis",
+      conformance,
+      diagnostics: Object.freeze(nonEmpty),
+      status: "invalid",
+    },
+    source,
+    authority,
+  );
+}
+
+export function createUnsupportedParserAnalysis(
+  reason: SqlParserUnsupportedReason,
+  statementText: unknown,
+  authority: SqlParserAuthority,
+): Extract<SqlParserAnalysis, { readonly status: "unsupported" }> {
+  requireIdentity(authority, parserAuthorities);
+  const source = requireStatementText(
+    statementText,
+    "invalid-analysis",
+  );
+  if (
+    reason !== "backend-capability" &&
+    reason !== "compatibility-rejected" &&
+    reason !== "resource-limit" &&
+    reason !== "uncovered-construct"
+  ) {
+    throw new SqlSyntaxContractError(
+      "invalid-analysis",
+      "SQL parser unsupported reason is invalid",
+    );
+  }
+  return recordAnalysis(
+    {
+      [parserAnalysisBrand]: "SqlParserAnalysis",
+      reason,
+      status: "unsupported",
+    },
+    source,
+    authority,
+  );
+}
+
+export function createFailedParserAnalysis(
+  reason: SqlParserFailureReason,
+  message: unknown,
+  retryable: unknown,
+  statementText: unknown,
+  authority: SqlParserAuthority,
+): Extract<SqlParserAnalysis, { readonly status: "failed" }> {
+  requireIdentity(authority, parserAuthorities);
+  const source = requireStatementText(
+    statementText,
+    "invalid-analysis",
+  );
+  if (
+    reason !== "backend-failure" &&
+    reason !== "malformed-output"
+  ) {
+    throw new SqlSyntaxContractError(
+      "invalid-analysis",
+      "SQL parser failure reason is invalid",
+    );
+  }
+  if (typeof retryable !== "boolean") {
+    throw new SqlSyntaxContractError(
+      "invalid-analysis",
+      "SQL parser failure retryability must be a boolean",
+    );
+  }
+  return recordAnalysis(
+    {
+      [parserAnalysisBrand]: "SqlParserAnalysis",
+      message: normalizeMessage(message, "invalid-analysis"),
+      reason,
+      retryable,
+      status: "failed",
+    },
+    source,
+    authority,
+  );
+}
+
+export type SqlSyntaxUnavailableReason =
+  | "dialect-not-supported"
+  | "parser-not-configured";
+
+interface SqlStatementSyntaxStateIdentity {
+  readonly [syntaxStateBrand]: "SqlStatementSyntaxState";
+}
+
+export type SqlStatementSyntaxState = SqlStatementSyntaxStateIdentity &
+  (
+    | {
+      readonly state: "empty";
+    }
+    | {
+      readonly state: "incomplete";
+      readonly construct: SqlUnterminatedConstruct;
+      readonly opening: SqlStatementRelativeRange;
+    }
+    | {
+      readonly state: "opaque";
+      readonly at: SqlStatementRelativeRange;
+      readonly reason: SqlOpaqueBoundaryReason;
+    }
+    | {
+      readonly state: "unavailable";
+      readonly reason: SqlSyntaxUnavailableReason;
+    }
+    | {
+      readonly state: "analyzed";
+      readonly analysis: SqlParserAnalysis;
+    }
+  );
+
+function recordSyntaxState<State extends SqlStatementSyntaxState>(
+  state: State,
+): State {
+  Object.freeze(state);
+  statementSyntaxStates.add(state);
+  return state;
+}
+
+function isUnterminatedConstruct(
+  value: unknown,
+): value is SqlUnterminatedConstruct {
+  switch (value) {
+    case "backtick-quoted-identifier":
+    case "block-comment":
+    case "dollar-quoted-string":
+    case "double-quoted-identifier":
+    case "double-quoted-string":
+    case "single-quoted-string":
+    case "triple-double-quoted-string":
+    case "triple-single-quoted-string":
+      return true;
+    default:
+      return false;
+  }
+}
+
+function isOpaqueBoundaryReason(
+  value: unknown,
+): value is SqlOpaqueBoundaryReason {
+  return (
+    value === "custom-delimiter" ||
+    value === "procedural-block" ||
+    value === "resource-limit"
+  );
+}
+
+export function createEmptySyntaxState(): Extract<
+  SqlStatementSyntaxState,
+  { readonly state: "empty" }
+> {
+  return recordSyntaxState({
+    [syntaxStateBrand]: "SqlStatementSyntaxState",
+    state: "empty",
+  });
+}
+
+export function createIncompleteSyntaxState(
+  construct: unknown,
+  opening: SqlStatementRelativeRange,
+  statementLength: unknown,
+): Extract<
+  SqlStatementSyntaxState,
+  { readonly state: "incomplete" }
+> {
+  const length = requireStatementLength(
+    statementLength,
+    "invalid-analysis",
+  );
+  if (!isUnterminatedConstruct(construct)) {
+    throw new SqlSyntaxContractError(
+      "invalid-analysis",
+      "SQL incomplete construct is invalid",
+    );
+  }
+  return recordSyntaxState({
+    [syntaxStateBrand]: "SqlStatementSyntaxState",
+    construct,
+    opening: requireStatementRange(
+      opening,
+      length,
+      "invalid-analysis",
+    ),
+    state: "incomplete",
+  });
+}
+
+export function createOpaqueSyntaxState(
+  reason: unknown,
+  at: SqlStatementRelativeRange,
+  statementLength: unknown,
+): Extract<
+  SqlStatementSyntaxState,
+  { readonly state: "opaque" }
+> {
+  const length = requireStatementLength(
+    statementLength,
+    "invalid-analysis",
+  );
+  if (!isOpaqueBoundaryReason(reason)) {
+    throw new SqlSyntaxContractError(
+      "invalid-analysis",
+      "SQL opaque boundary reason is invalid",
+    );
+  }
+  return recordSyntaxState({
+    [syntaxStateBrand]: "SqlStatementSyntaxState",
+    at: requireStatementRange(at, length, "invalid-analysis"),
+    reason,
+    state: "opaque",
+  });
+}
+
+export function createUnavailableSyntaxState(
+  reason: unknown,
+): Extract<
+  SqlStatementSyntaxState,
+  { readonly state: "unavailable" }
+> {
+  if (
+    reason !== "dialect-not-supported" &&
+    reason !== "parser-not-configured"
+  ) {
+    throw new SqlSyntaxContractError(
+      "invalid-analysis",
+      "SQL syntax unavailability reason is invalid",
+    );
+  }
+  return recordSyntaxState({
+    [syntaxStateBrand]: "SqlStatementSyntaxState",
+    reason,
+    state: "unavailable",
+  });
+}
+
+function createAnalyzedSyntaxState(
+  analysis: SqlParserAnalysis,
+): Extract<
+  SqlStatementSyntaxState,
+  { readonly state: "analyzed" }
+> {
+  if (!parserAnalyses.has(analysis)) {
+    throw new SqlSyntaxContractError(
+      "invalid-analysis",
+      "SQL parser analysis must be created by this syntax contract",
+    );
+  }
+  return recordSyntaxState({
+    [syntaxStateBrand]: "SqlStatementSyntaxState",
+    analysis,
+    state: "analyzed",
+  });
+}
+
+export function isSqlStatementSyntaxState(
+  value: unknown,
+): value is SqlStatementSyntaxState {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    statementSyntaxStates.has(value)
+  );
+}
+
+export interface SqlStatementParseRequest {
+  readonly [parserRequestBrand]: "SqlStatementParseRequest";
+  readonly text: string;
+  readonly signal: AbortSignal;
+}
+
+export interface SqlStatementParser {
+  readonly [statementParserBrand]: "SqlStatementParser";
+  readonly authority: SqlParserAuthority;
+}
+
+export type SqlStatementParserCallback = (
+  request: SqlStatementParseRequest,
+) => Promise<SqlParserAnalysis>;
+
+function isAbortSignal(value: unknown): value is AbortSignal {
+  if (value === null || typeof value !== "object") {
+    return false;
+  }
+  try {
+    return (
+      "aborted" in value &&
+      typeof value.aborted === "boolean" &&
+      "reason" in value &&
+      "onabort" in value &&
+      (value.onabort === null ||
+        typeof value.onabort === "function") &&
+      "addEventListener" in value &&
+      typeof value.addEventListener === "function" &&
+      "removeEventListener" in value &&
+      typeof value.removeEventListener === "function" &&
+      "dispatchEvent" in value &&
+      typeof value.dispatchEvent === "function" &&
+      "throwIfAborted" in value &&
+      typeof value.throwIfAborted === "function"
+    );
+  } catch {
+    return false;
+  }
+}
+
+export function createSqlStatementParseRequest(
+  text: unknown,
+  signal: unknown,
+): SqlStatementParseRequest {
+  const statementText = requireStatementText(text, "invalid-request");
+  if (!isAbortSignal(signal)) {
+    throw new SqlSyntaxContractError(
+      "invalid-request",
+      "SQL statement parser signal must satisfy the AbortSignal contract",
+    );
+  }
+  const request: SqlStatementParseRequest = {
+    [parserRequestBrand]: "SqlStatementParseRequest",
+    signal,
+    text: statementText,
+  };
+  Object.freeze(request);
+  parserRequests.add(request);
+  return request;
+}
+
+export function createSqlStatementParser(
+  authority: SqlParserAuthority,
+  parseStatement: SqlStatementParserCallback,
+): SqlStatementParser {
+  requireIdentity(authority, parserAuthorities);
+  if (typeof parseStatement !== "function") {
+    throw new SqlSyntaxContractError(
+      "invalid-request",
+      "SQL statement parser requires a parse function",
+    );
+  }
+  const parser: SqlStatementParser = {
+    [statementParserBrand]: "SqlStatementParser",
+    authority,
+  };
+  Object.freeze(parser);
+  statementParsers.add(parser);
+  parserCallbacks.set(parser, parseStatement);
+  return parser;
+}
+
+function conformanceMatchesParser(
+  conformance: SqlConformanceIdentity,
+  parser: SqlStatementParser,
+): boolean {
+  return conformanceAuthorities.get(conformance) === parser.authority;
+}
+
+function malformedParserOutput(
+  statementText: string,
+  authority: SqlParserAuthority,
+): Extract<
+  SqlParserAnalysis,
+  { readonly status: "failed" }
+> {
+  return createFailedParserAnalysis(
+    "malformed-output",
+    "SQL parser returned malformed normalized output",
+    false,
+    statementText,
+    authority,
+  );
+}
+
+export async function runSqlStatementParser(
+  parser: SqlStatementParser,
+  request: SqlStatementParseRequest,
+): Promise<
+  Extract<SqlStatementSyntaxState, { readonly state: "analyzed" }>
+> {
+  if (!statementParsers.has(parser) || !parserRequests.has(request)) {
+    throw new SqlSyntaxContractError(
+      "invalid-request",
+      "SQL parser and request must be created by this syntax contract",
+    );
+  }
+  const callback = parserCallbacks.get(parser);
+  if (callback === undefined) {
+    throw new SqlSyntaxContractError(
+      "invalid-request",
+      "SQL statement parser callback is unavailable",
+    );
+  }
+
+  let analysis: unknown;
+  try {
+    analysis = await callback(request);
+  } catch (error: unknown) {
+    if (error instanceof SqlSyntaxContractError) {
+      return createAnalyzedSyntaxState(
+        malformedParserOutput(request.text, parser.authority),
+      );
+    }
+    return createAnalyzedSyntaxState(
+      createFailedParserAnalysis(
+        "backend-failure",
+        "SQL parser backend failed",
+        true,
+        request.text,
+        parser.authority,
+      ),
+    );
+  }
+  if (!isSqlParserAnalysis(analysis)) {
+    return createAnalyzedSyntaxState(
+      malformedParserOutput(request.text, parser.authority),
+    );
+  }
+
+  const source = analysisSources.get(analysis);
+  if (
+    source === undefined ||
+    source !== request.text ||
+    analysisAuthorities.get(analysis) !== parser.authority
+  ) {
+    return createAnalyzedSyntaxState(
+      malformedParserOutput(request.text, parser.authority),
+    );
+  }
+  if (
+    (analysis.status === "invalid" ||
+      (analysis.status === "parsed" && analysis.mode === "direct")) &&
+    !conformanceMatchesParser(analysis.conformance, parser)
+  ) {
+    return createAnalyzedSyntaxState(
+      malformedParserOutput(request.text, parser.authority),
+    );
+  }
+  return createAnalyzedSyntaxState(analysis);
+}
+
+export function isSqlParserAnalysis(
+  value: unknown,
+): value is SqlParserAnalysis {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    parserAnalyses.has(value)
+  );
+}

--- a/src/vnext/syntax.ts
+++ b/src/vnext/syntax.ts
@@ -1005,6 +1005,8 @@ function isAbortSignal(value: unknown): value is AbortSignal {
   }
   try {
     return (
+      Object.prototype.toString.call(value) ===
+        "[object AbortSignal]" &&
       "aborted" in value &&
       typeof value.aborted === "boolean" &&
       "reason" in value &&
@@ -1023,6 +1025,14 @@ function isAbortSignal(value: unknown): value is AbortSignal {
   } catch {
     return false;
   }
+}
+
+function isAborted(signal: AbortSignal): boolean {
+  return signal.aborted;
+}
+
+function getAbortReason(signal: AbortSignal): unknown {
+  return signal.reason;
 }
 
 export function createSqlStatementParseRequest(
@@ -1090,6 +1100,83 @@ function malformedParserOutput(
   );
 }
 
+type SqlParserCallbackOutcome =
+  | {
+    readonly kind: "returned";
+    readonly analysis: unknown;
+  }
+  | {
+    readonly kind: "threw";
+    readonly error: unknown;
+  };
+
+const parserAbortMarker = Object.freeze({
+  kind: "SqlParserAbortMarker",
+});
+
+async function invokeParserCallback(
+  callback: SqlStatementParserCallback,
+  request: SqlStatementParseRequest,
+): Promise<SqlParserCallbackOutcome> {
+  const { signal } = request;
+  if (isAborted(signal)) {
+    throw getAbortReason(signal);
+  }
+
+  let abortObserved = false;
+  let abortReason: unknown;
+  let onAbort: (() => void) | undefined;
+  const abortOutcome = new Promise<typeof parserAbortMarker>((resolve) => {
+    onAbort = () => {
+      abortReason = getAbortReason(signal);
+      abortObserved = true;
+      resolve(parserAbortMarker);
+    };
+    signal.addEventListener("abort", onAbort, {
+      once: true,
+    });
+  });
+
+  try {
+    let callbackOutcome: Promise<SqlParserAnalysis>;
+    try {
+      callbackOutcome = callback(request);
+    } catch (error: unknown) {
+      if (abortObserved) {
+        throw abortReason;
+      }
+      return {
+        error,
+        kind: "threw",
+      };
+    }
+
+    let analysis: SqlParserAnalysis | typeof parserAbortMarker;
+    try {
+      analysis = await Promise.race([
+        abortOutcome,
+        callbackOutcome,
+      ]);
+    } catch (error: unknown) {
+      return {
+        error,
+        kind: "threw",
+      };
+    }
+    if (analysis === parserAbortMarker) {
+      throw abortReason;
+    }
+    return {
+      analysis,
+      kind: "returned",
+    };
+  } finally {
+    if (onAbort !== undefined) {
+      signal.removeEventListener("abort", onAbort);
+    }
+  }
+}
+
 export async function runSqlStatementParser(
   parser: SqlStatementParser,
   request: SqlStatementParseRequest,
@@ -1110,10 +1197,9 @@ export async function runSqlStatementParser(
     );
   }
 
-  let analysis: unknown;
-  try {
-    analysis = await callback(request);
-  } catch (error: unknown) {
+  const outcome = await invokeParserCallback(callback, request);
+  if (outcome.kind === "threw") {
+    const { error } = outcome;
     if (error instanceof SqlSyntaxContractError) {
       return createAnalyzedSyntaxState(
         malformedParserOutput(request.text, parser.authority),
@@ -1129,6 +1215,7 @@ export async function runSqlStatementParser(
       ),
     );
   }
+  const { analysis } = outcome;
   if (!isSqlParserAnalysis(analysis)) {
     return createAnalyzedSyntaxState(
       malformedParserOutput(request.text, parser.authority),

--- a/test/vnext-types/syntax.test-d.ts
+++ b/test/vnext-types/syntax.test-d.ts
@@ -1,0 +1,182 @@
+import type { SqlTextRange } from "../../src/vnext/index.js";
+import {
+  createCompatibilityParsedAnalysis,
+  createDirectParsedAnalysis,
+  createInvalidParserAnalysis,
+  createSqlConformanceIdentity,
+  createSqlParserAuthority,
+  createSqlParserDiagnostic,
+  createSqlStatementRelativeRange,
+  createSqlStatementParser,
+  createSqlStatementParseRequest,
+  createSqlSyntaxArtifact,
+  createSqlSyntaxBackendIdentity,
+  createSqlSyntaxConfigurationIdentity,
+  createSqlDialectSyntaxIdentity,
+  type SqlParserAnalysis,
+  runSqlStatementParser,
+  type SqlStatementParser,
+  type SqlStatementParseRequest,
+  type SqlStatementRelativeRange,
+  type SqlStatementSyntaxState,
+  type SqlSyntaxArtifact,
+} from "../../src/vnext/syntax.js";
+
+const range = createSqlStatementRelativeRange(0, 8, 8);
+const backendIdentity = createSqlSyntaxBackendIdentity();
+const configurationIdentity = createSqlSyntaxConfigurationIdentity();
+const dialectIdentity = createSqlDialectSyntaxIdentity();
+const authority = createSqlParserAuthority(
+  backendIdentity,
+  configurationIdentity,
+  dialectIdentity,
+);
+const conformance = createSqlConformanceIdentity(authority);
+const artifact = createSqlSyntaxArtifact(
+  "query",
+  "SELECT 1",
+  authority,
+);
+const diagnostic = createSqlParserDiagnostic(
+  "bad",
+  range,
+  "SELECT 1",
+  authority,
+);
+const direct = createDirectParsedAnalysis(conformance, artifact);
+const compatibility = createCompatibilityParsedAnalysis(artifact, [
+  "dialect-compatibility",
+]);
+const invalid = createInvalidParserAnalysis(conformance, [diagnostic]);
+
+function describeAnalysis(analysis: SqlParserAnalysis): string {
+  switch (analysis.status) {
+    case "parsed":
+      return analysis.mode === "direct"
+        ? analysis.conformance.toString()
+        : analysis.limitations.join(",");
+    case "invalid":
+      return analysis.diagnostics[0].message;
+    case "unsupported":
+      return analysis.reason;
+    case "failed":
+      return analysis.message;
+    default: {
+      const exhaustive: never = analysis;
+      return exhaustive;
+    }
+  }
+}
+
+function describeSyntaxState(state: SqlStatementSyntaxState): string {
+  switch (state.state) {
+    case "empty":
+      return "empty";
+    case "incomplete":
+      return state.construct;
+    case "opaque":
+      return state.reason;
+    case "unavailable":
+      return state.reason;
+    case "analyzed":
+      return describeAnalysis(state.analysis);
+    default: {
+      const exhaustive: never = state;
+      return exhaustive;
+    }
+  }
+}
+
+declare const publicRange: SqlTextRange;
+// @ts-expect-error absolute public ranges cannot become statement-relative
+const relativeRange: SqlStatementRelativeRange = publicRange;
+// @ts-expect-error statement-relative ranges require package construction
+const fabricatedRange: SqlStatementRelativeRange = { from: 0, to: 8 };
+// @ts-expect-error syntax artifacts require package construction
+const fabricatedArtifact: SqlSyntaxArtifact = { kind: "query", range };
+const impossibleDirect: SqlParserAnalysis = {
+  status: "parsed",
+  mode: "direct",
+  conformance,
+  artifact,
+  // @ts-expect-error direct parses cannot carry compatibility limitations
+  limitations: ["recovered"],
+};
+const impossibleCompatibility: SqlParserAnalysis = {
+  status: "parsed",
+  mode: "compatibility",
+  artifact,
+  limitations: ["recovered"],
+  // @ts-expect-error compatibility parses cannot claim direct conformance
+  conformance,
+};
+// @ts-expect-error invalid is authoritative and requires conformance
+const invalidWithoutConformance: SqlParserAnalysis = {
+  status: "invalid",
+  diagnostics: [diagnostic],
+};
+const invalidWithoutDiagnostics: SqlParserAnalysis = {
+  status: "invalid",
+  conformance,
+  // @ts-expect-error invalid requires at least one diagnostic
+  diagnostics: [],
+};
+const cancelledAnalysis: SqlParserAnalysis = {
+  // @ts-expect-error cancellation is request lifecycle, not parser analysis
+  status: "cancelled",
+  // @ts-expect-error cancellation reasons do not leak into parser failures
+  reason: "caller",
+};
+const incompleteAnalysis: SqlParserAnalysis = {
+  // @ts-expect-error lexical incompleteness is not a parser analysis
+  status: "incomplete",
+  construct: "single-quoted-string",
+};
+// @ts-expect-error raw ASTs are not exposed through normalized artifacts
+void artifact.ast;
+// @ts-expect-error backend payloads are private implementation data
+void artifact.payload;
+
+const parser = createSqlStatementParser(
+  authority,
+  async ({ signal, text }) => {
+    void signal;
+    void text;
+    return direct;
+  },
+);
+const typedParser: SqlStatementParser = parser;
+const request = createSqlStatementParseRequest(
+  "SELECT 1",
+  new AbortController().signal,
+);
+const typedRequest: SqlStatementParseRequest = request;
+void runSqlStatementParser(parser, request);
+
+// @ts-expect-error parsers require package construction
+const fabricatedParser: SqlStatementParser = {
+  authority,
+};
+// @ts-expect-error parser requests require package construction
+const fabricatedRequest: SqlStatementParseRequest = {
+  signal: new AbortController().signal,
+  text: "SELECT 1",
+};
+
+void cancelledAnalysis;
+void compatibility;
+void describeSyntaxState;
+void fabricatedArtifact;
+void fabricatedRange;
+void fabricatedParser;
+void fabricatedRequest;
+void impossibleCompatibility;
+void impossibleDirect;
+void incompleteAnalysis;
+void invalid;
+void invalidWithoutConformance;
+void invalidWithoutDiagnostics;
+void parser;
+void typedParser;
+void typedRequest;
+void relativeRange;


### PR DESCRIPTION
## Summary

- define the internal normalized syntax state and parser-analysis contracts
- bind every artifact, diagnostic, analysis, conformance claim, and parser to exact source plus authenticated backend/configuration/dialect authority
- add one mandatory parser runner that normalizes failures and returns runner-created analyzed state
- add runtime and compile-time invariant tests plus ADR 0002
- keep the stable vNext export surface unchanged

## Safety and correctness

- direct invalidity requires matching conformance authority
- compatibility rejection cannot become authoritative invalid SQL
- malformed locations fail closed instead of becoming unavailable
- parser input is capped at 1 MiB; messages, diagnostics, and limitations are bounded
- hostile custom iterators cannot bypass collection limits
- full AbortSignal runtime validation matches the declared callback surface
- raw ASTs and backend payloads remain private

## Validation

- 875 unit tests passed, with 1 governed expected failure
- changed syntax.ts coverage: 97.68% statements, 95.42% branches, 100% functions, 97.66% lines
- full typecheck and oxlint passed
- browser tests passed
- test integrity passed
- packed-consumer smoke passed
- demo build passed
- two independent adversarial reviewers approved exact commit db43409 after four fix/review loops

## Scope

Internal contract only. This PR does not add a parser adapter, cache/session wiring, catalog types, or stable public exports.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defines an internal normalized SQL syntax contract with a single parser runner that authenticates outputs and separates lexical eligibility from parser analysis. Strengthens cancellation: preserves the exact `AbortSignal` reason, rejects pre-aborted requests without invoking the backend, and races cancellation vs. backend completion correctly; public vNext exports stay the same and ADR 0002 documents the boundary.

- New Features
  - Normalized statement states and parser analyses.
  - Branded statement-relative ranges; parser receives only exact statement text and an AbortSignal.
  - Parser, authority, and conformance identities; artifacts/diagnostics bound to exact source and authority; backend data stays private.
  - Runner validates identities, normalizes sync/async failures, handles cancellation races, and returns authenticated analyzed state. Adds ADR 0002 and tests; no change to stable exports.

- Safety
  - 1 MiB input cap; bounded messages and collections; hostile iterators contained.
  - `AbortSignal` surface validated (cross-realm supported); preserves exact abort reason; pre-aborted requests skip backend; late aborts don’t override completed backend outcomes.
  - Malformed locations and fabricated results fail closed as malformed-output.
  - Compatibility rejection is never treated as invalid; invalidity requires matching conformance and authority identities.

<sup>Written for commit ed58bac9c2ef9ca7551c042a208fc1b49c11c47f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marimo-team/codemirror-sql/pull/176?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

