### PR TITLE
feat(vnext): add bounded node-sql-parser adapter

### DIFF
--- a/docs/adr/0002-normalized-syntax-contract.md
+++ b/docs/adr/0002-normalized-syntax-contract.md
@@ -179,6 +179,12 @@ request locations, retain backend data privately, and normalize every boundary
 before constructing these results. Cache/session wiring follows only after the
 adapter passes the contract suite.
 
+[ADR 0003](./0003-node-sql-parser-adapter.md) applies this contract
+conservatively: PostgreSQL, BigQuery, and DuckDB acceptance is compatibility
+evidence with explicit limitations; rejection is unsupported rather than
+invalid; and session wiring waits for an explicit
+synchronous-execution/worker decision.
+
 ## Non-goals
 
 This decision does not define:

--- a/docs/adr/0003-node-sql-parser-adapter.md
+++ b/docs/adr/0003-node-sql-parser-adapter.md
@@ -1,0 +1,202 @@
+# ADR 0003: Internal node-sql-parser Adapter
+
+Status: accepted
+Date: 2026-07-25
+
+## Context
+
+ADR 0002 defines an internal normalized syntax contract, but it deliberately
+does not decide how a concrete parser earns authority. The first adapter uses
+`node-sql-parser` because the dependency is already present and can provide a
+useful local AST in Node or an isolated worker. It must not turn the
+dependency's incomplete grammar,
+partial locations, synchronous execution, or packaging behavior into broader
+vNext guarantees.
+
+The installed `node-sql-parser` 5.4.0 package provides separate CommonJS
+bundles for PostgreSQL and BigQuery. The complete bundle is approximately
+2.5 MB uncompressed and 428 KiB compressed, while the PostgreSQL and BigQuery
+builds are approximately 59 KiB and 42 KiB compressed respectively. Loading
+the complete bundle would make consumers pay for unrelated grammars.
+
+The target-named grammars are not authoritative validators for their database
+engines. In local probes, the PostgreSQL build rejected valid `MERGE`,
+`FETCH FIRST`, `INSERT ... DEFAULT VALUES`, identity-column, and
+`FOR UPDATE SKIP LOCKED` statements. The BigQuery build rejected valid
+`QUALIFY`, `MERGE`, and `DECLARE` statements. A parse rejection therefore
+cannot establish that target-dialect SQL is invalid.
+
+The parser also runs synchronously. An `AbortSignal` can prevent work before
+the parse begins and suppress publication after it finishes, but it cannot
+interrupt `astify` while JavaScript is blocked.
+
+## Decision
+
+The adapter remains internal and is not exported from `/vnext`. This change
+does not connect it to document sessions, caches, diagnostics, completion, or
+any other feature. Session wiring requires a separate decision about worker
+isolation and cancellation.
+
+### Dependency and loading
+
+Pin `node-sql-parser` exactly to version `5.4.0`. The adapter depends on deep
+paths, CommonJS interop, AST shapes, and grammar behavior that are not stable
+enough for an unconstrained dependency range.
+
+Load only these extension-qualified paths:
+
+```text
+node-sql-parser/build/postgresql.js
+node-sql-parser/build/bigquery.js
+```
+
+After dynamically acquiring `createRequire` from `node:module`, the adapter
+revalidates the realm and synchronously requires the selected build. Module
+evaluation and global restoration therefore run in one JavaScript stack with
+no alias-mutation gap. The adapter does not load the all-dialect entry point
+and does not pass a `database` option to a dialect-specific build.
+
+Node ESM exposes these CommonJS builds through `default`/`module.exports` even
+though the declarations suggest a named `Parser` export. The module boundary
+is decoded from `unknown` and accepts only a runtime-validated constructor and
+`astify` method. No unchecked assertion compensates for the declaration/runtime
+mismatch.
+
+The parser receives fixed options:
+
+```ts
+{
+  trimQuery: false,
+  parseOptions: {
+    includeLocations: true,
+  },
+}
+```
+
+Disabling trimming is required to keep every backend offset relative to the
+exact untrimmed statement slice. Location inclusion is requested for future
+private semantic decoding, but location availability remains per node and is
+not promoted to a dialect-wide capability.
+
+The distributed UMD-style builds can assign `NodeSQLParser` and, in some
+environments, `global` on the global object while loading. The adapter refuses
+to load them whenever `window` or `self` exists, or `global` does not resolve
+exactly to `globalThis`. Only pure Node is currently eligible. This prevents
+global collisions, including DOM shims in Node, and accidental synchronous
+main-thread parsing. The Node loader captures the existing own-property
+descriptors for the affected names and restores them synchronously after module
+evaluation. A module that cannot be loaded and cleaned up safely permanently
+poisons loading and returns a non-retryable backend failure.
+
+### Evidence policy
+
+PostgreSQL and BigQuery acceptance is positive-only compatibility evidence. A
+successful target-specific parse produces `parsed/compatibility` with the
+`partial-artifact` limitation. It means only that the target-named backend
+produced a bounded normalized artifact. The adapter does not create a
+conformance identity because the grammar also accepts constructs that the
+target engines reject.
+
+Every PostgreSQL or BigQuery parse rejection produces:
+
+```text
+unsupported / uncovered-construct
+```
+
+It never produces `invalid`, even for input that appears obviously malformed.
+The same parser error is indistinguishable from rejection of valid syntax that
+the dependency does not implement. This adapter therefore creates no
+authoritative syntax diagnostics.
+
+DuckDB uses the PostgreSQL build only as a compatibility parser:
+
+- Acceptance produces `parsed/compatibility` with the
+  `dialect-compatibility` and `partial-artifact` limitations.
+- Rejection produces `unsupported/compatibility-rejected`.
+- The adapter performs no rewrites, success-without-AST shortcuts, bracket
+  quoting, comment stripping, or offset repair.
+
+Dremio has no node-sql-parser adapter. When a coordinator is added later, it
+will classify Dremio as `unavailable/dialect-not-supported` rather than silently
+selecting another grammar.
+
+Unexpected backend exceptions are failures, not syntax evidence. Invalid
+module shapes or malformed AST roots are `failed/malformed-output`; other
+unexpected parser exceptions are `failed/backend-failure`. Raw exceptions and
+backend messages do not cross the normalized boundary.
+
+### Input and artifacts
+
+The adapter imposes a 16 KiB statement limit, below the syntax contract's
+general 1 MiB ceiling. A larger statement returns
+`unsupported/resource-limit` before importing or invoking the backend.
+This conservative limit bounds work and temporary parser memory, but it does
+not satisfy the provisional active-statement latency envelope: warm local
+16 KiB parses already exceed that target. Placement measurements must set a
+lower interactive limit or move parsing off the main thread.
+
+The backend receives only the exact, untrimmed, code-bearing statement source.
+It receives no terminator, document coordinates, editor state, catalog, cursor,
+or host context.
+
+A successful result must contain exactly one object root with a string `type`.
+A direct object or one-element array is accepted. Zero or multiple roots are
+`unsupported/uncovered-construct`; malformed roots are
+`failed/malformed-output`.
+
+The public normalized artifact exposes only its closed statement kind and full
+statement-relative range. The backend AST is retained in a module-private
+`WeakMap` keyed by the authenticated artifact. It is neither enumerable nor
+returned through the syntax contract. Future relation extraction must decode
+and validate backend nodes inside the adapter boundary rather than exposing
+the raw AST to core features.
+
+### Cancellation and execution placement
+
+The callback checks cancellation before loading, after loading, and after
+parsing. These checks preserve the syntax runner's request-lifecycle behavior,
+but they cannot preempt synchronous parser execution.
+
+The adapter must not be wired into interactive session requests until a
+follow-up decision records one of:
+
+- Worker/process isolation with enforceable wall-clock and memory limits, or
+- Measured main-thread execution with an accepted adversarial-input risk and
+  explicit scheduling policy.
+
+That decision must include browser measurements, cancellation behavior,
+worker/module failure recovery, and the effect of many mounted editors.
+
+The current production loader supports pure Node only. A future browser
+integration must invoke parsing from a dedicated worker whose global object is
+not shared with application code, the legacy parser, or another installed copy.
+The unsupported-realm rejection remains until that isolated execution path
+exists.
+
+## Consequences
+
+- Local parsing can be evaluated without exposing a backend AST or
+  committing the language service to one parser.
+- PostgreSQL and BigQuery false negatives degrade to unsupported instead of
+  false invalid diagnostics.
+- PostgreSQL and BigQuery acceptance remains useful without claiming target
+  conformance.
+- DuckDB compatibility remains useful without pretending to be native
+  conformance.
+- Consumers do not load every node-sql-parser grammar.
+- The 16 KiB limit and lack of session wiring intentionally restrict initial
+  capability.
+- Authoritative invalidity requires a separately justified validator and an
+  owned dialect conformance corpus.
+
+## Non-goals
+
+This decision does not define:
+
+- Stable parser or provider APIs
+- Session cache keys or eviction
+- Document-level syntax diagnostics
+- Semantic relation, scope, column, or type models
+- A worker protocol
+- Native DuckDB or remote validation providers
+- Dremio parsing

