### PR TITLE
refactor(vnext): extract realm-neutral parser backend

### DIFF
--- a/docs/vnext/node-sql-parser-adapter.md
+++ b/docs/vnext/node-sql-parser-adapter.md
@@ -45,6 +45,14 @@ statement slice. Locations remain partial: PostgreSQL commonly omits root and
 identifier locations, while BigQuery provides broader but still incomplete
 coverage.
 
+Module-shape decoding, parser invocation, result validation, and error
+normalization live in a realm-neutral internal backend engine. That engine has
+no Node, browser-window, or worker dependency. The Node adapter remains
+responsible for realm validation, module loading, cleanup, parser authority,
+and private AST ownership. A browser worker can therefore reuse the same
+backend semantics without importing Node globals or weakening main-realm
+artifact authenticity.
+
 Loading the distributed bundles may write `NodeSQLParser` or `global` on a
 global object. The adapter rejects parser loads whenever `window` or `self`
 exists, or `global` does not resolve exactly to `globalThis`, before loading a

--- a/src/vnext/__tests__/node-sql-parser-backend.test.ts
+++ b/src/vnext/__tests__/node-sql-parser-backend.test.ts
@@ -1,0 +1,775 @@
+// @vitest-environment node
+
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import {
+  createNodeSqlParserBackend,
+  MAX_NODE_SQL_PARSER_STATEMENT_LENGTH,
+  type NodeSqlParserModuleLoadOutcome,
+} from "../node-sql-parser-backend.js";
+
+type ModuleShape =
+  | "constructor"
+  | "default-constructor"
+  | "default-named"
+  | "module-exports"
+  | "named";
+
+function loaded(moduleValue: unknown): NodeSqlParserModuleLoadOutcome {
+  return {
+    kind: "loaded",
+    moduleValue,
+  };
+}
+
+function createBackendModule(
+  astify: (statementText: string, options: unknown) => unknown,
+  shape: ModuleShape = "named",
+): unknown {
+  class Parser {
+    astify(statementText: string, options: unknown): unknown {
+      return astify(statementText, options);
+    }
+  }
+
+  switch (shape) {
+    case "constructor":
+      return Parser;
+    case "default-constructor":
+      return { default: Parser };
+    case "default-named":
+      return { default: { Parser } };
+    case "module-exports":
+      return { "module.exports": { Parser } };
+    case "named":
+      return { Parser };
+  }
+}
+
+function syntaxError(
+  message: string,
+  from: number,
+  to: number,
+): object {
+  return {
+    location: {
+      end: { offset: to },
+      start: { offset: from },
+    },
+    message,
+    name: "SyntaxError",
+  };
+}
+
+function backendFor(
+  astify: (statementText: string, options: unknown) => unknown,
+  shape: ModuleShape = "named",
+) {
+  return createNodeSqlParserBackend(async () =>
+    loaded(createBackendModule(astify, shape)),
+  );
+}
+
+describe("realm-neutral node-sql-parser backend", () => {
+  it.each([
+    ["select", "query"],
+    ["UNION", "query"],
+    ["insert", "insert"],
+    ["replace", "insert"],
+    ["update", "update"],
+    ["delete", "delete"],
+    ["create", "create"],
+    ["alter", "alter"],
+    ["drop", "drop"],
+    ["merge", "merge"],
+    ["transaction", "transaction"],
+    ["truncate", "other"],
+  ] as const)("maps backend type %s to %s", async (type, expected) => {
+    const root = { type };
+    const backend = backendFor(() => root);
+
+    const outcome = await backend.parse("SELECT 1");
+
+    expect(outcome).toStrictEqual({
+      kind: "parsed",
+      root,
+      statementKind: expected,
+    });
+    expect(Object.isFrozen(outcome)).toBe(true);
+    expect(Object.isFrozen(backend)).toBe(true);
+  });
+
+  it("passes exact source and immutable location-preserving options", async () => {
+    const source = "  SELECT 1\nFROM users";
+    let receivedSource: string | undefined;
+    let receivedOptions: unknown;
+    const backend = backendFor((statementText, options) => {
+      receivedSource = statementText;
+      receivedOptions = options;
+      return { type: "select" };
+    });
+
+    await backend.parse(source);
+
+    expect(receivedSource).toBe(source);
+    expect(receivedOptions).toStrictEqual({
+      parseOptions: { includeLocations: true },
+      trimQuery: false,
+    });
+    expect(Object.isFrozen(receivedOptions)).toBe(true);
+    expect(
+      Object.isFrozen(
+        (receivedOptions as { parseOptions: object }).parseOptions,
+      ),
+    ).toBe(true);
+  });
+
+  it.each([
+    "constructor",
+    "default-constructor",
+    "default-named",
+    "module-exports",
+    "named",
+  ] as const)("accepts the %s module shape", async (shape) => {
+    const backend = backendFor(
+      () => ({ type: "select" }),
+      shape,
+    );
+
+    await expect(backend.parse("SELECT 1")).resolves.toMatchObject({
+      kind: "parsed",
+      statementKind: "query",
+    });
+  });
+
+  it("does not load or checkpoint oversized input", async () => {
+    let loads = 0;
+    let checkpoints = 0;
+    const backend = createNodeSqlParserBackend(async () => {
+      loads += 1;
+      return loaded(
+        createBackendModule(() => ({ type: "select" })),
+      );
+    });
+
+    const outcome = await backend.parse(
+      "x".repeat(MAX_NODE_SQL_PARSER_STATEMENT_LENGTH + 1),
+      () => {
+        checkpoints += 1;
+      },
+    );
+
+    expect(outcome).toStrictEqual({
+      kind: "unsupported",
+      reason: "resource-limit",
+    });
+    expect(loads).toBe(0);
+    expect(checkpoints).toBe(0);
+  });
+
+  it("accepts the exact input boundary", async () => {
+    let calls = 0;
+    const backend = backendFor(() => {
+      calls += 1;
+      return { type: "select" };
+    });
+
+    const outcome = await backend.parse(
+      "x".repeat(MAX_NODE_SQL_PARSER_STATEMENT_LENGTH),
+    );
+
+    expect(outcome).toMatchObject({ kind: "parsed" });
+    expect(calls).toBe(1);
+  });
+
+  it("runs checkpoints before load, after load, and after astify", async () => {
+    const events: string[] = [];
+    let checkpoints = 0;
+    const backend = createNodeSqlParserBackend(async () => {
+      events.push("load");
+      return loaded(
+        createBackendModule(() => {
+          events.push("astify");
+          return { type: "select" };
+        }),
+      );
+    });
+
+    await backend.parse("SELECT 1", () => {
+      checkpoints += 1;
+      events.push(`checkpoint-${checkpoints}`);
+    });
+
+    expect(events).toStrictEqual([
+      "checkpoint-1",
+      "load",
+      "checkpoint-2",
+      "astify",
+      "checkpoint-3",
+    ]);
+  });
+
+  it("propagates the exact checkpoint error before loading", async () => {
+    const reason = Object.freeze({ checkpoint: "before-load" });
+    let loads = 0;
+    const backend = createNodeSqlParserBackend(async () => {
+      loads += 1;
+      return loaded({});
+    });
+
+    await expect(
+      backend.parse("SELECT 1", () => {
+        throw reason;
+      }),
+    ).rejects.toBe(reason);
+    expect(loads).toBe(0);
+  });
+
+  it("propagates the exact checkpoint error after loading", async () => {
+    const reason = Object.freeze({ checkpoint: "after-load" });
+    let checkpoints = 0;
+    let astifyCalls = 0;
+    const backend = backendFor(() => {
+      astifyCalls += 1;
+      return { type: "select" };
+    });
+
+    await expect(
+      backend.parse("SELECT 1", () => {
+        checkpoints += 1;
+        if (checkpoints === 2) {
+          throw reason;
+        }
+      }),
+    ).rejects.toBe(reason);
+    expect(astifyCalls).toBe(0);
+
+    await expect(backend.parse("SELECT 1")).resolves.toMatchObject({
+      kind: "parsed",
+    });
+    expect(astifyCalls).toBe(1);
+  });
+
+  it("propagates the exact checkpoint error after astify", async () => {
+    const reason = Object.freeze({ checkpoint: "after-astify" });
+    let checkpoints = 0;
+    let astifyCalls = 0;
+    const backend = backendFor(() => {
+      astifyCalls += 1;
+      return { type: "select" };
+    });
+
+    await expect(
+      backend.parse("SELECT 1", () => {
+        checkpoints += 1;
+        if (checkpoints === 3) {
+          throw reason;
+        }
+      }),
+    ).rejects.toBe(reason);
+    expect(astifyCalls).toBe(1);
+  });
+
+  it("checks cancellation after a throwing astify before classifying it", async () => {
+    const backendError = new Error("private backend failure");
+    const checkpointError = Object.freeze({
+      checkpoint: "after-throw",
+    });
+    let checkpoints = 0;
+    const backend = backendFor(() => {
+      throw backendError;
+    });
+
+    await expect(
+      backend.parse("SELECT 1", () => {
+        checkpoints += 1;
+        if (checkpoints === 3) {
+          throw checkpointError;
+        }
+      }),
+    ).rejects.toBe(checkpointError);
+  });
+});
+
+describe("node-sql-parser backend loading", () => {
+  it("deduplicates concurrent module loads", async () => {
+    let release: (() => void) | undefined;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    let loads = 0;
+    const backend = createNodeSqlParserBackend(async () => {
+      loads += 1;
+      await gate;
+      return loaded(
+        createBackendModule(() => ({ type: "select" })),
+      );
+    });
+
+    const first = backend.parse("SELECT 1");
+    const second = backend.parse("SELECT 2");
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(loads).toBe(1);
+    if (release === undefined) {
+      throw new Error("Load gate was not initialized");
+    }
+    release();
+
+    await expect(first).resolves.toMatchObject({ kind: "parsed" });
+    await expect(second).resolves.toMatchObject({ kind: "parsed" });
+    expect(loads).toBe(1);
+  });
+
+  it("clears a retryable failed load", async () => {
+    let loads = 0;
+    const backend = createNodeSqlParserBackend(async () => {
+      loads += 1;
+      if (loads === 1) {
+        return {
+          code: "module-load",
+          kind: "failed",
+          retryable: true,
+        };
+      }
+      return loaded(
+        createBackendModule(() => ({ type: "select" })),
+      );
+    });
+
+    await expect(backend.parse("SELECT 1")).resolves.toStrictEqual({
+      code: "module-load",
+      kind: "failed",
+      retryable: true,
+    });
+    await expect(backend.parse("SELECT 1")).resolves.toMatchObject({
+      kind: "parsed",
+    });
+    expect(loads).toBe(2);
+  });
+
+  it("caches a non-retryable failed load", async () => {
+    let loads = 0;
+    const backend = createNodeSqlParserBackend(async () => {
+      loads += 1;
+      return {
+        code: "backend",
+        kind: "failed",
+        retryable: false,
+      };
+    });
+
+    const expected = {
+      code: "backend",
+      kind: "failed",
+      retryable: false,
+    };
+    await expect(backend.parse("SELECT 1")).resolves.toStrictEqual(
+      expected,
+    );
+    await expect(backend.parse("SELECT 2")).resolves.toStrictEqual(
+      expected,
+    );
+    expect(loads).toBe(1);
+  });
+
+  it("normalizes a rejected loader and permits retry", async () => {
+    let loads = 0;
+    const backend = createNodeSqlParserBackend(async () => {
+      loads += 1;
+      if (loads === 1) {
+        throw new Error("private load rejection");
+      }
+      return loaded(
+        createBackendModule(() => ({ type: "select" })),
+      );
+    });
+
+    await expect(backend.parse("SELECT 1")).resolves.toStrictEqual({
+      code: "module-load",
+      kind: "failed",
+      retryable: true,
+    });
+    await expect(backend.parse("SELECT 1")).resolves.toMatchObject({
+      kind: "parsed",
+    });
+    expect(loads).toBe(2);
+  });
+
+  it.each([
+    null,
+    {},
+    { Parser: null },
+    { Parser: class MissingAstify {} },
+    {
+      Parser: class InvalidAstify {
+        readonly astify = "not callable";
+      },
+    },
+  ])("caches malformed module shape %#", async (moduleValue) => {
+    let loads = 0;
+    const backend = createNodeSqlParserBackend(async () => {
+      loads += 1;
+      return loaded(moduleValue);
+    });
+
+    const expected = {
+      code: "malformed-output",
+      kind: "failed",
+      retryable: false,
+    };
+    await expect(backend.parse("SELECT 1")).resolves.toStrictEqual(
+      expected,
+    );
+    await expect(backend.parse("SELECT 2")).resolves.toStrictEqual(
+      expected,
+    );
+    expect(loads).toBe(1);
+  });
+
+  it("caches a constructor failure without leaking it", async () => {
+    let constructions = 0;
+    class Parser {
+      constructor() {
+        constructions += 1;
+        throw new Error("private constructor detail");
+      }
+    }
+    const backend = createNodeSqlParserBackend(async () =>
+      loaded({ Parser }),
+    );
+
+    const first = await backend.parse("SELECT 1");
+    const second = await backend.parse("SELECT 2");
+
+    expect(first).toStrictEqual({
+      code: "backend",
+      kind: "failed",
+      retryable: false,
+    });
+    expect(second).toStrictEqual(first);
+    expect(JSON.stringify(first)).not.toContain("private");
+    expect(constructions).toBe(1);
+  });
+
+  it("does not invoke accessor-backed module or astify properties", async () => {
+    let moduleAccessorInvoked = false;
+    const moduleValue = {};
+    Object.defineProperty(moduleValue, "Parser", {
+      get() {
+        moduleAccessorInvoked = true;
+        throw new Error("private module accessor");
+      },
+    });
+    const moduleBackend = createNodeSqlParserBackend(async () =>
+      loaded(moduleValue),
+    );
+
+    await expect(
+      moduleBackend.parse("SELECT 1"),
+    ).resolves.toMatchObject({
+      code: "malformed-output",
+      kind: "failed",
+    });
+    expect(moduleAccessorInvoked).toBe(false);
+
+    let astifyAccessorInvoked = false;
+    class Parser {
+      get astify(): never {
+        astifyAccessorInvoked = true;
+        throw new Error("private astify accessor");
+      }
+    }
+    const astifyBackend = createNodeSqlParserBackend(async () =>
+      loaded({ Parser }),
+    );
+
+    await expect(
+      astifyBackend.parse("SELECT 1"),
+    ).resolves.toMatchObject({
+      code: "malformed-output",
+      kind: "failed",
+    });
+    expect(astifyAccessorInvoked).toBe(false);
+  });
+
+  it("normalizes a prototype-trapping parser", async () => {
+    const parser = new Proxy(
+      {},
+      {
+        getPrototypeOf() {
+          throw new Error("private prototype trap");
+        },
+      },
+    );
+    function Parser(): object {
+      return parser;
+    }
+    const backend = createNodeSqlParserBackend(async () =>
+      loaded({ Parser }),
+    );
+
+    const outcome = await backend.parse("SELECT 1");
+
+    expect(outcome).toStrictEqual({
+      code: "malformed-output",
+      kind: "failed",
+      retryable: false,
+    });
+    expect(JSON.stringify(outcome)).not.toContain("private");
+  });
+});
+
+describe("node-sql-parser backend output decoding", () => {
+  it("accepts a one-element AST array", async () => {
+    const root = { type: "select" };
+    const backend = backendFor(() => [root]);
+
+    await expect(backend.parse("SELECT 1")).resolves.toStrictEqual({
+      kind: "parsed",
+      root,
+      statementKind: "query",
+    });
+  });
+
+  it.each([
+    [[]],
+    [[{ type: "select" }, { type: "select" }]],
+  ] as const)(
+    "classifies AST array %# as multiple statements",
+    async (root) => {
+      const backend = backendFor(() => root);
+
+      await expect(backend.parse("SELECT 1")).resolves.toStrictEqual({
+        kind: "unsupported",
+        reason: "multiple-statements",
+      });
+    },
+  );
+
+  it.each([
+    null,
+    undefined,
+    1,
+    "select",
+    {},
+    { type: "" },
+    { type: " select" },
+    { type: "select " },
+    { type: "x".repeat(129) },
+    [null],
+    Array(1),
+  ])("rejects malformed root %#", async (root) => {
+    const backend = backendFor(() => root);
+
+    await expect(backend.parse("SELECT 1")).resolves.toStrictEqual({
+      code: "malformed-output",
+      kind: "failed",
+      retryable: false,
+    });
+  });
+
+  it("does not invoke an accessor-backed root type", async () => {
+    let invoked = false;
+    const root = {};
+    Object.defineProperty(root, "type", {
+      get() {
+        invoked = true;
+        throw new Error("private type accessor");
+      },
+    });
+    const backend = backendFor(() => root);
+
+    const outcome = await backend.parse("SELECT 1");
+
+    expect(outcome).toMatchObject({
+      code: "malformed-output",
+      kind: "failed",
+    });
+    expect(invoked).toBe(false);
+  });
+
+  it("normalizes descriptor-trapping and revoked roots", async () => {
+    const descriptorTrap = new Proxy(
+      { type: "select" },
+      {
+        getOwnPropertyDescriptor() {
+          throw new Error("private descriptor trap");
+        },
+      },
+    );
+    const revoked = Proxy.revocable({ type: "select" }, {});
+    revoked.revoke();
+
+    for (const root of [descriptorTrap, revoked.proxy]) {
+      const outcome = await backendFor(() => root).parse("SELECT 1");
+      expect(outcome).toStrictEqual({
+        code: "malformed-output",
+        kind: "failed",
+        retryable: false,
+      });
+      expect(JSON.stringify(outcome)).not.toContain("private");
+    }
+  });
+
+  it("rejects a callable AST root", async () => {
+    function root(): void {
+      // Backend AST roots are data.
+    }
+    Object.defineProperty(root, "type", {
+      value: "select",
+    });
+
+    await expect(
+      backendFor(() => root).parse("SELECT 1"),
+    ).resolves.toStrictEqual({
+      code: "malformed-output",
+      kind: "failed",
+      retryable: false,
+    });
+  });
+});
+
+describe("node-sql-parser backend error decoding", () => {
+  it("classifies a bounded SyntaxError without exposing its message", async () => {
+    const backend = backendFor(() => {
+      throw syntaxError("private syntax detail", 0, 1);
+    });
+
+    const outcome = await backend.parse("SELECT 1");
+
+    expect(outcome).toStrictEqual({ kind: "syntax-rejected" });
+    expect(JSON.stringify(outcome)).not.toContain("private");
+  });
+
+  it.each([
+    { location: null, message: "bad", name: "SyntaxError" },
+    { location: {}, message: "bad", name: "SyntaxError" },
+    {
+      location: { end: { offset: 1 }, start: { offset: -1 } },
+      message: "bad",
+      name: "SyntaxError",
+    },
+    {
+      location: { end: { offset: 1 }, start: { offset: 2 } },
+      message: "bad",
+      name: "SyntaxError",
+    },
+    {
+      location: { end: { offset: 9 }, start: { offset: 0 } },
+      message: "bad",
+      name: "SyntaxError",
+    },
+    {
+      location: { end: { offset: 1.5 }, start: { offset: 0 } },
+      message: "bad",
+      name: "SyntaxError",
+    },
+    {
+      location: { end: {}, start: { offset: 0 } },
+      message: "bad",
+      name: "SyntaxError",
+    },
+    syntaxError("", 0, 1),
+    syntaxError("x".repeat(8_193), 0, 1),
+  ])("rejects malformed SyntaxError %#", async (error) => {
+    const backend = backendFor(() => {
+      throw error;
+    });
+
+    await expect(backend.parse("SELECT 1")).resolves.toStrictEqual({
+      code: "malformed-output",
+      kind: "failed",
+      retryable: false,
+    });
+  });
+
+  it("does not invoke accessor-backed SyntaxError fields", async () => {
+    let invoked = false;
+    const error = {
+      message: "bad",
+      name: "SyntaxError",
+    };
+    Object.defineProperty(error, "location", {
+      get() {
+        invoked = true;
+        throw new Error("private location accessor");
+      },
+    });
+    const backend = backendFor(() => {
+      throw error;
+    });
+
+    const outcome = await backend.parse("SELECT 1");
+
+    expect(outcome).toMatchObject({
+      code: "malformed-output",
+      kind: "failed",
+    });
+    expect(invoked).toBe(false);
+  });
+
+  it.each([
+    new Error("private backend stack and message"),
+    "private primitive rejection",
+    null,
+  ])("normalizes backend failure %#", async (error) => {
+    const backend = backendFor(() => {
+      throw error;
+    });
+
+    const outcome = await backend.parse("SELECT 1");
+
+    expect(outcome).toStrictEqual({
+      code: "backend",
+      kind: "failed",
+      retryable: false,
+    });
+    expect(JSON.stringify(outcome)).not.toContain("private");
+  });
+});
+
+describe("node-sql-parser backend ambient boundary", () => {
+  it("does not reference environment-specific globals or modules", () => {
+    const source = readFileSync(
+      new URL("../node-sql-parser-backend.ts", import.meta.url),
+      "utf8",
+    );
+
+    expect(source).not.toMatch(
+      /\b(?:globalThis|window|self|Worker)\b|node:module/,
+    );
+  });
+
+  it("parses while ambient realm getters throw", async () => {
+    const keys = ["window", "self", "Worker"] as const;
+    const snapshots = keys.map((key) => ({
+      descriptor: Object.getOwnPropertyDescriptor(globalThis, key),
+      key,
+    }));
+    try {
+      for (const key of keys) {
+        Object.defineProperty(globalThis, key, {
+          configurable: true,
+          get() {
+            throw new Error(`Backend read ambient ${key}`);
+          },
+        });
+      }
+      const backend = backendFor(() => ({ type: "select" }));
+
+      await expect(backend.parse("SELECT 1")).resolves.toMatchObject({
+        kind: "parsed",
+        statementKind: "query",
+      });
+    } finally {
+      for (const { descriptor, key } of snapshots) {
+        if (descriptor === undefined) {
+          Reflect.deleteProperty(globalThis, key);
+        } else {
+          Object.defineProperty(globalThis, key, descriptor);
+        }
+      }
+    }
+  });
+});

--- a/src/vnext/__tests__/node-sql-parser-backend.test.ts
+++ b/src/vnext/__tests__/node-sql-parser-backend.test.ts
@@ -569,6 +569,32 @@ describe("node-sql-parser backend output decoding", () => {
     });
   });
 
+  it.each(["1", Number.NaN, -1, 1.5, Number.MAX_SAFE_INTEGER + 1])(
+    "rejects an array with a spoofed length descriptor %#",
+    async (length) => {
+      const root = new Proxy([{ type: "select" }], {
+        getOwnPropertyDescriptor(target, key) {
+          if (key === "length") {
+            return {
+              configurable: false,
+              enumerable: false,
+              value: length,
+              writable: true,
+            };
+          }
+          return Reflect.getOwnPropertyDescriptor(target, key);
+        },
+      });
+      const backend = backendFor(() => root);
+
+      await expect(backend.parse("SELECT 1")).resolves.toStrictEqual({
+        code: "malformed-output",
+        kind: "failed",
+        retryable: false,
+      });
+    },
+  );
+
   it("does not invoke an accessor-backed root type", async () => {
     let invoked = false;
     const root = {};

--- a/src/vnext/node-sql-parser-adapter.ts
+++ b/src/vnext/node-sql-parser-adapter.ts
@@ -1,4 +1,11 @@
 import {
+  createNodeSqlParserBackend,
+  type NodeSqlParserBackend,
+  type NodeSqlParserBackendOutcome,
+  type NodeSqlParserModuleLoadOutcome,
+  type NodeSqlParserModuleLoader,
+} from "./node-sql-parser-backend.js";
+import {
   createCompatibilityParsedAnalysis,
   createFailedParserAnalysis,
   createSqlDialectSyntaxIdentity,
@@ -8,24 +15,15 @@ import {
   createSqlSyntaxBackendIdentity,
   createSqlSyntaxConfigurationIdentity,
   createUnsupportedParserAnalysis,
-  MAX_SQL_SYNTAX_MESSAGE_INPUT_LENGTH,
   type SqlCompatibilityLimitation,
   type SqlParserAuthority,
-  type SqlStatementKind,
   type SqlStatementParser,
   type SqlSyntaxArtifact,
   type SqlSyntaxBackendIdentity,
 } from "./syntax.js";
 
-export const MAX_NODE_SQL_PARSER_STATEMENT_LENGTH = 16 * 1024;
+export { MAX_NODE_SQL_PARSER_STATEMENT_LENGTH } from "./node-sql-parser-backend.js";
 
-const MAX_BACKEND_TYPE_LENGTH = 128;
-const NODE_SQL_PARSER_OPTIONS = Object.freeze({
-  parseOptions: Object.freeze({
-    includeLocations: true,
-  }),
-  trimQuery: false,
-});
 const TARGET_GRAMMAR_LIMITATIONS = Object.freeze([
   "partial-artifact",
 ] as const);
@@ -38,20 +36,13 @@ type NodeSqlParserPolicy =
   | "dialect-compatibility"
   | "target-grammar";
 
-interface NodeSqlParserBackend {
-  readonly astify: (statementText: string) => unknown;
-}
-
-type NodeSqlParserBackendLoader = () => Promise<NodeSqlParserBackend>;
-type NodeSqlParserModuleLoader = () => Promise<unknown>;
-
 interface NodeSqlParserRuntime {
   readonly authority: SqlParserAuthority;
+  readonly backend: NodeSqlParserBackend;
   readonly limitations: readonly [
     SqlCompatibilityLimitation,
     ...SqlCompatibilityLimitation[],
   ];
-  readonly loadBackend: NodeSqlParserBackendLoader;
   readonly policy: NodeSqlParserPolicy;
 }
 
@@ -67,41 +58,10 @@ type OwnDataProperty =
     readonly value: unknown;
   };
 
-type DecodedRoot =
-  | {
-    readonly kind: "malformed";
-  }
-  | {
-    readonly kind: "root";
-    readonly root: object;
-    readonly statementKind: SqlStatementKind;
-  }
-  | {
-    readonly kind: "unsupported";
-  };
-
-type DecodedParserError =
-  | "backend-failure"
-  | "malformed-output"
-  | "syntax-rejection";
-
-class NodeSqlParserModuleShapeError extends Error {}
-class NodeSqlParserInitializationError extends Error {}
 class NodeSqlParserGlobalCleanupError extends Error {}
 class NodeSqlParserExecutionRealmError extends Error {}
 
 const backendPayloads = new WeakMap<SqlSyntaxArtifact, object>();
-
-function isObjectLike(value: unknown): value is object {
-  return (
-    (typeof value === "object" && value !== null) ||
-    typeof value === "function"
-  );
-}
-
-function isRecordObject(value: unknown): value is object {
-  return typeof value === "object" && value !== null;
-}
 
 function readOwnDataProperty(
   value: object,
@@ -144,113 +104,6 @@ function readDataProperty(
   return candidate === null
     ? { kind: "missing" }
     : { kind: "invalid" };
-}
-
-function readDataMethod(
-  value: object,
-  key: PropertyKey,
-): ((...arguments_: unknown[]) => unknown) | null {
-  let candidate: object | null = value;
-  for (let depth = 0; candidate !== null && depth < 16; depth += 1) {
-    const property = readOwnDataProperty(candidate, key);
-    if (property.kind === "invalid") {
-      return null;
-    }
-    if (property.kind === "value") {
-      if (typeof property.value !== "function") {
-        return null;
-      }
-      const method = property.value;
-      return (...arguments_: unknown[]) =>
-        Reflect.apply(method, value, arguments_);
-    }
-    try {
-      candidate = Object.getPrototypeOf(candidate);
-    } catch {
-      return null;
-    }
-  }
-  return null;
-}
-
-function moduleCandidates(moduleValue: unknown): readonly unknown[] {
-  if (!isObjectLike(moduleValue)) {
-    return [moduleValue];
-  }
-  const candidates: unknown[] = [moduleValue];
-  for (const key of ["default", "module.exports"] as const) {
-    const property = readOwnDataProperty(moduleValue, key);
-    if (property.kind === "value") {
-      candidates.push(property.value);
-    }
-  }
-  return candidates;
-}
-
-function findParserConstructor(moduleValue: unknown): unknown {
-  for (const candidate of moduleCandidates(moduleValue)) {
-    if (typeof candidate === "function") {
-      return candidate;
-    }
-    if (!isObjectLike(candidate)) {
-      continue;
-    }
-    const parser = readOwnDataProperty(candidate, "Parser");
-    if (parser.kind === "value" && typeof parser.value === "function") {
-      return parser.value;
-    }
-  }
-  return null;
-}
-
-function decodeBackendModule(moduleValue: unknown): NodeSqlParserBackend {
-  const Parser = findParserConstructor(moduleValue);
-  if (typeof Parser !== "function") {
-    throw new NodeSqlParserModuleShapeError();
-  }
-  let parser: object;
-  try {
-    parser = Reflect.construct(Parser, []);
-  } catch {
-    throw new NodeSqlParserInitializationError();
-  }
-  const astify = readDataMethod(parser, "astify");
-  if (astify === null) {
-    throw new NodeSqlParserModuleShapeError();
-  }
-  return Object.freeze({
-    astify(statementText: string): unknown {
-      return astify(statementText, NODE_SQL_PARSER_OPTIONS);
-    },
-  });
-}
-
-function createRetryingBackendLoader(
-  loadModule: NodeSqlParserModuleLoader,
-): NodeSqlParserBackendLoader {
-  let pending: Promise<NodeSqlParserBackend> | undefined;
-  return async () => {
-    if (pending === undefined) {
-      const current = Promise.resolve()
-        .then(loadModule)
-        .then(decodeBackendModule);
-      pending = current;
-      try {
-        return await current;
-      } catch (error: unknown) {
-        if (
-          !(error instanceof NodeSqlParserModuleShapeError) &&
-          !(error instanceof NodeSqlParserInitializationError) &&
-          !(error instanceof NodeSqlParserGlobalCleanupError) &&
-          !(error instanceof NodeSqlParserExecutionRealmError)
-        ) {
-          pending = undefined;
-        }
-        throw error;
-      }
-    }
-    return await pending;
-  };
 }
 
 const PARSER_GLOBAL_KEYS = ["NodeSQLParser", "global"] as const;
@@ -359,162 +212,47 @@ function rejectUnsupportedExecutionRealm(): void {
 
 async function loadNodeSqlParserBuild(
   specifier: string,
-): Promise<unknown> {
-  rejectUnsupportedExecutionRealm();
-  const { createRequire } = await import("node:module");
-  rejectUnsupportedExecutionRealm();
-  const require = createRequire(import.meta.url);
-  return loadNodeModuleSynchronously(
-    () => require(specifier),
-  );
+): Promise<NodeSqlParserModuleLoadOutcome> {
+  try {
+    rejectUnsupportedExecutionRealm();
+    const { createRequire } = await import("node:module");
+    rejectUnsupportedExecutionRealm();
+    const require = createRequire(import.meta.url);
+    return {
+      kind: "loaded",
+      moduleValue: loadNodeModuleSynchronously(
+        () => require(specifier),
+      ),
+    };
+  } catch (error: unknown) {
+    if (
+      error instanceof NodeSqlParserGlobalCleanupError ||
+      error instanceof NodeSqlParserExecutionRealmError
+    ) {
+      return {
+        code: "backend",
+        kind: "failed",
+        retryable: false,
+      };
+    }
+    return {
+      code: "module-load",
+      kind: "failed",
+      retryable: true,
+    };
+  }
 }
 
-function importPostgresqlBuild(): Promise<unknown> {
+function importPostgresqlBuild(): Promise<NodeSqlParserModuleLoadOutcome> {
   return loadNodeSqlParserBuild(
     "node-sql-parser/build/postgresql.js",
   );
 }
 
-function importBigQueryBuild(): Promise<unknown> {
+function importBigQueryBuild(): Promise<NodeSqlParserModuleLoadOutcome> {
   return loadNodeSqlParserBuild(
     "node-sql-parser/build/bigquery.js",
   );
-}
-
-function mapStatementKind(backendType: string): SqlStatementKind {
-  switch (backendType.toLowerCase()) {
-    case "select":
-    case "union":
-      return "query";
-    case "insert":
-    case "replace":
-      return "insert";
-    case "update":
-      return "update";
-    case "delete":
-      return "delete";
-    case "create":
-      return "create";
-    case "alter":
-      return "alter";
-    case "drop":
-      return "drop";
-    case "merge":
-      return "merge";
-    case "transaction":
-      return "transaction";
-    default:
-      return "other";
-  }
-}
-
-function decodeRoot(value: unknown): DecodedRoot {
-  let root = value;
-  let rootIsArray: boolean;
-  try {
-    rootIsArray = Array.isArray(root);
-  } catch {
-    return { kind: "malformed" };
-  }
-  if (rootIsArray && isRecordObject(root)) {
-    const length = readOwnDataProperty(root, "length");
-    if (length.kind !== "value") {
-      return { kind: "malformed" };
-    }
-    if (length.value !== 1) {
-      return { kind: "unsupported" };
-    }
-    const first = readOwnDataProperty(root, 0);
-    if (first.kind !== "value") {
-      return { kind: "malformed" };
-    }
-    root = first.value;
-  }
-  if (!isRecordObject(root)) {
-    return { kind: "malformed" };
-  }
-  const type = readOwnDataProperty(root, "type");
-  if (
-    type.kind !== "value" ||
-    typeof type.value !== "string" ||
-    type.value.length === 0 ||
-    type.value.length > MAX_BACKEND_TYPE_LENGTH ||
-    type.value.trim() !== type.value
-  ) {
-    return { kind: "malformed" };
-  }
-  return {
-    kind: "root",
-    root,
-    statementKind: mapStatementKind(type.value),
-  };
-}
-
-function decodeSafeOffset(
-  value: unknown,
-  statementLength: number,
-): number | null {
-  if (
-    typeof value === "number" &&
-    Number.isSafeInteger(value) &&
-    value >= 0 &&
-    value <= statementLength
-  ) {
-    return value;
-  }
-  return null;
-}
-
-function decodeParserError(
-  error: unknown,
-  statementLength: number,
-): DecodedParserError {
-  if (!isObjectLike(error)) {
-    return "backend-failure";
-  }
-  const name = readOwnDataProperty(error, "name");
-  if (
-    name.kind !== "value" ||
-    name.value !== "SyntaxError"
-  ) {
-    return "backend-failure";
-  }
-  const message = readOwnDataProperty(error, "message");
-  const location = readOwnDataProperty(error, "location");
-  if (
-    message.kind !== "value" ||
-    typeof message.value !== "string" ||
-    message.value.trim().length === 0 ||
-    message.value.length > MAX_SQL_SYNTAX_MESSAGE_INPUT_LENGTH ||
-    location.kind !== "value" ||
-    !isRecordObject(location.value)
-  ) {
-    return "malformed-output";
-  }
-  const start = readOwnDataProperty(location.value, "start");
-  const end = readOwnDataProperty(location.value, "end");
-  if (
-    start.kind !== "value" ||
-    end.kind !== "value" ||
-    !isRecordObject(start.value) ||
-    !isRecordObject(end.value)
-  ) {
-    return "malformed-output";
-  }
-  const startOffset = readOwnDataProperty(start.value, "offset");
-  const endOffset = readOwnDataProperty(end.value, "offset");
-  if (
-    startOffset.kind !== "value" ||
-    endOffset.kind !== "value"
-  ) {
-    return "malformed-output";
-  }
-  const from = decodeSafeOffset(startOffset.value, statementLength);
-  const to = decodeSafeOffset(endOffset.value, statementLength);
-  if (from === null || to === null || from > to) {
-    return "malformed-output";
-  }
-  return "syntax-rejection";
 }
 
 function backendFailure(
@@ -545,105 +283,72 @@ function malformedOutput(
   );
 }
 
+function materializeBackendOutcome(
+  runtime: NodeSqlParserRuntime,
+  statementText: string,
+  outcome: NodeSqlParserBackendOutcome,
+) {
+  switch (outcome.kind) {
+    case "failed":
+      if (outcome.code === "malformed-output") {
+        return malformedOutput(runtime.authority, statementText);
+      }
+      return backendFailure(
+          runtime.authority,
+          statementText,
+          outcome.code === "module-load"
+            ? "node-sql-parser failed to load"
+            : "node-sql-parser backend failed",
+          outcome.retryable,
+        );
+    case "parsed": {
+      const artifact = createSqlSyntaxArtifact(
+        outcome.statementKind,
+        statementText,
+        runtime.authority,
+      );
+      backendPayloads.set(artifact, outcome.root);
+      return createCompatibilityParsedAnalysis(
+        artifact,
+        runtime.limitations,
+      );
+    }
+    case "syntax-rejected":
+      return createUnsupportedParserAnalysis(
+        runtime.policy === "dialect-compatibility"
+          ? "compatibility-rejected"
+          : "uncovered-construct",
+        statementText,
+        runtime.authority,
+      );
+    case "unsupported":
+      return createUnsupportedParserAnalysis(
+        outcome.reason === "resource-limit"
+          ? "resource-limit"
+          : "uncovered-construct",
+        statementText,
+        runtime.authority,
+      );
+  }
+}
+
 function createAdapter(runtime: NodeSqlParserRuntime): SqlStatementParser {
   return createSqlStatementParser(
     runtime.authority,
     async (request) => {
       const { signal, text } = request;
-      if (text.length > MAX_NODE_SQL_PARSER_STATEMENT_LENGTH) {
-        return createUnsupportedParserAnalysis(
-          "resource-limit",
-          text,
-          runtime.authority,
-        );
-      }
-
-      signal.throwIfAborted();
-      let backend: NodeSqlParserBackend;
-      try {
-        backend = await runtime.loadBackend();
-      } catch (error: unknown) {
-        signal.throwIfAborted();
-        if (error instanceof NodeSqlParserModuleShapeError) {
-          return malformedOutput(runtime.authority, text);
-        }
-        if (
-          error instanceof NodeSqlParserInitializationError ||
-          error instanceof NodeSqlParserGlobalCleanupError ||
-          error instanceof NodeSqlParserExecutionRealmError
-        ) {
-          return backendFailure(
-            runtime.authority,
-            text,
-            "node-sql-parser backend failed",
-            false,
-          );
-        }
-        return backendFailure(
-          runtime.authority,
-          text,
-          "node-sql-parser failed to load",
-          true,
-        );
-      }
-      signal.throwIfAborted();
-
-      let output: unknown;
-      try {
-        output = backend.astify(text);
-      } catch (error: unknown) {
-        signal.throwIfAborted();
-        const decoded = decodeParserError(error, text.length);
-        if (decoded === "malformed-output") {
-          return malformedOutput(runtime.authority, text);
-        }
-        if (decoded === "syntax-rejection") {
-          return createUnsupportedParserAnalysis(
-            runtime.policy === "dialect-compatibility"
-              ? "compatibility-rejected"
-              : "uncovered-construct",
-            text,
-            runtime.authority,
-          );
-        }
-        return backendFailure(
-          runtime.authority,
-          text,
-          "node-sql-parser backend failed",
-          false,
-        );
-      }
-      signal.throwIfAborted();
-
-      const decoded = decodeRoot(output);
-      if (decoded.kind === "unsupported") {
-        return createUnsupportedParserAnalysis(
-          "uncovered-construct",
-          text,
-          runtime.authority,
-        );
-      }
-      if (decoded.kind === "malformed") {
-        return malformedOutput(runtime.authority, text);
-      }
-
-      const artifact = createSqlSyntaxArtifact(
-        decoded.statementKind,
+      const outcome = await runtime.backend.parse(
         text,
-        runtime.authority,
+        () => signal.throwIfAborted(),
       );
-      backendPayloads.set(artifact, decoded.root);
-      return createCompatibilityParsedAnalysis(
-        artifact,
-        runtime.limitations,
-      );
+      return materializeBackendOutcome(runtime, text, outcome);
     },
   );
 }
 
 function createRuntime(
   backendIdentity: SqlSyntaxBackendIdentity,
-  loadBackend: NodeSqlParserBackendLoader,
+  backend: NodeSqlParserBackend,
   policy: NodeSqlParserPolicy,
 ): NodeSqlParserRuntime {
   const authority = createSqlParserAuthority(
@@ -653,21 +358,21 @@ function createRuntime(
   );
   return Object.freeze({
     authority,
+    backend,
     limitations:
       policy === "dialect-compatibility"
         ? DIALECT_COMPATIBILITY_LIMITATIONS
         : TARGET_GRAMMAR_LIMITATIONS,
-    loadBackend,
     policy,
   });
 }
 
 const postgresqlBackendIdentity = createSqlSyntaxBackendIdentity();
 const bigQueryBackendIdentity = createSqlSyntaxBackendIdentity();
-const postgresqlBackend = createRetryingBackendLoader(
+const postgresqlBackend = createNodeSqlParserBackend(
   importPostgresqlBuild,
 );
-const bigQueryBackend = createRetryingBackendLoader(importBigQueryBuild);
+const bigQueryBackend = createNodeSqlParserBackend(importBigQueryBuild);
 
 const postgresqlParser = createAdapter(
   createRuntime(
@@ -691,6 +396,35 @@ const duckDbParser = createAdapter(
   ),
 );
 
+function adaptModuleLoaderForTesting(
+  loadModule: () => Promise<unknown>,
+): NodeSqlParserModuleLoader {
+  return async () => {
+    try {
+      return {
+        kind: "loaded",
+        moduleValue: await loadModule(),
+      };
+    } catch (error: unknown) {
+      if (
+        error instanceof NodeSqlParserGlobalCleanupError ||
+        error instanceof NodeSqlParserExecutionRealmError
+      ) {
+        return {
+          code: "backend",
+          kind: "failed",
+          retryable: false,
+        };
+      }
+      return {
+        code: "module-load",
+        kind: "failed",
+        retryable: true,
+      };
+    }
+  };
+}
+
 export function getPostgresqlNodeSqlStatementParser(): SqlStatementParser {
   return postgresqlParser;
 }
@@ -706,13 +440,15 @@ export function getDuckDbCompatibilityNodeSqlStatementParser(): SqlStatementPars
 export const exportedForTesting = Object.freeze({
   createParser(
     policy: NodeSqlParserPolicy,
-    loadModule: NodeSqlParserModuleLoader,
+    loadModule: () => Promise<unknown>,
   ): SqlStatementParser {
     const backendIdentity = createSqlSyntaxBackendIdentity();
     return createAdapter(
       createRuntime(
         backendIdentity,
-        createRetryingBackendLoader(loadModule),
+        createNodeSqlParserBackend(
+          adaptModuleLoaderForTesting(loadModule),
+        ),
         policy,
       ),
     );

--- a/src/vnext/node-sql-parser-backend.ts
+++ b/src/vnext/node-sql-parser-backend.ts
@@ -255,7 +255,11 @@ function decodeRoot(
   }
   if (rootIsArray && isRecordObject(root)) {
     const length = readOwnDataProperty(root, "length");
-    if (length.kind !== "value") {
+    if (
+      length.kind !== "value" ||
+      !Number.isSafeInteger(length.value) ||
+      Number(length.value) < 0
+    ) {
       return failed("malformed-output", false);
     }
     if (length.value !== 1) {

--- a/src/vnext/node-sql-parser-backend.ts
+++ b/src/vnext/node-sql-parser-backend.ts
@@ -1,0 +1,427 @@
+import {
+  MAX_SQL_SYNTAX_MESSAGE_INPUT_LENGTH,
+  type SqlStatementKind,
+} from "./syntax.js";
+
+export const MAX_NODE_SQL_PARSER_STATEMENT_LENGTH = 16 * 1024;
+
+const MAX_BACKEND_TYPE_LENGTH = 128;
+const NODE_SQL_PARSER_OPTIONS = Object.freeze({
+  parseOptions: Object.freeze({
+    includeLocations: true,
+  }),
+  trimQuery: false,
+});
+
+export type NodeSqlParserModuleLoadOutcome =
+  | {
+      readonly kind: "loaded";
+      readonly moduleValue: unknown;
+    }
+  | {
+      readonly kind: "failed";
+      readonly code: "backend" | "module-load";
+      readonly retryable: boolean;
+    };
+
+export type NodeSqlParserModuleLoader =
+  () => Promise<NodeSqlParserModuleLoadOutcome>;
+
+export type NodeSqlParserBackendOutcome =
+  | {
+      readonly kind: "parsed";
+      readonly root: object;
+      readonly statementKind: SqlStatementKind;
+    }
+  | {
+      readonly kind: "syntax-rejected";
+    }
+  | {
+      readonly kind: "unsupported";
+      readonly reason: "multiple-statements" | "resource-limit";
+    }
+  | {
+      readonly kind: "failed";
+      readonly code:
+        | "backend"
+        | "malformed-output"
+        | "module-load";
+      readonly retryable: boolean;
+    };
+
+export interface NodeSqlParserBackend {
+  readonly parse: (
+    statementText: string,
+    checkpoint?: () => void,
+  ) => Promise<NodeSqlParserBackendOutcome>;
+}
+
+interface DecodedBackend {
+  readonly astify: (statementText: string) => unknown;
+}
+
+type BackendLoadOutcome =
+  | {
+      readonly kind: "loaded";
+      readonly backend: DecodedBackend;
+    }
+  | Extract<NodeSqlParserBackendOutcome, { readonly kind: "failed" }>;
+
+type OwnDataProperty =
+  | {
+      readonly kind: "missing";
+    }
+  | {
+      readonly kind: "invalid";
+    }
+  | {
+      readonly kind: "value";
+      readonly value: unknown;
+    };
+
+function failed(
+  code: Extract<
+    NodeSqlParserBackendOutcome,
+    { readonly kind: "failed" }
+  >["code"],
+  retryable: boolean,
+): Extract<
+  NodeSqlParserBackendOutcome,
+  { readonly kind: "failed" }
+> {
+  return Object.freeze({
+    code,
+    kind: "failed",
+    retryable,
+  });
+}
+
+function isObjectLike(value: unknown): value is object {
+  return (
+    (typeof value === "object" && value !== null) ||
+    typeof value === "function"
+  );
+}
+
+function isRecordObject(value: unknown): value is object {
+  return typeof value === "object" && value !== null;
+}
+
+function readOwnDataProperty(
+  value: object,
+  key: PropertyKey,
+): OwnDataProperty {
+  let descriptor: PropertyDescriptor | undefined;
+  try {
+    descriptor = Object.getOwnPropertyDescriptor(value, key);
+  } catch {
+    return { kind: "invalid" };
+  }
+  if (descriptor === undefined) {
+    return { kind: "missing" };
+  }
+  if (!("value" in descriptor)) {
+    return { kind: "invalid" };
+  }
+  return {
+    kind: "value",
+    value: descriptor.value,
+  };
+}
+
+function readDataMethod(
+  value: object,
+  key: PropertyKey,
+): ((...arguments_: unknown[]) => unknown) | null {
+  let candidate: object | null = value;
+  for (let depth = 0; candidate !== null && depth < 16; depth += 1) {
+    const property = readOwnDataProperty(candidate, key);
+    if (property.kind === "invalid") {
+      return null;
+    }
+    if (property.kind === "value") {
+      if (typeof property.value !== "function") {
+        return null;
+      }
+      const method = property.value;
+      return (...arguments_: unknown[]) =>
+        Reflect.apply(method, value, arguments_);
+    }
+    try {
+      candidate = Object.getPrototypeOf(candidate);
+    } catch {
+      return null;
+    }
+  }
+  return null;
+}
+
+function moduleCandidates(moduleValue: unknown): readonly unknown[] {
+  if (!isObjectLike(moduleValue)) {
+    return [moduleValue];
+  }
+  const candidates: unknown[] = [moduleValue];
+  for (const key of ["default", "module.exports"] as const) {
+    const property = readOwnDataProperty(moduleValue, key);
+    if (property.kind === "value") {
+      candidates.push(property.value);
+    }
+  }
+  return candidates;
+}
+
+function findParserConstructor(moduleValue: unknown): unknown {
+  for (const candidate of moduleCandidates(moduleValue)) {
+    if (typeof candidate === "function") {
+      return candidate;
+    }
+    if (!isObjectLike(candidate)) {
+      continue;
+    }
+    const parser = readOwnDataProperty(candidate, "Parser");
+    if (
+      parser.kind === "value" &&
+      typeof parser.value === "function"
+    ) {
+      return parser.value;
+    }
+  }
+  return null;
+}
+
+function decodeBackendModule(moduleValue: unknown): BackendLoadOutcome {
+  const Parser = findParserConstructor(moduleValue);
+  if (typeof Parser !== "function") {
+    return failed("malformed-output", false);
+  }
+  let parser: object;
+  try {
+    parser = Reflect.construct(Parser, []);
+  } catch {
+    return failed("backend", false);
+  }
+  const astify = readDataMethod(parser, "astify");
+  if (astify === null) {
+    return failed("malformed-output", false);
+  }
+  return Object.freeze({
+    backend: Object.freeze({
+      astify(statementText: string): unknown {
+        return astify(statementText, NODE_SQL_PARSER_OPTIONS);
+      },
+    }),
+    kind: "loaded",
+  });
+}
+
+function mapStatementKind(backendType: string): SqlStatementKind {
+  switch (backendType.toLowerCase()) {
+    case "select":
+    case "union":
+      return "query";
+    case "insert":
+    case "replace":
+      return "insert";
+    case "update":
+      return "update";
+    case "delete":
+      return "delete";
+    case "create":
+      return "create";
+    case "alter":
+      return "alter";
+    case "drop":
+      return "drop";
+    case "merge":
+      return "merge";
+    case "transaction":
+      return "transaction";
+    default:
+      return "other";
+  }
+}
+
+function decodeRoot(
+  value: unknown,
+): Exclude<NodeSqlParserBackendOutcome, {
+  readonly kind: "syntax-rejected";
+}> {
+  let root = value;
+  let rootIsArray: boolean;
+  try {
+    rootIsArray = Array.isArray(root);
+  } catch {
+    return failed("malformed-output", false);
+  }
+  if (rootIsArray && isRecordObject(root)) {
+    const length = readOwnDataProperty(root, "length");
+    if (length.kind !== "value") {
+      return failed("malformed-output", false);
+    }
+    if (length.value !== 1) {
+      return Object.freeze({
+        kind: "unsupported",
+        reason: "multiple-statements",
+      });
+    }
+    const first = readOwnDataProperty(root, 0);
+    if (first.kind !== "value") {
+      return failed("malformed-output", false);
+    }
+    root = first.value;
+  }
+  if (!isRecordObject(root)) {
+    return failed("malformed-output", false);
+  }
+  const type = readOwnDataProperty(root, "type");
+  if (
+    type.kind !== "value" ||
+    typeof type.value !== "string" ||
+    type.value.length === 0 ||
+    type.value.length > MAX_BACKEND_TYPE_LENGTH ||
+    type.value.trim() !== type.value
+  ) {
+    return failed("malformed-output", false);
+  }
+  return Object.freeze({
+    kind: "parsed",
+    root,
+    statementKind: mapStatementKind(type.value),
+  });
+}
+
+function decodeSafeOffset(
+  value: unknown,
+  statementLength: number,
+): number | null {
+  if (
+    typeof value === "number" &&
+    Number.isSafeInteger(value) &&
+    value >= 0 &&
+    value <= statementLength
+  ) {
+    return value;
+  }
+  return null;
+}
+
+function decodeParserError(
+  error: unknown,
+  statementLength: number,
+): Exclude<NodeSqlParserBackendOutcome, {
+  readonly kind: "parsed";
+}> {
+  if (!isObjectLike(error)) {
+    return failed("backend", false);
+  }
+  const name = readOwnDataProperty(error, "name");
+  if (
+    name.kind !== "value" ||
+    name.value !== "SyntaxError"
+  ) {
+    return failed("backend", false);
+  }
+  const message = readOwnDataProperty(error, "message");
+  const location = readOwnDataProperty(error, "location");
+  if (
+    message.kind !== "value" ||
+    typeof message.value !== "string" ||
+    message.value.trim().length === 0 ||
+    message.value.length > MAX_SQL_SYNTAX_MESSAGE_INPUT_LENGTH ||
+    location.kind !== "value" ||
+    !isRecordObject(location.value)
+  ) {
+    return failed("malformed-output", false);
+  }
+  const start = readOwnDataProperty(location.value, "start");
+  const end = readOwnDataProperty(location.value, "end");
+  if (
+    start.kind !== "value" ||
+    end.kind !== "value" ||
+    !isRecordObject(start.value) ||
+    !isRecordObject(end.value)
+  ) {
+    return failed("malformed-output", false);
+  }
+  const startOffset = readOwnDataProperty(start.value, "offset");
+  const endOffset = readOwnDataProperty(end.value, "offset");
+  if (
+    startOffset.kind !== "value" ||
+    endOffset.kind !== "value"
+  ) {
+    return failed("malformed-output", false);
+  }
+  const from = decodeSafeOffset(startOffset.value, statementLength);
+  const to = decodeSafeOffset(endOffset.value, statementLength);
+  if (from === null || to === null || from > to) {
+    return failed("malformed-output", false);
+  }
+  return Object.freeze({
+    kind: "syntax-rejected",
+  });
+}
+
+export function createNodeSqlParserBackend(
+  loadModule: NodeSqlParserModuleLoader,
+): NodeSqlParserBackend {
+  let pending: Promise<BackendLoadOutcome> | undefined;
+
+  async function loadBackend(): Promise<BackendLoadOutcome> {
+    if (pending !== undefined) {
+      return await pending;
+    }
+    const current = Promise.resolve()
+      .then(loadModule)
+      .then((outcome): BackendLoadOutcome => {
+        if (outcome.kind === "failed") {
+          return failed(outcome.code, outcome.retryable);
+        }
+        return decodeBackendModule(outcome.moduleValue);
+      })
+      .catch(() => failed("module-load", true));
+    pending = current;
+    const outcome = await current;
+    if (
+      outcome.kind === "failed" &&
+      outcome.retryable &&
+      pending === current
+    ) {
+      pending = undefined;
+    }
+    return outcome;
+  }
+
+  return Object.freeze({
+    async parse(
+      statementText: string,
+      checkpoint?: () => void,
+    ): Promise<NodeSqlParserBackendOutcome> {
+      if (
+        statementText.length >
+        MAX_NODE_SQL_PARSER_STATEMENT_LENGTH
+      ) {
+        return Object.freeze({
+          kind: "unsupported",
+          reason: "resource-limit",
+        });
+      }
+
+      checkpoint?.();
+      const loaded = await loadBackend();
+      checkpoint?.();
+      if (loaded.kind === "failed") {
+        return loaded;
+      }
+
+      let output: unknown;
+      try {
+        output = loaded.backend.astify(statementText);
+      } catch (error: unknown) {
+        checkpoint?.();
+        return decodeParserError(error, statementText.length);
+      }
+      checkpoint?.();
+      return decodeRoot(output);
+    },
+  });
+}


### PR DESCRIPTION
## Summary

- extract module decoding, parser invocation, result validation, and error normalization into an internal realm-neutral backend
- preserve Node-specific realm validation, module loading, cleanup, parser authority, and private AST ownership in the existing adapter
- add exhaustive backend contract tests covering bounds, cancellation checkpoints, retry caching, hostile values, and ambient neutrality
- document the host/engine responsibility boundary

No public export, session wiring, worker protocol, or user-visible API is added.

## Validation

- 1,041 unit tests passed; 1 intentional expected failure
- vNext coverage: 98.54% statements, 97.06% branches, 100% functions, 98.53% lines
- new backend coverage: 100% statements, branches, functions, and lines
- source and test TypeScript checks
- oxlint and test-integrity checks
- Chromium browser tests
- exact packed-consumer smoke test
- isolated worker placement and bundle-budget harness
- demo production build
- parser adapter benchmark
- git diff check

## Independent review

Two independent adversarial reviewers approved exact commit 96bd2ce with zero actionable findings.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted a new internal backend for `node-sql-parser` and rewired the Node adapter to call it. No public API changes.

- **Refactors**
  - New `node-sql-parser-backend`: decodes module, runs `astify`, validates output, and normalizes errors; no Node/window/worker refs.
  - Node adapter now only handles realm checks, `require` loading, cleanup, parser authority, and private AST ownership; uses backend outcomes.
  - Unified backend outcomes; concurrent load de‑dup and retry cache; enforces `MAX_NODE_SQL_PARSER_STATEMENT_LENGTH`.
  - Accepts constructor/`default`/`module.exports`/named `Parser`; ignores accessors/proxies and redacts private data.
  - Added backend tests (bounds, cancellation, retry, hostile values, ambient neutrality) and documented the host/engine boundary.

- **Bug Fixes**
  - Validate AST array lengths, rejecting spoofed or non‑integer length descriptors.

<sup>Written for commit 08a9d67d1957bcadc18871e1eb8dbeedc9ae6f53. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marimo-team/codemirror-sql/pull/179?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