--- a/docs/vnext/node-sql-parser-adapter.md
+++ b/docs/vnext/node-sql-parser-adapter.md
@@ -1,0 +1,116 @@
+# vNext node-sql-parser Adapter
+
+Status: internal and not wired to sessions
+
+The first concrete syntax adapter exercises the normalized contract from
+[ADR 0002](../adr/0002-normalized-syntax-contract.md) under the evidence and
+execution policy in
+[ADR 0003](../adr/0003-node-sql-parser-adapter.md). It is not exported from
+`/vnext` and does not currently power completion, diagnostics, hover,
+navigation, or any other editor feature.
+
+## Capability matrix
+
+| Dialect | Backend | Acceptance | Rejection |
+| --- | --- | --- | --- |
+| PostgreSQL | PostgreSQL-specific build | `parsed/compatibility` with `partial-artifact` | `unsupported/uncovered-construct` |
+| BigQuery | BigQuery-specific build | `parsed/compatibility` with `partial-artifact` | `unsupported/uncovered-construct` |
+| DuckDB | PostgreSQL-specific build | `parsed/compatibility` with `dialect-compatibility`, `partial-artifact` | `unsupported/compatibility-rejected` |
+| Dremio | None | Unavailable when coordinator wiring exists | `unavailable/dialect-not-supported` |
+
+This adapter never returns `direct` or `invalid`. The PostgreSQL and BigQuery
+grammars both reject valid target-dialect constructs and accept constructs the
+target engines reject. Acceptance therefore records only a partial
+compatibility artifact; rejection is not an authoritative syntax diagnostic.
+
+## Loading and packaging
+
+The implementation is tied to an exact `node-sql-parser` 5.4.0 pin and loads
+only:
+
+```text
+node-sql-parser/build/postgresql.js
+node-sql-parser/build/bigquery.js
+```
+
+The complete all-dialect entry point is not used. In pure Node, the adapter
+dynamically acquires `createRequire`, revalidates the realm, then synchronously
+requires the selected build so evaluation and cleanup cannot be interleaved
+with another task. Runtime module decoding handles the package's CommonJS shape
+rather than trusting its inaccurate named-export declarations.
+
+The adapter invokes `astify` with location collection enabled and query
+trimming disabled. Disabling trimming preserves offsets relative to the exact
+statement slice. Locations remain partial: PostgreSQL commonly omits root and
+identifier locations, while BigQuery provides broader but still incomplete
+coverage.
+
+Loading the distributed bundles may write `NodeSQLParser` or `global` on a
+global object. The adapter rejects parser loads whenever `window` or `self`
+exists, or `global` does not resolve exactly to `globalThis`, before loading a
+bundle. This blocks browser windows and Node DOM shims from exposing an
+unguarded secondary target. Pure Node loads restore the exact prior descriptors
+synchronously after module evaluation, including removing names that were
+previously absent. Cleanup failure permanently poisons loading. A
+dedicated-worker loader remains future work.
+
+Approximate local Node 24 arm64 measurements for the installed package were:
+
+| Build | Raw size | gzip size | Cold import |
+| --- | ---: | ---: | ---: |
+| PostgreSQL-specific | 308,145 B | 58,648 B | 19 ms |
+| BigQuery-specific | 208,264 B | 41,828 B | 14 ms |
+| All dialects | 2,505,457 B | 428,097 B | Not selected |
+
+These figures are investigation evidence, not cross-machine performance
+guarantees. Reproducible browser and bundle baselines are required before
+session integration.
+
+## Input and output rules
+
+The adapter accepts at most 16 KiB of statement text. Larger statements return
+`unsupported/resource-limit` before a backend import or parse.
+
+The input is the exact code-bearing normal statement source:
+
+- Leading and trailing trivia are retained.
+- A statement terminator is excluded.
+- The source is not trimmed or rewritten.
+- The backend receives no editor state, document offset, cursor, catalog, or
+  host context.
+
+A usable backend result has exactly one object root with a string `type`. The
+adapter accepts either that object directly or a one-element array containing
+it. Empty or multi-root output is uncovered; structurally malformed output is a
+backend contract failure.
+
+Normalized statement kinds are intentionally small:
+
+| Backend type | Normalized kind |
+| --- | --- |
+| `select`, `union` | `query` |
+| `insert`, `replace` | `insert` |
+| `update`, `delete`, `create`, `alter`, `drop`, `merge`, `transaction` | Same closed kind |
+| Any other string | `other` |
+
+Only the normalized kind and full statement-relative range appear in the
+syntax artifact. The raw AST stays in private weakly keyed storage for a future
+adapter-owned semantic decoder. Flat `tableList` and `columnList` output is not
+used as the semantic model.
+
+## Failure and cancellation behavior
+
+Expected PostgreSQL and BigQuery PEG rejections are uncovered capability, not
+failures. DuckDB rejection is compatibility rejection. Unexpected native
+exceptions, module-load failures, and malformed module or AST values remain
+explicit backend failures; raw exceptions are not retained in results.
+
+Cancellation is checked before and after asynchronous loading and after the
+parse. The parse itself is synchronous and cannot be interrupted by an
+`AbortSignal` while it blocks JavaScript. A late result can be discarded, but
+the CPU work has already occurred. Unsupported execution realms fail closed
+without importing a backend.
+
+For that reason, this adapter remains unwired. A worker-versus-main-thread ADR,
+with browser latency, memory, hostile-input, timeout, and recovery evidence, is
+required before interactive sessions may call it.

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "test:coverage:changed": "node ./scripts/changed-coverage.mjs",
     "test:browser": "vitest run --config vitest.browser.config.ts",
     "test:integrity": "node ./scripts/check-test-integrity.mjs",
+    "bench:parser-adapter": "vitest bench --run src/vnext/__tests__/node-sql-parser-adapter.bench.ts",
     "bench:statement-index": "vitest bench --run src/vnext/__tests__/statement-index.bench.ts",
     "test:package": "node ./scripts/clean.mjs && tsc && node ./scripts/package-smoke.mjs",
     "demo": "vite build",
@@ -95,6 +96,6 @@
   },
   "module": "./dist/index.js",
   "dependencies": {
-    "node-sql-parser": "^5.3.13"
+    "node-sql-parser": "5.4.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,7 +18,7 @@ importers:
         specifier: ^6
         version: 6.7.1
       node-sql-parser:
-        specifier: ^5.3.13
+        specifier: 5.4.0
         version: 5.4.0
     devDependencies:
       '@codemirror/lang-sql':

--- a/src/node-module.d.ts
+++ b/src/node-module.d.ts
@@ -1,0 +1,5 @@
+declare module "node:module" {
+  export function createRequire(
+    filename: string,
+  ): (specifier: string) => unknown;
+}

--- a/src/vnext/__tests__/node-sql-parser-adapter.bench.ts
+++ b/src/vnext/__tests__/node-sql-parser-adapter.bench.ts
@@ -1,0 +1,126 @@
+// @vitest-environment node
+
+import { beforeAll, bench, describe, expect } from "vitest";
+import {
+  getBigQueryNodeSqlStatementParser,
+  getDuckDbCompatibilityNodeSqlStatementParser,
+  getPostgresqlNodeSqlStatementParser,
+} from "../node-sql-parser-adapter.js";
+import {
+  createSqlStatementParseRequest,
+  runSqlStatementParser,
+  type SqlStatementParser,
+} from "../syntax.js";
+
+function statementNear(targetLength: number): string {
+  const prefix = "SELECT ";
+  const suffix = " FROM benchmark_table";
+  const columns: string[] = [];
+  let columnLength = 0;
+  for (let index = 0; ; index += 1) {
+    const column = `column_${index}`;
+    const separatorLength = columns.length === 0 ? 0 : 2;
+    if (
+      prefix.length +
+        columnLength +
+        separatorLength +
+        column.length +
+        suffix.length >
+      targetLength
+    ) {
+      break;
+    }
+    columns.push(column);
+    columnLength += separatorLength + column.length;
+  }
+  return `${prefix}${columns.join(", ")}${suffix}`;
+}
+
+const controller = new AbortController();
+const statements = [
+  ["1 KiB", statementNear(1024)],
+  ["8 KiB", statementNear(8 * 1024)],
+  ["16 KiB", statementNear(16 * 1024)],
+] as const;
+
+function requestFor(statement: string) {
+  return createSqlStatementParseRequest(
+    statement,
+    controller.signal,
+  );
+}
+
+const requests = statements.map(
+  ([label, statement]) =>
+    [label, requestFor(statement)] as const,
+);
+
+const postgresqlParser = getPostgresqlNodeSqlStatementParser();
+const bigQueryParser = getBigQueryNodeSqlStatementParser();
+const duckDbParser = getDuckDbCompatibilityNodeSqlStatementParser();
+
+async function parse(
+  parser: SqlStatementParser,
+  request: ReturnType<typeof createSqlStatementParseRequest>,
+) {
+  return await runSqlStatementParser(parser, request);
+}
+
+beforeAll(async () => {
+  const warmup = requestFor("SELECT 1");
+  const warmups = await Promise.all([
+    parse(postgresqlParser, warmup),
+    parse(bigQueryParser, warmup),
+    parse(duckDbParser, warmup),
+  ]);
+  for (const state of warmups) {
+    expect(state.analysis).toMatchObject({
+      mode: "compatibility",
+      status: "parsed",
+    });
+  }
+  for (const [, request] of requests) {
+    const states = await Promise.all([
+      parse(postgresqlParser, request),
+      parse(bigQueryParser, request),
+    ]);
+    for (const state of states) {
+      expect(state.analysis).toMatchObject({
+        limitations: ["partial-artifact"],
+        mode: "compatibility",
+        status: "parsed",
+      });
+    }
+  }
+  const duckDbRequest = requests[1]?.[1];
+  if (duckDbRequest === undefined) {
+    throw new Error("DuckDB benchmark request is unavailable");
+  }
+  expect(
+    (await parse(duckDbParser, duckDbRequest)).analysis,
+  ).toMatchObject({
+    limitations: ["dialect-compatibility", "partial-artifact"],
+    mode: "compatibility",
+    status: "parsed",
+  });
+});
+
+describe("node-sql-parser adapter", () => {
+  for (const [label, request] of requests) {
+    bench(`PostgreSQL ${label}`, async () => {
+      await parse(postgresqlParser, request);
+    });
+
+    bench(`BigQuery ${label}`, async () => {
+      await parse(bigQueryParser, request);
+    });
+  }
+
+  bench("DuckDB compatibility 8 KiB", async () => {
+    const request = requests[1]?.[1];
+    if (request === undefined) {
+      throw new Error("DuckDB benchmark request is unavailable");
+    }
+    await parse(duckDbParser, request);
+  });
+});

--- a/src/vnext/__tests__/node-sql-parser-adapter.test.ts
+++ b/src/vnext/__tests__/node-sql-parser-adapter.test.ts
@@ -900,14 +900,14 @@ describe("real node-sql-parser builds", () => {
       "SELECT value FROM dataset.table QUALIFY ROW_NUMBER() OVER () = 1",
     ],
     [
-      "PostgreSQL typo",
+      "PostgreSQL malformed query",
       getPostgresqlNodeSqlStatementParser,
-      "SELEC 1",
+      "SELECT FROM",
     ],
     [
-      "BigQuery typo",
+      "BigQuery malformed query",
       getBigQueryNodeSqlStatementParser,
-      "SELEC 1",
+      "SELECT FROM",
     ],
   ] as const)(
     "classifies %s syntax rejection as unsupported",

--- a/src/vnext/__tests__/node-sql-parser-adapter.test.ts
+++ b/src/vnext/__tests__/node-sql-parser-adapter.test.ts
@@ -1,0 +1,1174 @@
+// @vitest-environment node
+
+import { describe, expect, it, vi } from "vitest";
+import {
+  exportedForTesting,
+  getBigQueryNodeSqlStatementParser,
+  getDuckDbCompatibilityNodeSqlStatementParser,
+  getPostgresqlNodeSqlStatementParser,
+  MAX_NODE_SQL_PARSER_STATEMENT_LENGTH,
+} from "../node-sql-parser-adapter.js";
+import {
+  createSqlStatementParseRequest,
+  runSqlStatementParser,
+  type SqlStatementParser,
+} from "../syntax.js";
+
+type ModuleShape =
+  | "constructor"
+  | "default-constructor"
+  | "default-named"
+  | "module-exports"
+  | "named";
+
+function invokeWithUnknown(
+  callback: (...values: never[]) => unknown,
+  ...values: unknown[]
+): unknown {
+  return Reflect.apply(callback, undefined, values);
+}
+
+function createBackendModule(
+  astify: (statementText: string, options: unknown) => unknown,
+  shape: ModuleShape = "named",
+): unknown {
+  class Parser {
+    astify(statementText: string, options: unknown): unknown {
+      return astify(statementText, options);
+    }
+  }
+
+  switch (shape) {
+    case "constructor":
+      return Parser;
+    case "default-constructor":
+      return { default: Parser };
+    case "default-named":
+      return { default: { Parser } };
+    case "module-exports":
+      return { "module.exports": { Parser } };
+    case "named":
+      return { Parser };
+  }
+}
+
+function createFakeParser(
+  astify: (statementText: string, options: unknown) => unknown,
+  policy: "dialect-compatibility" | "target-grammar" = "target-grammar",
+  shape: ModuleShape = "named",
+): SqlStatementParser {
+  return exportedForTesting.createParser(
+    policy,
+    async () => createBackendModule(astify, shape),
+  );
+}
+
+async function parse(
+  parser: SqlStatementParser,
+  text = "SELECT 1",
+  signal: AbortSignal = new AbortController().signal,
+) {
+  return await runSqlStatementParser(
+    parser,
+    createSqlStatementParseRequest(text, signal),
+  );
+}
+
+function syntaxError(
+  message: string,
+  from: number,
+  to: number,
+): object {
+  return {
+    location: {
+      end: { offset: to },
+      start: { offset: from },
+    },
+    message,
+    name: "SyntaxError",
+  };
+}
+
+function expectFailed(
+  state: Awaited<ReturnType<typeof parse>>,
+  reason: "backend-failure" | "malformed-output",
+): void {
+  expect(state.analysis).toMatchObject({
+    reason,
+    status: "failed",
+  });
+}
+
+describe("node-sql-parser module boundary", () => {
+  it("returns stable frozen parsers with scoped authority identities", () => {
+    const postgresql = getPostgresqlNodeSqlStatementParser();
+    const bigQuery = getBigQueryNodeSqlStatementParser();
+    const duckDb = getDuckDbCompatibilityNodeSqlStatementParser();
+
+    expect(getPostgresqlNodeSqlStatementParser()).toBe(postgresql);
+    expect(getBigQueryNodeSqlStatementParser()).toBe(bigQuery);
+    expect(getDuckDbCompatibilityNodeSqlStatementParser()).toBe(duckDb);
+    expect(Object.isFrozen(postgresql)).toBe(true);
+    expect(Object.isFrozen(bigQuery)).toBe(true);
+    expect(Object.isFrozen(duckDb)).toBe(true);
+    expect(duckDb.authority.backendIdentity).toBe(
+      postgresql.authority.backendIdentity,
+    );
+    expect(duckDb.authority.configurationIdentity).not.toBe(
+      postgresql.authority.configurationIdentity,
+    );
+    expect(duckDb.authority.dialectIdentity).not.toBe(
+      postgresql.authority.dialectIdentity,
+    );
+    expect(bigQuery.authority.backendIdentity).not.toBe(
+      postgresql.authority.backendIdentity,
+    );
+  });
+
+  it.each<ModuleShape>([
+    "constructor",
+    "default-constructor",
+    "default-named",
+    "module-exports",
+    "named",
+  ])("accepts the supported %s module shape", async (shape) => {
+    const parser = createFakeParser(
+      () => ({ type: "select" }),
+      "target-grammar",
+      shape,
+    );
+
+    const state = await parse(parser);
+
+    expect(state.analysis).toMatchObject({
+      artifact: { kind: "query", range: { from: 0, to: 8 } },
+      mode: "compatibility",
+      status: "parsed",
+    });
+  });
+
+  it("passes immutable location-preserving options and exact source", async () => {
+    const source = "  SELECT 1\n";
+    let receivedText: string | undefined;
+    let receivedOptions: unknown;
+    const parser = createFakeParser((text, options) => {
+      receivedText = text;
+      receivedOptions = options;
+      return { type: "select" };
+    });
+
+    await parse(parser, source);
+
+    expect(receivedText).toBe(source);
+    expect(receivedOptions).toEqual({
+      parseOptions: { includeLocations: true },
+      trimQuery: false,
+    });
+    expect(Object.isFrozen(receivedOptions)).toBe(true);
+    if (receivedOptions === null || typeof receivedOptions !== "object") {
+      throw new Error("Expected parser options");
+    }
+    const parseOptions = Reflect.get(receivedOptions, "parseOptions");
+    expect(Object.isFrozen(parseOptions)).toBe(true);
+  });
+
+  it("deduplicates concurrent module loads", async () => {
+    let release: (() => void) | undefined;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    let loads = 0;
+    const parser = exportedForTesting.createParser(
+      "target-grammar",
+      async () => {
+        loads += 1;
+        await gate;
+        return createBackendModule(() => ({ type: "select" }));
+      },
+    );
+
+    const first = parse(parser, "SELECT 1");
+    const second = parse(parser, "SELECT 2");
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(loads).toBe(1);
+    if (release === undefined) {
+      throw new Error("Module load gate was not initialized");
+    }
+    release();
+
+    await expect(first).resolves.toMatchObject({
+      analysis: { status: "parsed" },
+    });
+    await expect(second).resolves.toMatchObject({
+      analysis: { status: "parsed" },
+    });
+    expect(loads).toBe(1);
+  });
+
+  it("clears a rejected load so the next request can retry", async () => {
+    let loads = 0;
+    const parser = exportedForTesting.createParser(
+      "target-grammar",
+      async () => {
+        loads += 1;
+        if (loads === 1) {
+          throw new Error("private loader details");
+        }
+        return createBackendModule(() => ({ type: "select" }));
+      },
+    );
+
+    const first = await parse(parser);
+    expect(first.analysis).toEqual(
+      expect.objectContaining({
+        message: "node-sql-parser failed to load",
+        reason: "backend-failure",
+        retryable: true,
+        status: "failed",
+      }),
+    );
+    expect(JSON.stringify(first)).not.toContain("private loader details");
+
+    const second = await parse(parser);
+    expect(second.analysis).toMatchObject({
+      mode: "compatibility",
+      status: "parsed",
+    });
+    expect(loads).toBe(2);
+  });
+
+  it("classifies and caches a constructor exception as a backend failure", async () => {
+    let constructions = 0;
+    class Parser {
+      constructor() {
+        constructions += 1;
+        throw new Error("private constructor details");
+      }
+    }
+    const parser = exportedForTesting.createParser(
+      "target-grammar",
+      async () => ({ Parser }),
+    );
+
+    const state = await parse(parser);
+
+    expectFailed(state, "backend-failure");
+    expect(state.analysis).toMatchObject({
+      message: "node-sql-parser backend failed",
+      retryable: false,
+    });
+    expect(JSON.stringify(state)).not.toContain("private");
+    expectFailed(await parse(parser), "backend-failure");
+    expect(constructions).toBe(1);
+  });
+
+  it.each([
+    null,
+    {},
+    { Parser: null },
+    { Parser: class MissingAstify {} },
+    {
+      Parser: class InvalidAstify {
+        readonly astify = "not callable";
+      },
+    },
+  ])("normalizes malformed module shape %#", async (moduleValue) => {
+    const parser = exportedForTesting.createParser(
+      "target-grammar",
+      async () => moduleValue,
+    );
+
+    const state = await parse(parser);
+
+    expectFailed(state, "malformed-output");
+    expect(state.analysis).toMatchObject({
+      message: "node-sql-parser returned malformed output",
+      retryable: false,
+    });
+  });
+
+  it("caches a non-retryable malformed module shape", async () => {
+    let loads = 0;
+    const parser = exportedForTesting.createParser(
+      "target-grammar",
+      async () => {
+        loads += 1;
+        return {};
+      },
+    );
+
+    expectFailed(await parse(parser), "malformed-output");
+    expectFailed(await parse(parser), "malformed-output");
+    expect(loads).toBe(1);
+  });
+
+  it("does not invoke an accessor-backed astify method", async () => {
+    let invoked = false;
+    class Parser {
+      get astify(): never {
+        invoked = true;
+        throw new Error("private accessor details");
+      }
+    }
+    const parser = exportedForTesting.createParser(
+      "target-grammar",
+      async () => ({ Parser }),
+    );
+
+    const state = await parse(parser);
+
+    expectFailed(state, "malformed-output");
+    expect(invoked).toBe(false);
+  });
+
+  it("normalizes a prototype-trapping parser instance", async () => {
+    const parserInstance = new Proxy(
+      {},
+      {
+        getPrototypeOf() {
+          throw new Error("private prototype details");
+        },
+      },
+    );
+    function Parser(): object {
+      return parserInstance;
+    }
+    const parser = exportedForTesting.createParser(
+      "target-grammar",
+      async () => ({ Parser }),
+    );
+
+    const state = await parse(parser);
+
+    expectFailed(state, "malformed-output");
+    expect(JSON.stringify(state)).not.toContain("private");
+  });
+
+  it("restores globals and recovers from a synchronous load failure", () => {
+    const sentinel = {};
+    const descriptor: PropertyDescriptor = {
+      configurable: true,
+      enumerable: false,
+      value: sentinel,
+      writable: true,
+    };
+    const syntheticGlobal = {};
+    Object.defineProperty(
+      syntheticGlobal,
+      "NodeSQLParser",
+      descriptor,
+    );
+    const loadSynchronously =
+      exportedForTesting.createSynchronousModuleLoader(
+        syntheticGlobal,
+      );
+
+    expect(() =>
+      loadSynchronously(() => {
+        Object.defineProperty(
+          syntheticGlobal,
+          "NodeSQLParser",
+          {
+            configurable: true,
+            value: "temporary",
+          },
+        );
+        throw new Error("private load details");
+      }),
+    ).toThrow("private load details");
+    expect(
+      Object.getOwnPropertyDescriptor(
+        syntheticGlobal,
+        "NodeSQLParser",
+      ),
+    ).toStrictEqual(descriptor);
+    expect(loadSynchronously(() => "loaded")).toBe("loaded");
+  });
+
+  it("permanently poisons synchronous loading after cleanup failure", async () => {
+    const syntheticGlobal = {};
+    const loadSynchronously =
+      exportedForTesting.createSynchronousModuleLoader(
+        syntheticGlobal,
+      );
+    let firstLoads = 0;
+    const firstParser = exportedForTesting.createParser(
+      "target-grammar",
+      async () =>
+        loadSynchronously(() => {
+          firstLoads += 1;
+          Object.defineProperty(
+            syntheticGlobal,
+            "NodeSQLParser",
+            {
+              configurable: false,
+              value: "pollution",
+            },
+          );
+          return createBackendModule(() => ({ type: "select" }));
+        }),
+    );
+
+    const first = await parse(firstParser);
+
+    expectFailed(first, "backend-failure");
+    expect(first.analysis).toMatchObject({ retryable: false });
+    expect(firstLoads).toBe(1);
+
+    let laterLoads = 0;
+    const laterParser = exportedForTesting.createParser(
+      "target-grammar",
+      async () =>
+        loadSynchronously(() => {
+          laterLoads += 1;
+          return createBackendModule(() => ({ type: "select" }));
+        }),
+    );
+
+    const later = await parse(laterParser);
+
+    expectFailed(later, "backend-failure");
+    expect(later.analysis).toMatchObject({ retryable: false });
+    expect(laterLoads).toBe(0);
+    expect(
+      Reflect.get(syntheticGlobal, "NodeSQLParser"),
+    ).toBe("pollution");
+  });
+
+  it("permanently poisons synchronous loading after snapshot failure", () => {
+    let inspections = 0;
+    const syntheticGlobal = new Proxy(
+      {},
+      {
+        getOwnPropertyDescriptor() {
+          inspections += 1;
+          throw new Error("private snapshot details");
+        },
+      },
+    );
+    const loadSynchronously =
+      exportedForTesting.createSynchronousModuleLoader(
+        syntheticGlobal,
+      );
+    let loads = 0;
+
+    expect(() =>
+      loadSynchronously(() => {
+        loads += 1;
+      }),
+    ).toThrow();
+    const inspectionsAfterFirst = inspections;
+    expect(() =>
+      loadSynchronously(() => {
+        loads += 1;
+      }),
+    ).toThrow();
+    expect(inspections).toBe(inspectionsAfterFirst);
+    expect(loads).toBe(0);
+  });
+});
+
+describe("node-sql-parser result decoding", () => {
+  it.each([
+    ["select", "query"],
+    ["UNION", "query"],
+    ["insert", "insert"],
+    ["replace", "insert"],
+    ["update", "update"],
+    ["delete", "delete"],
+    ["create", "create"],
+    ["alter", "alter"],
+    ["drop", "drop"],
+    ["merge", "merge"],
+    ["transaction", "transaction"],
+    ["truncate", "other"],
+  ] as const)("maps backend kind %s to %s", async (backend, expected) => {
+    const state = await parse(
+      createFakeParser(() => ({ type: backend })),
+    );
+
+    expect(state.analysis).toMatchObject({
+      artifact: { kind: expected },
+      mode: "compatibility",
+      status: "parsed",
+    });
+  });
+
+  it("accepts a one-element AST array", async () => {
+    const state = await parse(
+      createFakeParser(() => [{ type: "select" }]),
+    );
+
+    expect(state.analysis).toMatchObject({
+      artifact: { kind: "query" },
+      status: "parsed",
+    });
+  });
+
+  it.each([
+    [[]],
+    [[{ type: "select" }, { type: "select" }]],
+  ] as const)("classifies non-singleton AST arrays as unsupported", async (root) => {
+    const state = await parse(createFakeParser(() => root));
+
+    expect(state.analysis).toEqual(
+      expect.objectContaining({
+        reason: "uncovered-construct",
+        status: "unsupported",
+      }),
+    );
+  });
+
+  it.each([
+    null,
+    undefined,
+    1,
+    "select",
+    {},
+    { type: "" },
+    { type: " select" },
+    { type: "select " },
+    { type: "x".repeat(129) },
+    [null],
+    Array(1),
+  ])("rejects malformed root %#", async (root) => {
+    const state = await parse(createFakeParser(() => root));
+
+    expectFailed(state, "malformed-output");
+  });
+
+  it("rejects an accessor-backed type without invoking it", async () => {
+    let invoked = false;
+    const root = {};
+    Object.defineProperty(root, "type", {
+      get() {
+        invoked = true;
+        throw new Error("private accessor details");
+      },
+    });
+
+    const state = await parse(createFakeParser(() => root));
+
+    expectFailed(state, "malformed-output");
+    expect(invoked).toBe(false);
+    expect(JSON.stringify(state)).not.toContain("private accessor details");
+  });
+
+  it("normalizes a descriptor-trapping root proxy as malformed", async () => {
+    const root = new Proxy(
+      { type: "select" },
+      {
+        getOwnPropertyDescriptor() {
+          throw new Error("private proxy details");
+        },
+      },
+    );
+
+    const state = await parse(createFakeParser(() => root));
+
+    expectFailed(state, "malformed-output");
+    expect(JSON.stringify(state)).not.toContain("private proxy details");
+  });
+
+  it("normalizes revoked and array-length-trapping proxies as malformed", async () => {
+    const revoked = Proxy.revocable({ type: "select" }, {});
+    revoked.revoke();
+    const arrayProxy = new Proxy(
+      [{ type: "select" }],
+      {
+        getOwnPropertyDescriptor(target, key) {
+          if (key === "length") {
+            throw new Error("private array proxy details");
+          }
+          return Reflect.getOwnPropertyDescriptor(target, key);
+        },
+      },
+    );
+
+    for (const root of [revoked.proxy, arrayProxy]) {
+      const state = await parse(createFakeParser(() => root));
+      expectFailed(state, "malformed-output");
+      expect(JSON.stringify(state)).not.toContain("private");
+    }
+  });
+
+  it("rejects callable AST roots", async () => {
+    function root(): void {
+      // A parser AST is data, never executable.
+    }
+    Object.defineProperty(root, "type", {
+      value: "select",
+    });
+
+    const state = await parse(createFakeParser(() => root));
+
+    expectFailed(state, "malformed-output");
+  });
+});
+
+describe("node-sql-parser error boundary", () => {
+  it.each([
+    ["target-grammar", "uncovered-construct"],
+    ["dialect-compatibility", "compatibility-rejected"],
+  ] as const)(
+    "keeps a %s grammar rejection non-authoritative",
+    async (policy, expected) => {
+      const parser = createFakeParser(() => {
+        throw syntaxError("Unexpected token", 7, 8);
+      }, policy);
+
+      const state = await parse(parser);
+
+      expect(state.analysis).toEqual(
+        expect.objectContaining({
+          reason: expected,
+          status: "unsupported",
+        }),
+      );
+      expect(JSON.stringify(state)).not.toContain("Unexpected token");
+    },
+  );
+
+  it.each([
+    [
+      "PostgreSQL",
+      getPostgresqlNodeSqlStatementParser,
+      "SELECT `value` FROM `items`",
+    ],
+    [
+      "BigQuery",
+      getBigQueryNodeSqlStatementParser,
+      "SELECT value FROM dataset.items LIMIT 1, 2",
+    ],
+  ] as const)(
+    "does not claim direct %s conformance for an over-accepted construct",
+    async (_dialect, getParser, source) => {
+      const state = await parse(getParser(), source);
+
+      expect(state.analysis).toMatchObject({
+        limitations: ["partial-artifact"],
+        mode: "compatibility",
+        status: "parsed",
+      });
+    },
+  );
+
+  it.each([
+    { location: null, message: "bad", name: "SyntaxError" },
+    { location: {}, message: "bad", name: "SyntaxError" },
+    {
+      location: { end: { offset: 1 }, start: { offset: -1 } },
+      message: "bad",
+      name: "SyntaxError",
+    },
+    {
+      location: { end: { offset: 1 }, start: { offset: 2 } },
+      message: "bad",
+      name: "SyntaxError",
+    },
+    {
+      location: { end: { offset: 9 }, start: { offset: 0 } },
+      message: "bad",
+      name: "SyntaxError",
+    },
+    {
+      location: { end: { offset: 1.5 }, start: { offset: 0 } },
+      message: "bad",
+      name: "SyntaxError",
+    },
+    {
+      location: { end: {}, start: { offset: 0 } },
+      message: "bad",
+      name: "SyntaxError",
+    },
+    syntaxError("", 0, 1),
+    syntaxError("x".repeat(8_193), 0, 1),
+  ])("rejects malformed SyntaxError %#", async (error) => {
+    const state = await parse(
+      createFakeParser(() => {
+        throw error;
+      }),
+    );
+
+    expectFailed(state, "malformed-output");
+  });
+
+  it("does not invoke accessor-backed SyntaxError fields", async () => {
+    let invoked = false;
+    const error = {
+      message: "bad",
+      name: "SyntaxError",
+    };
+    Object.defineProperty(error, "location", {
+      get() {
+        invoked = true;
+        throw new Error("private accessor details");
+      },
+    });
+
+    const state = await parse(
+      createFakeParser(() => {
+        throw error;
+      }),
+    );
+
+    expectFailed(state, "malformed-output");
+    expect(invoked).toBe(false);
+  });
+
+  it.each([
+    new Error("private backend stack and message"),
+    "private primitive rejection",
+    null,
+  ])("normalizes backend failure %# without raw leakage", async (error) => {
+    const state = await parse(
+      createFakeParser(() => {
+        throw error;
+      }),
+    );
+
+    expectFailed(state, "backend-failure");
+    expect(state.analysis).toMatchObject({
+      message: "node-sql-parser backend failed",
+      retryable: false,
+    });
+    expect(JSON.stringify(state)).not.toContain("private");
+  });
+});
+
+describe("node-sql-parser resource and cancellation boundary", () => {
+  it("rejects oversized input without loading the backend", async () => {
+    let loads = 0;
+    const parser = exportedForTesting.createParser(
+      "target-grammar",
+      async () => {
+        loads += 1;
+        return createBackendModule(() => ({ type: "select" }));
+      },
+    );
+
+    const state = await parse(
+      parser,
+      "x".repeat(MAX_NODE_SQL_PARSER_STATEMENT_LENGTH + 1),
+    );
+
+    expect(state.analysis).toEqual(
+      expect.objectContaining({
+        reason: "resource-limit",
+        status: "unsupported",
+      }),
+    );
+    expect(loads).toBe(0);
+  });
+
+  it("accepts the exact adapter input boundary", async () => {
+    let calls = 0;
+    const parser = createFakeParser(() => {
+      calls += 1;
+      return { type: "select" };
+    });
+
+    const state = await parse(
+      parser,
+      "x".repeat(MAX_NODE_SQL_PARSER_STATEMENT_LENGTH),
+    );
+
+    expect(state.analysis).toMatchObject({
+      mode: "compatibility",
+      status: "parsed",
+    });
+    expect(calls).toBe(1);
+  });
+
+  it("does not load for a pre-aborted request", async () => {
+    let loads = 0;
+    const reason = Object.freeze({ reason: "pre-aborted" });
+    const controller = new AbortController();
+    controller.abort(reason);
+    const parser = exportedForTesting.createParser(
+      "target-grammar",
+      async () => {
+        loads += 1;
+        return createBackendModule(() => ({ type: "select" }));
+      },
+    );
+
+    await expect(
+      parse(parser, "SELECT 1", controller.signal),
+    ).rejects.toBe(reason);
+    expect(loads).toBe(0);
+  });
+
+  it("propagates exact abort during module load and never parses", async () => {
+    let release: (() => void) | undefined;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    let astifyCalls = 0;
+    const parser = exportedForTesting.createParser(
+      "target-grammar",
+      async () => {
+        await gate;
+        return createBackendModule(() => {
+          astifyCalls += 1;
+          return { type: "select" };
+        });
+      },
+    );
+    const controller = new AbortController();
+    const reason = Object.freeze({ reason: "during-load" });
+
+    const result = parse(parser, "SELECT 1", controller.signal);
+    await Promise.resolve();
+    controller.abort(reason);
+    if (release === undefined) {
+      throw new Error("Module load gate was not initialized");
+    }
+    release();
+
+    await expect(result).rejects.toBe(reason);
+    expect(astifyCalls).toBe(0);
+  });
+
+  it("does not publish when the backend aborts synchronously", async () => {
+    const controller = new AbortController();
+    const reason = Object.freeze({ reason: "during-parse" });
+    const parser = createFakeParser(() => {
+      controller.abort(reason);
+      return { type: "select" };
+    });
+
+    await expect(
+      parse(parser, "SELECT 1", controller.signal),
+    ).rejects.toBe(reason);
+  });
+});
+
+describe("real node-sql-parser builds", () => {
+  it.each([
+    [
+      "PostgreSQL",
+      getPostgresqlNodeSqlStatementParser,
+      "  SELECT 1\nFROM users",
+      "query",
+    ],
+    [
+      "PostgreSQL",
+      getPostgresqlNodeSqlStatementParser,
+      "BEGIN",
+      "transaction",
+    ],
+    [
+      "BigQuery",
+      getBigQueryNodeSqlStatementParser,
+      "SELECT `project.dataset.table`.id FROM `project.dataset.table`",
+      "query",
+    ],
+    [
+      "BigQuery",
+      getBigQueryNodeSqlStatementParser,
+      "CREATE TABLE dataset.result (id INT64)",
+      "create",
+    ],
+  ] as const)(
+    "parses a valid %s statement",
+    async (_dialect, getParser, source, expectedKind) => {
+      const state = await parse(getParser(), source);
+
+      expect(state.analysis).toMatchObject({
+        artifact: {
+          kind: expectedKind,
+          range: { from: 0, to: source.length },
+        },
+        limitations: ["partial-artifact"],
+        mode: "compatibility",
+        status: "parsed",
+      });
+    },
+  );
+
+  it.each([
+    [
+      "PostgreSQL",
+      getPostgresqlNodeSqlStatementParser,
+      "MERGE INTO target USING source ON target.id = source.id WHEN MATCHED THEN UPDATE SET value = source.value",
+    ],
+    [
+      "BigQuery",
+      getBigQueryNodeSqlStatementParser,
+      "SELECT value FROM dataset.table QUALIFY ROW_NUMBER() OVER () = 1",
+    ],
+    [
+      "PostgreSQL typo",
+      getPostgresqlNodeSqlStatementParser,
+      "SELEC 1",
+    ],
+    [
+      "BigQuery typo",
+      getBigQueryNodeSqlStatementParser,
+      "SELEC 1",
+    ],
+  ] as const)(
+    "classifies %s syntax rejection as unsupported",
+    async (_dialect, getParser, source) => {
+      const state = await parse(getParser(), source);
+
+      expect(state.analysis).toEqual(
+        expect.objectContaining({
+          reason: "uncovered-construct",
+          status: "unsupported",
+        }),
+      );
+    },
+  );
+
+  it("marks DuckDB's PostgreSQL subset as compatibility evidence", async () => {
+    const state = await parse(
+      getDuckDbCompatibilityNodeSqlStatementParser(),
+      "SELECT 1",
+    );
+
+    expect(state.analysis).toMatchObject({
+      artifact: { kind: "query" },
+      limitations: ["dialect-compatibility", "partial-artifact"],
+      mode: "compatibility",
+      status: "parsed",
+    });
+  });
+
+  it("never turns a DuckDB compatibility rejection into invalid SQL", async () => {
+    const state = await parse(
+      getDuckDbCompatibilityNodeSqlStatementParser(),
+      "FROM 'data.parquet'",
+    );
+
+    expect(state.analysis).toEqual(
+      expect.objectContaining({
+        reason: "compatibility-rejected",
+        status: "unsupported",
+      }),
+    );
+  });
+});
+
+describe("backend artifact privacy", () => {
+  it("retains backend data only behind the authentic artifact", async () => {
+    const backendRoot = {
+      privateBackendField: "must-not-leak",
+      type: "select",
+    };
+    const state = await parse(createFakeParser(() => backendRoot));
+    if (
+      state.analysis.status !== "parsed"
+    ) {
+      throw new Error("Expected a parsed analysis");
+    }
+    const { artifact } = state.analysis;
+
+    expect(exportedForTesting.hasBackendPayload(artifact)).toBe(true);
+    expect(Object.keys(artifact)).toEqual(["kind", "range"]);
+    expect(JSON.stringify(state)).not.toContain("must-not-leak");
+    expect(Reflect.ownKeys(artifact)).not.toContain("privateBackendField");
+
+    const structuralCopy = {
+      kind: artifact.kind,
+      range: artifact.range,
+    };
+    expect(
+      invokeWithUnknown(
+        exportedForTesting.hasBackendPayload,
+        structuralCopy,
+      ),
+    ).toBe(false);
+  });
+
+  it("does not retain malformed or unsupported backend values", async () => {
+    const malformedState = await parse(createFakeParser(() => null));
+    const unsupportedState = await parse(createFakeParser(() => []));
+
+    for (const state of [malformedState, unsupportedState]) {
+      expect(state.analysis.status).not.toBe("parsed");
+      const fabricated = {
+        kind: "other",
+        range: { from: 0, to: 0 },
+      };
+      expect(
+        invokeWithUnknown(
+          exportedForTesting.hasBackendPayload,
+          fabricated,
+        ),
+      ).toBe(false);
+    }
+  });
+});
+
+describe("execution realm boundary", () => {
+  it.each(["self", "window"] as const)(
+    "rejects and caches a distinct %s alias before import",
+    async (alias) => {
+      const original = Object.getOwnPropertyDescriptor(
+        globalThis,
+        alias,
+      );
+      const sentinel = {};
+      Object.defineProperty(globalThis, alias, {
+        configurable: true,
+        value: sentinel,
+      });
+
+      try {
+        vi.resetModules();
+        const isolatedAdapter = await import(
+          "../node-sql-parser-adapter.js"
+        );
+        const isolatedSyntax = await import("../syntax.js");
+        const parser =
+          isolatedAdapter.getPostgresqlNodeSqlStatementParser();
+        const run = async () =>
+          await isolatedSyntax.runSqlStatementParser(
+            parser,
+            isolatedSyntax.createSqlStatementParseRequest(
+              "SELECT 1",
+              new AbortController().signal,
+            ),
+          );
+
+        const first = await run();
+        expect(first.analysis).toMatchObject({
+          reason: "backend-failure",
+          retryable: false,
+          status: "failed",
+        });
+        expect(Reflect.deleteProperty(globalThis, alias)).toBe(true);
+
+        const second = await run();
+        expect(second.analysis).toMatchObject({
+          reason: "backend-failure",
+          retryable: false,
+          status: "failed",
+        });
+        expect(
+          Object.getOwnPropertyDescriptor(
+            sentinel,
+            "NodeSQLParser",
+          ),
+        ).toBeUndefined();
+      } finally {
+        if (original === undefined) {
+          Reflect.deleteProperty(globalThis, alias);
+        } else {
+          Object.defineProperty(globalThis, alias, original);
+        }
+        vi.resetModules();
+      }
+    },
+  );
+
+  it("rejects and caches an inherited self alias", async () => {
+    const prototype = Object.getPrototypeOf(globalThis);
+    if (prototype === null) {
+      throw new Error("Expected a global prototype");
+    }
+    const original = Object.getOwnPropertyDescriptor(
+      prototype,
+      "self",
+    );
+    const sentinel = {};
+    Object.defineProperty(prototype, "self", {
+      configurable: true,
+      value: sentinel,
+    });
+
+    try {
+      vi.resetModules();
+      const isolatedAdapter = await import(
+        "../node-sql-parser-adapter.js"
+      );
+      const isolatedSyntax = await import("../syntax.js");
+      const parser =
+        isolatedAdapter.getPostgresqlNodeSqlStatementParser();
+      const run = async () =>
+        await isolatedSyntax.runSqlStatementParser(
+          parser,
+          isolatedSyntax.createSqlStatementParseRequest(
+            "SELECT 1",
+            new AbortController().signal,
+          ),
+        );
+
+      expect((await run()).analysis).toMatchObject({
+        reason: "backend-failure",
+        retryable: false,
+        status: "failed",
+      });
+      expect(Reflect.deleteProperty(prototype, "self")).toBe(true);
+      expect((await run()).analysis).toMatchObject({
+        reason: "backend-failure",
+        retryable: false,
+        status: "failed",
+      });
+      expect(
+        Object.getOwnPropertyDescriptor(
+          sentinel,
+          "NodeSQLParser",
+        ),
+      ).toBeUndefined();
+    } finally {
+      if (original === undefined) {
+        Reflect.deleteProperty(prototype, "self");
+      } else {
+        Object.defineProperty(prototype, "self", original);
+      }
+      vi.resetModules();
+    }
+  });
+
+  it("rejects an inherited window accessor without invoking it", async () => {
+    const prototype = Object.getPrototypeOf(globalThis);
+    if (prototype === null) {
+      throw new Error("Expected a global prototype");
+    }
+    const original = Object.getOwnPropertyDescriptor(
+      prototype,
+      "window",
+    );
+    let invoked = false;
+    Object.defineProperty(prototype, "window", {
+      configurable: true,
+      get() {
+        invoked = true;
+        return {};
+      },
+    });
+
+    try {
+      vi.resetModules();
+      const isolatedAdapter = await import(
+        "../node-sql-parser-adapter.js"
+      );
+      const isolatedSyntax = await import("../syntax.js");
+      const state = await isolatedSyntax.runSqlStatementParser(
+        isolatedAdapter.getPostgresqlNodeSqlStatementParser(),
+        isolatedSyntax.createSqlStatementParseRequest(
+          "SELECT 1",
+          new AbortController().signal,
+        ),
+      );
+
+      expect(state.analysis).toMatchObject({
+        reason: "backend-failure",
+        retryable: false,
+        status: "failed",
+      });
+      expect(invoked).toBe(false);
+    } finally {
+      if (original === undefined) {
+        Reflect.deleteProperty(prototype, "window");
+      } else {
+        Object.defineProperty(prototype, "window", original);
+      }
+      vi.resetModules();
+    }
+  });
+});

--- a/src/vnext/browser_tests/node-sql-parser-adapter.test.ts
+++ b/src/vnext/browser_tests/node-sql-parser-adapter.test.ts
@@ -1,0 +1,102 @@
+import { expect, test } from "vitest";
+import {
+  getBigQueryNodeSqlStatementParser,
+  getPostgresqlNodeSqlStatementParser,
+} from "../node-sql-parser-adapter.js";
+import {
+  createSqlStatementParseRequest,
+  runSqlStatementParser,
+  type SqlStatementParser,
+} from "../syntax.js";
+
+const parserGlobalKeys = ["NodeSQLParser", "global"] as const;
+
+function snapshotGlobals() {
+  return parserGlobalKeys.map((key) => ({
+    descriptor: Object.getOwnPropertyDescriptor(globalThis, key),
+    key,
+  }));
+}
+
+function restoreGlobals(
+  snapshots: ReturnType<typeof snapshotGlobals>,
+): void {
+  for (const { descriptor, key } of snapshots) {
+    if (descriptor === undefined) {
+      Reflect.deleteProperty(globalThis, key);
+    } else {
+      Object.defineProperty(globalThis, key, descriptor);
+    }
+  }
+}
+
+async function expectWindowRealmBlocked(
+  parser: SqlStatementParser,
+): Promise<void> {
+  const state = await runSqlStatementParser(
+    parser,
+    createSqlStatementParseRequest(
+      "SELECT 1 AS value",
+      new AbortController().signal,
+    ),
+  );
+  expect(state).toMatchObject({
+    analysis: {
+      reason: "backend-failure",
+      retryable: false,
+      status: "failed",
+    },
+    state: "analyzed",
+  });
+}
+
+test(
+  "window-realm dialect requests fail without mutating globals",
+  { timeout: 10_000 },
+  async () => {
+    const original = snapshotGlobals();
+    try {
+      const nodeSqlParserSentinel = Object.freeze({
+        owner: "consumer",
+      });
+      const nodeSqlParserDescriptor: PropertyDescriptor = {
+        configurable: true,
+        enumerable: false,
+        value: nodeSqlParserSentinel,
+        writable: true,
+      };
+      const globalDescriptor: PropertyDescriptor = {
+        configurable: true,
+        enumerable: true,
+        value: undefined,
+        writable: true,
+      };
+      Object.defineProperty(
+        globalThis,
+        "NodeSQLParser",
+        nodeSqlParserDescriptor,
+      );
+      Object.defineProperty(globalThis, "global", globalDescriptor);
+
+      await Promise.all([
+        expectWindowRealmBlocked(
+          getPostgresqlNodeSqlStatementParser(),
+        ),
+        expectWindowRealmBlocked(
+          getBigQueryNodeSqlStatementParser(),
+        ),
+      ]);
+      expect(
+        Object.getOwnPropertyDescriptor(
+          globalThis,
+          "NodeSQLParser",
+        ),
+      ).toStrictEqual(nodeSqlParserDescriptor);
+      expect(
+        Object.getOwnPropertyDescriptor(globalThis, "global"),
+      ).toStrictEqual(globalDescriptor);
+    } finally {
+      restoreGlobals(original);
+    }
+  },
+);

--- a/src/vnext/node-sql-parser-adapter.ts
+++ b/src/vnext/node-sql-parser-adapter.ts
@@ -1,0 +1,724 @@
+import {
+  createCompatibilityParsedAnalysis,
+  createFailedParserAnalysis,
+  createSqlDialectSyntaxIdentity,
+  createSqlParserAuthority,
+  createSqlStatementParser,
+  createSqlSyntaxArtifact,
+  createSqlSyntaxBackendIdentity,
+  createSqlSyntaxConfigurationIdentity,
+  createUnsupportedParserAnalysis,
+  MAX_SQL_SYNTAX_MESSAGE_INPUT_LENGTH,
+  type SqlCompatibilityLimitation,
+  type SqlParserAuthority,
+  type SqlStatementKind,
+  type SqlStatementParser,
+  type SqlSyntaxArtifact,
+  type SqlSyntaxBackendIdentity,
+} from "./syntax.js";
+
+export const MAX_NODE_SQL_PARSER_STATEMENT_LENGTH = 16 * 1024;
+
+const MAX_BACKEND_TYPE_LENGTH = 128;
+const NODE_SQL_PARSER_OPTIONS = Object.freeze({
+  parseOptions: Object.freeze({
+    includeLocations: true,
+  }),
+  trimQuery: false,
+});
+const TARGET_GRAMMAR_LIMITATIONS = Object.freeze([
+  "partial-artifact",
+] as const);
+const DIALECT_COMPATIBILITY_LIMITATIONS = Object.freeze([
+  "dialect-compatibility",
+  "partial-artifact",
+] as const);
+
+type NodeSqlParserPolicy =
+  | "dialect-compatibility"
+  | "target-grammar";
+
+interface NodeSqlParserBackend {
+  readonly astify: (statementText: string) => unknown;
+}
+
+type NodeSqlParserBackendLoader = () => Promise<NodeSqlParserBackend>;
+type NodeSqlParserModuleLoader = () => Promise<unknown>;
+
+interface NodeSqlParserRuntime {
+  readonly authority: SqlParserAuthority;
+  readonly limitations: readonly [
+    SqlCompatibilityLimitation,
+    ...SqlCompatibilityLimitation[],
+  ];
+  readonly loadBackend: NodeSqlParserBackendLoader;
+  readonly policy: NodeSqlParserPolicy;
+}
+
+type OwnDataProperty =
+  | {
+    readonly kind: "missing";
+  }
+  | {
+    readonly kind: "invalid";
+  }
+  | {
+    readonly kind: "value";
+    readonly value: unknown;
+  };
+
+type DecodedRoot =
+  | {
+    readonly kind: "malformed";
+  }
+  | {
+    readonly kind: "root";
+    readonly root: object;
+    readonly statementKind: SqlStatementKind;
+  }
+  | {
+    readonly kind: "unsupported";
+  };
+
+type DecodedParserError =
+  | "backend-failure"
+  | "malformed-output"
+  | "syntax-rejection";
+
+class NodeSqlParserModuleShapeError extends Error {}
+class NodeSqlParserInitializationError extends Error {}
+class NodeSqlParserGlobalCleanupError extends Error {}
+class NodeSqlParserExecutionRealmError extends Error {}
+
+const backendPayloads = new WeakMap<SqlSyntaxArtifact, object>();
+
+function isObjectLike(value: unknown): value is object {
+  return (
+    (typeof value === "object" && value !== null) ||
+    typeof value === "function"
+  );
+}
+
+function isRecordObject(value: unknown): value is object {
+  return typeof value === "object" && value !== null;
+}
+
+function readOwnDataProperty(
+  value: object,
+  key: PropertyKey,
+): OwnDataProperty {
+  let descriptor: PropertyDescriptor | undefined;
+  try {
+    descriptor = Object.getOwnPropertyDescriptor(value, key);
+  } catch {
+    return { kind: "invalid" };
+  }
+  if (descriptor === undefined) {
+    return { kind: "missing" };
+  }
+  if (!("value" in descriptor)) {
+    return { kind: "invalid" };
+  }
+  return {
+    kind: "value",
+    value: descriptor.value,
+  };
+}
+
+function readDataProperty(
+  value: object,
+  key: PropertyKey,
+): OwnDataProperty {
+  let candidate: object | null = value;
+  for (let depth = 0; candidate !== null && depth < 16; depth += 1) {
+    const property = readOwnDataProperty(candidate, key);
+    if (property.kind !== "missing") {
+      return property;
+    }
+    try {
+      candidate = Object.getPrototypeOf(candidate);
+    } catch {
+      return { kind: "invalid" };
+    }
+  }
+  return candidate === null
+    ? { kind: "missing" }
+    : { kind: "invalid" };
+}
+
+function readDataMethod(
+  value: object,
+  key: PropertyKey,
+): ((...arguments_: unknown[]) => unknown) | null {
+  let candidate: object | null = value;
+  for (let depth = 0; candidate !== null && depth < 16; depth += 1) {
+    const property = readOwnDataProperty(candidate, key);
+    if (property.kind === "invalid") {
+      return null;
+    }
+    if (property.kind === "value") {
+      if (typeof property.value !== "function") {
+        return null;
+      }
+      const method = property.value;
+      return (...arguments_: unknown[]) =>
+        Reflect.apply(method, value, arguments_);
+    }
+    try {
+      candidate = Object.getPrototypeOf(candidate);
+    } catch {
+      return null;
+    }
+  }
+  return null;
+}
+
+function moduleCandidates(moduleValue: unknown): readonly unknown[] {
+  if (!isObjectLike(moduleValue)) {
+    return [moduleValue];
+  }
+  const candidates: unknown[] = [moduleValue];
+  for (const key of ["default", "module.exports"] as const) {
+    const property = readOwnDataProperty(moduleValue, key);
+    if (property.kind === "value") {
+      candidates.push(property.value);
+    }
+  }
+  return candidates;
+}
+
+function findParserConstructor(moduleValue: unknown): unknown {
+  for (const candidate of moduleCandidates(moduleValue)) {
+    if (typeof candidate === "function") {
+      return candidate;
+    }
+    if (!isObjectLike(candidate)) {
+      continue;
+    }
+    const parser = readOwnDataProperty(candidate, "Parser");
+    if (parser.kind === "value" && typeof parser.value === "function") {
+      return parser.value;
+    }
+  }
+  return null;
+}
+
+function decodeBackendModule(moduleValue: unknown): NodeSqlParserBackend {
+  const Parser = findParserConstructor(moduleValue);
+  if (typeof Parser !== "function") {
+    throw new NodeSqlParserModuleShapeError();
+  }
+  let parser: object;
+  try {
+    parser = Reflect.construct(Parser, []);
+  } catch {
+    throw new NodeSqlParserInitializationError();
+  }
+  const astify = readDataMethod(parser, "astify");
+  if (astify === null) {
+    throw new NodeSqlParserModuleShapeError();
+  }
+  return Object.freeze({
+    astify(statementText: string): unknown {
+      return astify(statementText, NODE_SQL_PARSER_OPTIONS);
+    },
+  });
+}
+
+function createRetryingBackendLoader(
+  loadModule: NodeSqlParserModuleLoader,
+): NodeSqlParserBackendLoader {
+  let pending: Promise<NodeSqlParserBackend> | undefined;
+  return async () => {
+    if (pending === undefined) {
+      const current = Promise.resolve()
+        .then(loadModule)
+        .then(decodeBackendModule);
+      pending = current;
+      try {
+        return await current;
+      } catch (error: unknown) {
+        if (
+          !(error instanceof NodeSqlParserModuleShapeError) &&
+          !(error instanceof NodeSqlParserInitializationError) &&
+          !(error instanceof NodeSqlParserGlobalCleanupError) &&
+          !(error instanceof NodeSqlParserExecutionRealmError)
+        ) {
+          pending = undefined;
+        }
+        throw error;
+      }
+    }
+    return await pending;
+  };
+}
+
+const PARSER_GLOBAL_KEYS = ["NodeSQLParser", "global"] as const;
+
+type ParserGlobalSnapshots = readonly {
+  readonly descriptor: PropertyDescriptor | undefined;
+  readonly key: (typeof PARSER_GLOBAL_KEYS)[number];
+}[];
+
+function snapshotParserGlobals(target: object): ParserGlobalSnapshots {
+  try {
+    return PARSER_GLOBAL_KEYS.map((key) => ({
+      descriptor: Object.getOwnPropertyDescriptor(target, key),
+      key,
+    }));
+  } catch {
+    throw new NodeSqlParserGlobalCleanupError();
+  }
+}
+
+function restoreParserGlobals(
+  target: object,
+  snapshots: ParserGlobalSnapshots,
+): boolean {
+  let cleanupFailed = false;
+  for (const snapshot of snapshots) {
+    try {
+      if (snapshot.descriptor === undefined) {
+        if (!Reflect.deleteProperty(target, snapshot.key)) {
+          cleanupFailed = true;
+        }
+      } else {
+        Object.defineProperty(
+          target,
+          snapshot.key,
+          snapshot.descriptor,
+        );
+      }
+    } catch {
+      cleanupFailed = true;
+    }
+  }
+  return !cleanupFailed;
+}
+
+function createSynchronousModuleLoader(target: object) {
+  let poisoned = false;
+  return (loadModule: () => unknown): unknown => {
+    if (poisoned) {
+      throw new NodeSqlParserGlobalCleanupError();
+    }
+    let snapshots: ParserGlobalSnapshots;
+    try {
+      snapshots = snapshotParserGlobals(target);
+    } catch {
+      poisoned = true;
+      throw new NodeSqlParserGlobalCleanupError();
+    }
+    const outcome:
+      | { readonly kind: "failed"; readonly error: unknown }
+      | { readonly kind: "loaded"; readonly value: unknown } = (() => {
+        try {
+          return {
+            kind: "loaded",
+            value: loadModule(),
+          };
+        } catch (error: unknown) {
+          return {
+            error,
+            kind: "failed",
+          };
+        }
+      })();
+    if (!restoreParserGlobals(target, snapshots)) {
+      poisoned = true;
+      throw new NodeSqlParserGlobalCleanupError();
+    }
+    if (outcome.kind === "failed") {
+      throw outcome.error;
+    }
+    return outcome.value;
+  };
+}
+
+const loadNodeModuleSynchronously =
+  createSynchronousModuleLoader(globalThis);
+
+function rejectUnsupportedExecutionRealm(): void {
+  const windowAlias = readDataProperty(globalThis, "window");
+  const selfAlias = readDataProperty(globalThis, "self");
+  const globalAlias = readDataProperty(globalThis, "global");
+  if (
+    windowAlias.kind === "invalid" ||
+    (windowAlias.kind === "value" &&
+      windowAlias.value !== undefined) ||
+    selfAlias.kind === "invalid" ||
+    (selfAlias.kind === "value" &&
+      selfAlias.value !== undefined) ||
+    globalAlias.kind === "invalid" ||
+    globalAlias.kind !== "value" ||
+    globalAlias.value !== globalThis
+  ) {
+    throw new NodeSqlParserExecutionRealmError();
+  }
+}
+
+async function loadNodeSqlParserBuild(
+  specifier: string,
+): Promise<unknown> {
+  rejectUnsupportedExecutionRealm();
+  const { createRequire } = await import("node:module");
+  rejectUnsupportedExecutionRealm();
+  const require = createRequire(import.meta.url);
+  return loadNodeModuleSynchronously(
+    () => require(specifier),
+  );
+}
+
+function importPostgresqlBuild(): Promise<unknown> {
+  return loadNodeSqlParserBuild(
+    "node-sql-parser/build/postgresql.js",
+  );
+}
+
+function importBigQueryBuild(): Promise<unknown> {
+  return loadNodeSqlParserBuild(
+    "node-sql-parser/build/bigquery.js",
+  );
+}
+
+function mapStatementKind(backendType: string): SqlStatementKind {
+  switch (backendType.toLowerCase()) {
+    case "select":
+    case "union":
+      return "query";
+    case "insert":
+    case "replace":
+      return "insert";
+    case "update":
+      return "update";
+    case "delete":
+      return "delete";
+    case "create":
+      return "create";
+    case "alter":
+      return "alter";
+    case "drop":
+      return "drop";
+    case "merge":
+      return "merge";
+    case "transaction":
+      return "transaction";
+    default:
+      return "other";
+  }
+}
+
+function decodeRoot(value: unknown): DecodedRoot {
+  let root = value;
+  let rootIsArray: boolean;
+  try {
+    rootIsArray = Array.isArray(root);
+  } catch {
+    return { kind: "malformed" };
+  }
+  if (rootIsArray && isRecordObject(root)) {
+    const length = readOwnDataProperty(root, "length");
+    if (length.kind !== "value") {
+      return { kind: "malformed" };
+    }
+    if (length.value !== 1) {
+      return { kind: "unsupported" };
+    }
+    const first = readOwnDataProperty(root, 0);
+    if (first.kind !== "value") {
+      return { kind: "malformed" };
+    }
+    root = first.value;
+  }
+  if (!isRecordObject(root)) {
+    return { kind: "malformed" };
+  }
+  const type = readOwnDataProperty(root, "type");
+  if (
+    type.kind !== "value" ||
+    typeof type.value !== "string" ||
+    type.value.length === 0 ||
+    type.value.length > MAX_BACKEND_TYPE_LENGTH ||
+    type.value.trim() !== type.value
+  ) {
+    return { kind: "malformed" };
+  }
+  return {
+    kind: "root",
+    root,
+    statementKind: mapStatementKind(type.value),
+  };
+}
+
+function decodeSafeOffset(
+  value: unknown,
+  statementLength: number,
+): number | null {
+  if (
+    typeof value === "number" &&
+    Number.isSafeInteger(value) &&
+    value >= 0 &&
+    value <= statementLength
+  ) {
+    return value;
+  }
+  return null;
+}
+
+function decodeParserError(
+  error: unknown,
+  statementLength: number,
+): DecodedParserError {
+  if (!isObjectLike(error)) {
+    return "backend-failure";
+  }
+  const name = readOwnDataProperty(error, "name");
+  if (
+    name.kind !== "value" ||
+    name.value !== "SyntaxError"
+  ) {
+    return "backend-failure";
+  }
+  const message = readOwnDataProperty(error, "message");
+  const location = readOwnDataProperty(error, "location");
+  if (
+    message.kind !== "value" ||
+    typeof message.value !== "string" ||
+    message.value.trim().length === 0 ||
+    message.value.length > MAX_SQL_SYNTAX_MESSAGE_INPUT_LENGTH ||
+    location.kind !== "value" ||
+    !isRecordObject(location.value)
+  ) {
+    return "malformed-output";
+  }
+  const start = readOwnDataProperty(location.value, "start");
+  const end = readOwnDataProperty(location.value, "end");
+  if (
+    start.kind !== "value" ||
+    end.kind !== "value" ||
+    !isRecordObject(start.value) ||
+    !isRecordObject(end.value)
+  ) {
+    return "malformed-output";
+  }
+  const startOffset = readOwnDataProperty(start.value, "offset");
+  const endOffset = readOwnDataProperty(end.value, "offset");
+  if (
+    startOffset.kind !== "value" ||
+    endOffset.kind !== "value"
+  ) {
+    return "malformed-output";
+  }
+  const from = decodeSafeOffset(startOffset.value, statementLength);
+  const to = decodeSafeOffset(endOffset.value, statementLength);
+  if (from === null || to === null || from > to) {
+    return "malformed-output";
+  }
+  return "syntax-rejection";
+}
+
+function backendFailure(
+  authority: SqlParserAuthority,
+  statementText: string,
+  message: string,
+  retryable: boolean,
+) {
+  return createFailedParserAnalysis(
+    "backend-failure",
+    message,
+    retryable,
+    statementText,
+    authority,
+  );
+}
+
+function malformedOutput(
+  authority: SqlParserAuthority,
+  statementText: string,
+) {
+  return createFailedParserAnalysis(
+    "malformed-output",
+    "node-sql-parser returned malformed output",
+    false,
+    statementText,
+    authority,
+  );
+}
+
+function createAdapter(runtime: NodeSqlParserRuntime): SqlStatementParser {
+  return createSqlStatementParser(
+    runtime.authority,
+    async (request) => {
+      const { signal, text } = request;
+      if (text.length > MAX_NODE_SQL_PARSER_STATEMENT_LENGTH) {
+        return createUnsupportedParserAnalysis(
+          "resource-limit",
+          text,
+          runtime.authority,
+        );
+      }
+
+      signal.throwIfAborted();
+      let backend: NodeSqlParserBackend;
+      try {
+        backend = await runtime.loadBackend();
+      } catch (error: unknown) {
+        signal.throwIfAborted();
+        if (error instanceof NodeSqlParserModuleShapeError) {
+          return malformedOutput(runtime.authority, text);
+        }
+        if (
+          error instanceof NodeSqlParserInitializationError ||
+          error instanceof NodeSqlParserGlobalCleanupError ||
+          error instanceof NodeSqlParserExecutionRealmError
+        ) {
+          return backendFailure(
+            runtime.authority,
+            text,
+            "node-sql-parser backend failed",
+            false,
+          );
+        }
+        return backendFailure(
+          runtime.authority,
+          text,
+          "node-sql-parser failed to load",
+          true,
+        );
+      }
+      signal.throwIfAborted();
+
+      let output: unknown;
+      try {
+        output = backend.astify(text);
+      } catch (error: unknown) {
+        signal.throwIfAborted();
+        const decoded = decodeParserError(error, text.length);
+        if (decoded === "malformed-output") {
+          return malformedOutput(runtime.authority, text);
+        }
+        if (decoded === "syntax-rejection") {
+          return createUnsupportedParserAnalysis(
+            runtime.policy === "dialect-compatibility"
+              ? "compatibility-rejected"
+              : "uncovered-construct",
+            text,
+            runtime.authority,
+          );
+        }
+        return backendFailure(
+          runtime.authority,
+          text,
+          "node-sql-parser backend failed",
+          false,
+        );
+      }
+      signal.throwIfAborted();
+
+      const decoded = decodeRoot(output);
+      if (decoded.kind === "unsupported") {
+        return createUnsupportedParserAnalysis(
+          "uncovered-construct",
+          text,
+          runtime.authority,
+        );
+      }
+      if (decoded.kind === "malformed") {
+        return malformedOutput(runtime.authority, text);
+      }
+
+      const artifact = createSqlSyntaxArtifact(
+        decoded.statementKind,
+        text,
+        runtime.authority,
+      );
+      backendPayloads.set(artifact, decoded.root);
+      return createCompatibilityParsedAnalysis(
+        artifact,
+        runtime.limitations,
+      );
+    },
+  );
+}
+
+function createRuntime(
+  backendIdentity: SqlSyntaxBackendIdentity,
+  loadBackend: NodeSqlParserBackendLoader,
+  policy: NodeSqlParserPolicy,
+): NodeSqlParserRuntime {
+  const authority = createSqlParserAuthority(
+    backendIdentity,
+    createSqlSyntaxConfigurationIdentity(),
+    createSqlDialectSyntaxIdentity(),
+  );
+  return Object.freeze({
+    authority,
+    limitations:
+      policy === "dialect-compatibility"
+        ? DIALECT_COMPATIBILITY_LIMITATIONS
+        : TARGET_GRAMMAR_LIMITATIONS,
+    loadBackend,
+    policy,
+  });
+}
+
+const postgresqlBackendIdentity = createSqlSyntaxBackendIdentity();
+const bigQueryBackendIdentity = createSqlSyntaxBackendIdentity();
+const postgresqlBackend = createRetryingBackendLoader(
+  importPostgresqlBuild,
+);
+const bigQueryBackend = createRetryingBackendLoader(importBigQueryBuild);
+
+const postgresqlParser = createAdapter(
+  createRuntime(
+    postgresqlBackendIdentity,
+    postgresqlBackend,
+    "target-grammar",
+  ),
+);
+const bigQueryParser = createAdapter(
+  createRuntime(
+    bigQueryBackendIdentity,
+    bigQueryBackend,
+    "target-grammar",
+  ),
+);
+const duckDbParser = createAdapter(
+  createRuntime(
+    postgresqlBackendIdentity,
+    postgresqlBackend,
+    "dialect-compatibility",
+  ),
+);
+
+export function getPostgresqlNodeSqlStatementParser(): SqlStatementParser {
+  return postgresqlParser;
+}
+
+export function getBigQueryNodeSqlStatementParser(): SqlStatementParser {
+  return bigQueryParser;
+}
+
+export function getDuckDbCompatibilityNodeSqlStatementParser(): SqlStatementParser {
+  return duckDbParser;
+}
+
+export const exportedForTesting = Object.freeze({
+  createParser(
+    policy: NodeSqlParserPolicy,
+    loadModule: NodeSqlParserModuleLoader,
+  ): SqlStatementParser {
+    const backendIdentity = createSqlSyntaxBackendIdentity();
+    return createAdapter(
+      createRuntime(
+        backendIdentity,
+        createRetryingBackendLoader(loadModule),
+        policy,
+      ),
+    );
+  },
+  hasBackendPayload(artifact: SqlSyntaxArtifact): boolean {
+    return backendPayloads.has(artifact);
+  },
+  createSynchronousModuleLoader,
+});

--- a/state/artifacts/reports/pr-177-spelling-ci.md
+++ b/state/artifacts/reports/pr-177-spelling-ci.md
@@ -2,9 +2,9 @@
 
 ## Root cause
 
-The adapter rejection tests used `SELEC 1` as deliberately invalid SQL. The
-repository spelling check correctly flagged `SELEC` even though it was test
-data.
+The adapter rejection tests used a misspelled SQL keyword as deliberately
+invalid SQL. The repository spelling check correctly flagged it even though it
+was test data.
 
 ## Resolution
 

--- a/state/artifacts/reports/pr-177-spelling-ci.md
+++ b/state/artifacts/reports/pr-177-spelling-ci.md
@@ -1,0 +1,25 @@
+# PR #177 spelling CI regression
+
+## Root cause
+
+The adapter rejection tests used `SELEC 1` as deliberately invalid SQL. The
+repository spelling check correctly flagged `SELEC` even though it was test
+data.
+
+## Resolution
+
+The fixtures now use the correctly spelled but syntactically invalid
+`SELECT FROM`. This preserves the rejection-path coverage without broadening
+the spelling allowlist.
+
+## Verification
+
+- Focused node-sql-parser adapter tests
+- vNext test typecheck
+- Lint and repository integrity checks
+- `git diff --check`
+
+## Follow-up
+
+Prefer malformed grammar over misspelled keywords for parser rejection
+fixtures unless a spelling error is itself the behavior under test.


### PR DESCRIPTION
## Summary
- add an internal normalized node-sql-parser adapter for PostgreSQL, BigQuery, and DuckDB compatibility evidence
- pin node-sql-parser 5.4.0 and load only dialect-specific builds through a race-safe pure-Node loader
- keep all successful evidence non-conformant, retain ASTs privately, and fail closed in browser/worker/DOM-shim realms pending dedicated-worker support
- document the evidence, execution, resource, packaging, and global-cleanup boundaries in ADR 0003
- add adversarial unit/browser coverage and validated warm parser benchmarks

## Correctness policy
- PostgreSQL/BigQuery acceptance: parsed/compatibility with partial-artifact
- PostgreSQL/BigQuery rejection: unsupported/uncovered-construct, never invalid
- DuckDB acceptance: parsed/compatibility with dialect-compatibility + partial-artifact
- DuckDB rejection: unsupported/compatibility-rejected
- Dremio: no adapter

## Validation
- 971 tests passed, 1 expected failure
- changed coverage: 99.13% statements, 99.35% branches, 100% functions, 99.12% lines
- full strict typecheck and non-mutating lint
- Chromium browser suite
- isolated package smoke and demo build
- test integrity check
- preflight-validated parser benchmark
- two independent adversarial review loops approved the final exact tree

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an internal `node-sql-parser` adapter for PostgreSQL and BigQuery with a DuckDB compatibility path that returns small, private artifacts under strict bounds and pure-Node loading. Also fixes and documents a test spelling false positive, and keeps the CI report spelling-clean.

- **New Features**
  - Evidence policy: PostgreSQL/BigQuery accept -> parsed/compatibility (partial); reject -> unsupported/uncovered-construct. DuckDB uses the PostgreSQL build: accept -> parsed/compatibility (dialect-compatibility, partial); reject -> unsupported/compatibility-rejected.
  - Bounded artifacts: only statement kind + full range; backend ASTs kept private.
  - Resource/placement: 16 KiB statement limit; synchronous parse; cancellation checked before/after load and after parse; not wired to sessions.
  - Execution realm safety: pure Node only with race-safe loader and global cleanup; fails closed in window/worker/DOM-shim realms.
  - Docs and tests: added ADR 0003, linked ADR 0002, and a vNext adapter doc; Node and browser tests plus a warm parser benchmark and `bench:parser-adapter` script; fixed spelling CI false positive and kept `state/artifacts/reports/pr-177-spelling-ci.md` spelling-clean.

- **Dependencies**
  - Pin `node-sql-parser` to `5.4.0` and load only `build/postgresql.js` and `build/bigquery.js`.

<sup>Written for commit 254362469573211dac7783331b67b156c299be6c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marimo-team/codemirror-sql/pull/177?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

