### PR TITLE
feat(vnext): sketch relation completion contracts

### DIFF
--- a/src/vnext/codemirror/relation-completion-types.ts
+++ b/src/vnext/codemirror/relation-completion-types.ts
@@ -1,5 +1,3 @@
-import type { CompletionInfo } from "@codemirror/autocomplete";
-
 import type { SqlRelationCompletionItem } from "../relation-completion-types.js";
 
 // Provisional CodeMirror-only boundary; the framework-independent core stays DOM-free.
@@ -7,7 +5,15 @@ export interface SqlCompletionInfoResolverContext {
   readonly signal: AbortSignal;
 }
 
+export interface SqlDisposableCompletionInfo {
+  readonly dom: Node;
+  readonly destroy: () => void;
+}
+
 export type SqlCompletionInfoResolver = (
   item: SqlRelationCompletionItem,
   context: SqlCompletionInfoResolverContext,
-) => CompletionInfo | Promise<CompletionInfo>;
+) =>
+  | SqlDisposableCompletionInfo
+  | null
+  | Promise<SqlDisposableCompletionInfo | null>;

--- a/src/vnext/codemirror/relation-completion-types.ts
+++ b/src/vnext/codemirror/relation-completion-types.ts
@@ -1,0 +1,13 @@
+import type { CompletionInfo } from "@codemirror/autocomplete";
+
+import type { SqlRelationCompletionItem } from "../relation-completion-types.js";
+
+// Provisional CodeMirror-only boundary; the framework-independent core stays DOM-free.
+export interface SqlCompletionInfoResolverContext {
+  readonly signal: AbortSignal;
+}
+
+export type SqlCompletionInfoResolver = (
+  item: SqlRelationCompletionItem,
+  context: SqlCompletionInfoResolverContext,
+) => CompletionInfo | Promise<CompletionInfo>;

--- a/src/vnext/index.ts
+++ b/src/vnext/index.ts
@@ -16,6 +16,8 @@ export type {
   SqlDocumentReplacement,
   SqlDocumentSession,
   SqlDocumentUpdate,
+  SqlIdentifierComponent,
+  SqlIdentifierPath,
   SqlLanguageService,
   SqlLanguageServiceOptions,
   SqlPlainData,

--- a/src/vnext/relation-completion-types.ts
+++ b/src/vnext/relation-completion-types.ts
@@ -128,6 +128,44 @@ export interface SqlRelationCatalogProvider {
   ) => SqlDisposable;
 }
 
+export type SqlIdentifierDecodeResult =
+  | {
+      readonly status: "decoded";
+      readonly component: SqlIdentifierComponent;
+      readonly quality: "exact" | "recovered";
+    }
+  | {
+      readonly status: "unavailable";
+      readonly reason:
+        | "invalid-identifier"
+        | "unsupported-quote"
+        | "undecodable-identifier";
+    };
+
+export type SqlRenderedRelationPath =
+  | {
+      readonly status: "rendered";
+      readonly text: string;
+    }
+  | {
+      readonly status: "unsupported";
+      readonly reason: "illegal-role-sequence";
+    };
+
+export interface SqlRelationCompletionDialectRuntime {
+  readonly decodeIdentifier: (
+    token: string,
+    mode: "complete" | "completion-prefix",
+  ) => SqlIdentifierDecodeResult;
+  readonly renderRelationPath: (
+    path: SqlCanonicalRelationPath,
+  ) => SqlRenderedRelationPath;
+  readonly cteIdentifiersEqual: (
+    left: SqlIdentifierComponent,
+    right: SqlIdentifierComponent,
+  ) => boolean;
+}
+
 export interface SqlRelationCompletionOpenDocument<
   Context extends SqlDocumentContext,
 > {
@@ -180,9 +218,19 @@ export interface SqlSessionChangeEvent {
   readonly reason: SqlSessionChangeReason;
 }
 
+export type SqlCompletionTrigger =
+  | {
+      readonly kind: "invoked";
+    }
+  | {
+      readonly kind: "trigger-character";
+      readonly character: string;
+    };
+
 export interface SqlCompletionRequest {
   readonly position: number;
-  readonly trigger: "automatic" | "explicit";
+  readonly trigger: SqlCompletionTrigger;
+  readonly signal?: AbortSignal;
 }
 
 export interface SqlCteCompletionProvenance {
@@ -248,6 +296,7 @@ export type SqlRelationCompletionList =
     };
 
 export type SqlCompletionUnavailableReason =
+  | "inactive"
   | "unsupported-query-site"
   | "opaque-statement"
   | "ambiguous-query-site"
@@ -256,28 +305,66 @@ export type SqlCompletionUnavailableReason =
 export type SqlCompletionCancellationReason =
   | "caller"
   | "superseded"
-  | "session-disposed"
-  | "service-disposed";
+  | "disposed";
+
+export type SqlCatalogProviderUnavailableReason =
+  | "queue-overloaded"
+  | "queue-timeout"
+  | "execution-timeout"
+  | "synchronous-timeout"
+  | "provider-rejected"
+  | "malformed-response";
+
+interface SqlCatalogProviderReportBase {
+  readonly feature: "relation-catalog";
+  readonly providerId: string;
+}
+
+export type SqlCatalogProviderReport =
+  | (SqlCatalogProviderReportBase & {
+      readonly outcome: "ready";
+      readonly coverage: SqlCatalogReadyCoverage["kind"];
+    })
+  | (SqlCatalogProviderReportBase & {
+      readonly outcome: "loading";
+    })
+  | (SqlCatalogProviderReportBase & {
+      readonly outcome: "failed";
+      readonly code: SqlCatalogFailureCode;
+      readonly retry: SqlCatalogRetryPolicy;
+    })
+  | (SqlCatalogProviderReportBase & {
+      readonly outcome: "unavailable";
+      readonly reason: SqlCatalogProviderUnavailableReason;
+    });
+
+export interface SqlServiceFailure {
+  readonly code: "internal";
+  readonly retryable: boolean;
+}
 
 export type SqlRelationCompletionResult =
   | {
       readonly status: "ready";
       readonly revision: SqlRevision;
       readonly value: SqlRelationCompletionList;
-    }
-  | {
-      readonly status: "inactive";
-      readonly revision: SqlRevision;
+      readonly sources: readonly SqlCatalogProviderReport[];
     }
   | {
       readonly status: "unavailable";
       readonly revision: SqlRevision;
       readonly reason: SqlCompletionUnavailableReason;
+      readonly retryable: boolean;
     }
   | {
       readonly status: "cancelled";
       readonly revision: SqlRevision;
       readonly reason: SqlCompletionCancellationReason;
+    }
+  | {
+      readonly status: "failed";
+      readonly revision: SqlRevision;
+      readonly failure: SqlServiceFailure;
     };
 
 export interface SqlRelationCompletionSession<
@@ -289,7 +376,6 @@ export interface SqlRelationCompletionSession<
   ) => SqlRevision;
   readonly complete: (
     request: SqlCompletionRequest,
-    signal?: AbortSignal,
   ) => Promise<SqlRelationCompletionResult>;
   readonly onDidChange: (
     listener: (event: SqlSessionChangeEvent) => void,

--- a/src/vnext/relation-completion-types.ts
+++ b/src/vnext/relation-completion-types.ts
@@ -1,0 +1,299 @@
+import type { SqlEmbeddedRegion } from "./source.js";
+import type {
+  SqlContextInput,
+  SqlDocumentContext,
+  SqlDocumentEdit,
+  SqlIdentifierComponent,
+  SqlIdentifierPath,
+  SqlRevision,
+  SqlTextChange,
+} from "./types.js";
+
+// Provisional package-private declarations until the vertical slice is proven.
+export interface SqlDisposable {
+  readonly dispose: () => void;
+}
+
+export type SqlCatalogContainerRole =
+  | "catalog"
+  | "schema"
+  | "project"
+  | "dataset";
+
+export interface SqlCatalogContainerComponent
+  extends SqlIdentifierComponent {
+  readonly role: SqlCatalogContainerRole;
+}
+
+export interface SqlCatalogRelationComponent
+  extends SqlIdentifierComponent {
+  readonly role: "relation";
+}
+
+export type SqlCanonicalRelationPath = readonly [
+  ...containers: SqlCatalogContainerComponent[],
+  relation: SqlCatalogRelationComponent,
+];
+
+export interface SqlCatalogEpoch {
+  readonly generation: number;
+  readonly token: string;
+}
+
+export type SqlCatalogRelationKind =
+  | "temporary-table"
+  | "table"
+  | "view"
+  | "materialized-view"
+  | "external-relation";
+
+export type SqlCatalogMatchQuality = "exact" | "equivalent";
+
+export interface SqlCatalogRelation {
+  readonly entityId: string;
+  readonly relationKind: SqlCatalogRelationKind;
+  readonly canonicalPath: SqlCanonicalRelationPath;
+  readonly completionPathStart: number;
+  readonly matchQuality: SqlCatalogMatchQuality;
+  readonly detail?: string;
+}
+
+export interface SqlCatalogSearchRequest {
+  readonly scope: string;
+  readonly searchPaths: readonly SqlIdentifierPath[];
+  readonly dialectId: string;
+  readonly qualifier: SqlIdentifierPath;
+  readonly prefix: SqlIdentifierComponent;
+  readonly limit: number;
+  readonly expectedEpoch: SqlCatalogEpoch | null;
+  readonly continuationToken: string | null;
+}
+
+export type SqlCatalogReadyCoverage =
+  | {
+      readonly kind: "complete";
+    }
+  | {
+      readonly kind: "partial";
+    }
+  | {
+      readonly kind: "paginated";
+      readonly continuationToken: string;
+    };
+
+export type SqlCatalogFailureCode =
+  | "authentication"
+  | "authorization"
+  | "invalid-configuration"
+  | "rate-limited"
+  | "unavailable"
+  | "unknown";
+
+export type SqlCatalogRetryPolicy =
+  | "never"
+  | "next-request"
+  | "after-invalidation";
+
+export type SqlCatalogSearchResponse =
+  | {
+      readonly status: "ready";
+      readonly epoch: SqlCatalogEpoch;
+      readonly coverage: SqlCatalogReadyCoverage;
+      readonly relations: readonly SqlCatalogRelation[];
+    }
+  | {
+      readonly status: "loading";
+      readonly epoch: SqlCatalogEpoch;
+    }
+  | {
+      readonly status: "failed";
+      readonly epoch: SqlCatalogEpoch;
+      readonly code: SqlCatalogFailureCode;
+      readonly retry: SqlCatalogRetryPolicy;
+    };
+
+export interface SqlCatalogInvalidation {
+  readonly epoch: SqlCatalogEpoch;
+}
+
+export interface SqlRelationCatalogProvider {
+  readonly id: string;
+  readonly search: (
+    request: SqlCatalogSearchRequest,
+    signal: AbortSignal,
+  ) => Promise<SqlCatalogSearchResponse>;
+  readonly subscribe?: (
+    scope: string,
+    onInvalidation: (event: SqlCatalogInvalidation) => void,
+  ) => SqlDisposable;
+}
+
+export interface SqlRelationCompletionOpenDocument<
+  Context extends SqlDocumentContext,
+> {
+  readonly text: string;
+  readonly context: SqlContextInput<Context>;
+  readonly embeddedRegions?: readonly SqlEmbeddedRegion[];
+}
+
+interface SqlRelationCompletionUpdateBase {
+  readonly baseRevision: SqlRevision;
+}
+
+type SqlRelationCompletionDocumentUpdate<
+  Context extends SqlDocumentContext,
+> = SqlRelationCompletionUpdateBase & {
+  readonly document: SqlDocumentEdit;
+  readonly embeddedRegions: readonly SqlEmbeddedRegion[];
+  readonly context?: SqlContextInput<Context>;
+};
+
+type SqlRelationCompletionContextUpdate<
+  Context extends SqlDocumentContext,
+> = SqlRelationCompletionUpdateBase & {
+  readonly document?: never;
+  readonly context: SqlContextInput<Context>;
+  readonly embeddedRegions?: readonly SqlEmbeddedRegion[];
+};
+
+type SqlRelationCompletionRegionUpdate =
+  SqlRelationCompletionUpdateBase & {
+    readonly document?: never;
+    readonly context?: never;
+    readonly embeddedRegions: readonly SqlEmbeddedRegion[];
+  };
+
+export type SqlRelationCompletionDocumentTransaction<
+  Context extends SqlDocumentContext,
+> =
+  | SqlRelationCompletionDocumentUpdate<Context>
+  | SqlRelationCompletionContextUpdate<Context>
+  | SqlRelationCompletionRegionUpdate;
+
+export type SqlSessionChangeReason =
+  | "catalog"
+  | "catalog-availability"
+  | "provider-configuration";
+
+export interface SqlSessionChangeEvent {
+  readonly revision: SqlRevision;
+  readonly reason: SqlSessionChangeReason;
+}
+
+export interface SqlCompletionRequest {
+  readonly position: number;
+  readonly trigger: "automatic" | "explicit";
+}
+
+export interface SqlCteCompletionProvenance {
+  readonly kind: "cte";
+  readonly declarationPosition: number;
+}
+
+export interface SqlCatalogCompletionProvenance {
+  readonly kind: "catalog";
+  readonly providerId: string;
+  readonly entityId: string;
+}
+
+interface SqlCompletionItemBase {
+  readonly label: string;
+  readonly edit: SqlTextChange;
+  readonly detail?: string;
+}
+
+export type SqlRelationCompletionItem =
+  | (SqlCompletionItemBase & {
+      readonly relationKind: "cte";
+      readonly provenance: SqlCteCompletionProvenance;
+    })
+  | (SqlCompletionItemBase & {
+      readonly relationKind: SqlCatalogRelationKind;
+      readonly provenance: SqlCatalogCompletionProvenance;
+    });
+
+export type SqlCompletionIssue =
+  | {
+      readonly reason: "catalog-loading";
+      readonly remainingIntentLeaseMs: number;
+    }
+  | {
+      readonly reason:
+        | "catalog-partial"
+        | "catalog-paginated"
+        | "catalog-failed"
+        | "catalog-malformed"
+        | "catalog-overloaded"
+        | "catalog-queue-timeout"
+        | "catalog-timeout"
+        | "query-site-recovery"
+        | "opaque-template-context"
+        | "recursive-cte-uncertainty"
+        | "result-limit";
+    };
+
+export type SqlRelationCompletionList =
+  | {
+      readonly items: readonly SqlRelationCompletionItem[];
+      readonly isIncomplete: false;
+      readonly issues: readonly [];
+    }
+  | {
+      readonly items: readonly SqlRelationCompletionItem[];
+      readonly isIncomplete: true;
+      readonly issues: readonly [
+        SqlCompletionIssue,
+        ...SqlCompletionIssue[],
+      ];
+    };
+
+export type SqlCompletionUnavailableReason =
+  | "unsupported-query-site"
+  | "opaque-statement"
+  | "ambiguous-query-site"
+  | "resource-limit";
+
+export type SqlCompletionCancellationReason =
+  | "caller"
+  | "superseded"
+  | "session-disposed"
+  | "service-disposed";
+
+export type SqlRelationCompletionResult =
+  | {
+      readonly status: "ready";
+      readonly revision: SqlRevision;
+      readonly value: SqlRelationCompletionList;
+    }
+  | {
+      readonly status: "inactive";
+      readonly revision: SqlRevision;
+    }
+  | {
+      readonly status: "unavailable";
+      readonly revision: SqlRevision;
+      readonly reason: SqlCompletionUnavailableReason;
+    }
+  | {
+      readonly status: "cancelled";
+      readonly revision: SqlRevision;
+      readonly reason: SqlCompletionCancellationReason;
+    };
+
+export interface SqlRelationCompletionSession<
+  Context extends SqlDocumentContext,
+> {
+  readonly revision: SqlRevision;
+  readonly update: (
+    transaction: SqlRelationCompletionDocumentTransaction<Context>,
+  ) => SqlRevision;
+  readonly complete: (
+    request: SqlCompletionRequest,
+    signal?: AbortSignal,
+  ) => Promise<SqlRelationCompletionResult>;
+  readonly onDidChange: (
+    listener: (event: SqlSessionChangeEvent) => void,
+  ) => SqlDisposable;
+  readonly isCurrent: (revision: SqlRevision) => boolean;
+  readonly dispose: () => void;
+}

--- a/src/vnext/types.ts
+++ b/src/vnext/types.ts
@@ -13,9 +13,16 @@ export function createSqlRevisionToken(): SqlRevision {
   return revision;
 }
 
+export interface SqlIdentifierComponent {
+  readonly value: string;
+  readonly quoted: boolean;
+}
+
+export type SqlIdentifierPath = readonly SqlIdentifierComponent[];
+
 export interface SqlCatalogContext {
   readonly scope: string;
-  readonly searchPath?: readonly string[];
+  readonly searchPath?: readonly SqlIdentifierPath[];
 }
 
 export interface SqlDocumentContext {

--- a/test/vnext-types/marimo-relation-completion-codemirror.test-d.ts
+++ b/test/vnext-types/marimo-relation-completion-codemirror.test-d.ts
@@ -1,4 +1,3 @@
-import type { CompletionInfo } from "@codemirror/autocomplete";
 import type { EditorView } from "@codemirror/view";
 
 import type {
@@ -7,22 +6,30 @@ import type {
 } from "../../src/vnext/codemirror/relation-completion-types.js";
 import type { SqlRelationCompletionItem } from "../../src/vnext/relation-completion-types.js";
 
+interface ReactRootLike {
+  readonly render: (value: unknown) => void;
+  readonly unmount: () => void;
+}
+
+declare function createReactRoot(container: Element): ReactRootLike;
+
 const resolveInfo: SqlCompletionInfoResolver = async (item, { signal }) => {
   signal.throwIfAborted();
   if (item.provenance.kind !== "catalog") {
     return null;
   }
 
-  const root = document.createElement("div");
-  root.textContent = `${item.provenance.providerId}:${item.provenance.entityId}`;
+  const dom = document.createElement("div");
+  const root = createReactRoot(dom);
+  root.render(`${item.provenance.providerId}:${item.provenance.entityId}`);
   return {
-    destroy: () => root.replaceChildren(),
-    dom: root,
+    destroy: () => root.unmount(),
+    dom,
   };
 };
 
 declare const item: SqlRelationCompletionItem;
-const resolved: CompletionInfo | Promise<CompletionInfo> = resolveInfo(item, {
+const resolved = resolveInfo(item, {
   signal: new AbortController().signal,
 });
 
@@ -46,8 +53,17 @@ const resolverReturningReactData: SqlCompletionInfoResolver = () => ({
   props: {},
   type: "table",
 });
+const resolverReturningNode: SqlCompletionInfoResolver = () =>
+  // @ts-expect-error custom UI must expose explicit cleanup
+  document.createElement("div");
+// @ts-expect-error custom UI resources require a destroy hook
+const resolverWithoutDestroy: SqlCompletionInfoResolver = () => ({
+  dom: document.createElement("div"),
+});
 
 void resolved;
+void resolverReturningNode;
 void resolverReturningNumber;
 void resolverReturningReactData;
+void resolverWithoutDestroy;
 void resolverWithView;

--- a/test/vnext-types/marimo-relation-completion-codemirror.test-d.ts
+++ b/test/vnext-types/marimo-relation-completion-codemirror.test-d.ts
@@ -1,0 +1,53 @@
+import type { CompletionInfo } from "@codemirror/autocomplete";
+import type { EditorView } from "@codemirror/view";
+
+import type {
+  SqlCompletionInfoResolver,
+  SqlCompletionInfoResolverContext,
+} from "../../src/vnext/codemirror/relation-completion-types.js";
+import type { SqlRelationCompletionItem } from "../../src/vnext/relation-completion-types.js";
+
+const resolveInfo: SqlCompletionInfoResolver = async (item, { signal }) => {
+  signal.throwIfAborted();
+  if (item.provenance.kind !== "catalog") {
+    return null;
+  }
+
+  const root = document.createElement("div");
+  root.textContent = `${item.provenance.providerId}:${item.provenance.entityId}`;
+  return {
+    destroy: () => root.replaceChildren(),
+    dom: root,
+  };
+};
+
+declare const item: SqlRelationCompletionItem;
+const resolved: CompletionInfo | Promise<CompletionInfo> = resolveInfo(item, {
+  signal: new AbortController().signal,
+});
+
+// @ts-expect-error resolver items are immutable
+item.label = "changed";
+if (item.provenance.kind === "catalog") {
+  // @ts-expect-error catalog provenance is immutable
+  item.provenance.entityId = "changed";
+}
+
+// @ts-expect-error live editor state is not a resolver parameter
+const resolverWithView: SqlCompletionInfoResolver = (
+  _item: SqlRelationCompletionItem,
+  _context: SqlCompletionInfoResolverContext,
+  _view: EditorView,
+) => null;
+// @ts-expect-error arbitrary host values are not CodeMirror completion info
+const resolverReturningNumber: SqlCompletionInfoResolver = () => 42;
+// @ts-expect-error React-shaped data is not a disposable CodeMirror resource
+const resolverReturningReactData: SqlCompletionInfoResolver = () => ({
+  props: {},
+  type: "table",
+});
+
+void resolved;
+void resolverReturningNumber;
+void resolverReturningReactData;
+void resolverWithView;

--- a/test/vnext-types/marimo-relation-completion.test-d.ts
+++ b/test/vnext-types/marimo-relation-completion.test-d.ts
@@ -40,9 +40,9 @@ const context: MarimoSqlContext = {
   dialect: "duckdb",
   engine: "local",
 };
-const regions = [
+const regions: readonly SqlEmbeddedRegion[] = [
   { from: 14, language: "python", to: 18 },
-] satisfies readonly SqlEmbeddedRegion[];
+];
 const openWithoutRegions: SqlRelationCompletionOpenDocument<MarimoSqlContext> = {
   context,
   text: "SELECT * FROM users",
@@ -187,7 +187,7 @@ const missingEngine: SqlRelationCompletionOpenDocument<MarimoSqlContext> = {
   text: "",
 };
 // @ts-expect-error embedded regions are readonly
-regions[0].from = 0;
+regions[0]!.from = 0;
 session.onDidChange((event) => {
   // @ts-expect-error service-originated event data is readonly
   event.reason = "catalog";

--- a/test/vnext-types/marimo-relation-completion.test-d.ts
+++ b/test/vnext-types/marimo-relation-completion.test-d.ts
@@ -6,13 +6,18 @@ import type {
 } from "../../src/vnext/index.js";
 import type {
   SqlCanonicalRelationPath,
+  SqlCatalogProviderReport,
   SqlCatalogReadyCoverage,
   SqlCatalogRelation,
   SqlCatalogSearchRequest,
   SqlCatalogSearchResponse,
+  SqlCompletionCancellationReason,
   SqlCompletionIssue,
+  SqlRelationCompletionItem,
+  SqlRelationCompletionList,
   SqlRelationCatalogProvider,
   SqlRelationCompletionDocumentTransaction,
+  SqlRelationCompletionDialectRuntime,
   SqlRelationCompletionOpenDocument,
   SqlRelationCompletionSession,
 } from "../../src/vnext/relation-completion-types.js";
@@ -82,11 +87,15 @@ const subscription = session.onDidChange((event) => {
 });
 subscription.dispose();
 subscription.dispose();
-void session.complete(
-  { position: 14, trigger: "explicit" },
-  new AbortController().signal,
-);
-void session.complete({ position: 14, trigger: "automatic" }).then((result) => {
+void session.complete({
+  position: 14,
+  signal: new AbortController().signal,
+  trigger: { kind: "invoked" },
+});
+void session.complete({
+  position: 14,
+  trigger: { character: ".", kind: "trigger-character" },
+}).then((result) => {
   // @ts-expect-error scheduler work identities never enter consumer results
   void result.workId;
   // @ts-expect-error catalog epochs never enter consumer results
@@ -126,6 +135,27 @@ const relation: SqlCatalogRelation = {
   relationKind: "table",
 };
 void relation;
+
+const dialectRuntime: SqlRelationCompletionDialectRuntime = {
+  cteIdentifiersEqual: (left, right) =>
+    left.quoted === right.quoted && left.value === right.value,
+  decodeIdentifier: (token) => ({
+    component: { quoted: false, value: token },
+    quality: "exact",
+    status: "decoded",
+  }),
+  renderRelationPath: (path) => ({
+    status: "rendered",
+    text: path.map((component) => component.value).join("."),
+  }),
+};
+void dialectRuntime;
+
+// @ts-expect-error semantic catalog roles are a closed set
+const invalidRole: SqlCatalogRelation["canonicalPath"][number]["role"] =
+  "database";
+// @ts-expect-error match evidence is provider-proven and closed
+const invalidMatch: SqlCatalogRelation["matchQuality"] = "prefix";
 
 const loadingIssue: SqlCompletionIssue = {
   reason: "catalog-loading",
@@ -206,6 +236,24 @@ const malformedLoading = {
   relations: [],
   status: "loading",
 } satisfies SqlCatalogSearchResponse;
+const providerRenderedSql = {
+  canonicalPath: relationPath,
+  completionPathStart: 1,
+  entityId: "users",
+  // @ts-expect-error providers return decoded paths, never SQL insertion text
+  insertText: "main.users",
+  matchQuality: "exact",
+  relationKind: "table",
+} satisfies SqlCatalogRelation;
+const leakedProviderFailure = {
+  code: "unavailable",
+  // @ts-expect-error raw provider errors never cross the completion boundary
+  error: new Error("secret"),
+  feature: "relation-catalog",
+  outcome: "failed",
+  providerId: "marimo",
+  retry: "next-request",
+} satisfies SqlCatalogProviderReport;
 const synchronousProvider: SqlRelationCatalogProvider = {
   id: "sync",
   // @ts-expect-error relation catalog providers are asynchronous
@@ -216,6 +264,31 @@ const synchronousProvider: SqlRelationCatalogProvider = {
 };
 // @ts-expect-error catalog-loading always carries its remaining intent lease
 const loadingWithoutLease: SqlCompletionIssue = { reason: "catalog-loading" };
+const mismatchedItem = {
+  edit: { from: 0, insert: "users", to: 0 },
+  label: "users",
+  provenance: {
+    // @ts-expect-error CTE items require CTE provenance
+    entityId: "users",
+    kind: "catalog",
+    providerId: "marimo",
+  },
+  relationKind: "cte",
+} satisfies SqlRelationCompletionItem;
+const contradictoryCompleteList = {
+  isIncomplete: false,
+  // @ts-expect-error complete lists cannot carry incomplete issues
+  issues: [{ reason: "catalog-partial" }],
+  items: [],
+} satisfies SqlRelationCompletionList;
+const contradictoryIncompleteList = {
+  isIncomplete: true,
+  issues: [],
+  items: [],
+  // @ts-expect-error incomplete lists require at least one issue
+} satisfies SqlRelationCompletionList;
+// @ts-expect-error timeouts are unavailable evidence, not cancellation
+const invalidCancellation: SqlCompletionCancellationReason = "timeout";
 // @ts-expect-error a document transaction cannot explicitly omit context
 const undefinedContext: SqlRelationCompletionDocumentTransaction<MarimoSqlContext> = {
   baseRevision: session.revision,
@@ -224,16 +297,24 @@ const undefinedContext: SqlRelationCompletionDocumentTransaction<MarimoSqlContex
 };
 
 void extraContinuation;
+void contradictoryCompleteList;
+void contradictoryIncompleteList;
 void flatSearchPath;
 void incompleteComponent;
+void invalidCancellation;
+void invalidMatch;
+void invalidRole;
 void leakedRequestState;
 void leakedDocumentText;
+void leakedProviderFailure;
 void loadingWithoutLease;
 void malformedLoading;
 void missingContinuation;
 void missingEngine;
 void missingRelation;
+void mismatchedItem;
 void openWithRegions;
 void openWithoutRegions;
+void providerRenderedSql;
 void synchronousProvider;
 void undefinedContext;

--- a/test/vnext-types/marimo-relation-completion.test-d.ts
+++ b/test/vnext-types/marimo-relation-completion.test-d.ts
@@ -1,0 +1,239 @@
+import type { SqlEmbeddedRegion } from "../../src/vnext/source.js";
+import type {
+  SqlCatalogContext,
+  SqlDocumentContext,
+  SqlIdentifierComponent,
+} from "../../src/vnext/index.js";
+import type {
+  SqlCanonicalRelationPath,
+  SqlCatalogReadyCoverage,
+  SqlCatalogRelation,
+  SqlCatalogSearchRequest,
+  SqlCatalogSearchResponse,
+  SqlCompletionIssue,
+  SqlRelationCatalogProvider,
+  SqlRelationCompletionDocumentTransaction,
+  SqlRelationCompletionOpenDocument,
+  SqlRelationCompletionSession,
+} from "../../src/vnext/relation-completion-types.js";
+
+interface MarimoSqlContext extends SqlDocumentContext {
+  readonly engine: string;
+}
+
+const catalog: SqlCatalogContext = {
+  scope: "notebook:demo",
+  searchPath: [
+    [
+      { quoted: true, value: "database.with.dot" },
+      { quoted: false, value: "main" },
+    ],
+  ],
+};
+const context: MarimoSqlContext = {
+  catalog,
+  dialect: "duckdb",
+  engine: "local",
+};
+const regions = [
+  { from: 14, language: "python", to: 18 },
+] satisfies readonly SqlEmbeddedRegion[];
+const openWithoutRegions: SqlRelationCompletionOpenDocument<MarimoSqlContext> = {
+  context,
+  text: "SELECT * FROM users",
+};
+const openWithRegions: SqlRelationCompletionOpenDocument<MarimoSqlContext> = {
+  context,
+  embeddedRegions: regions,
+  text: "SELECT * FROM {df}",
+};
+
+declare const session: SqlRelationCompletionSession<MarimoSqlContext>;
+session.update({
+  baseRevision: session.revision,
+  document: { kind: "replace", text: "SELECT * FROM {next_df}" },
+  embeddedRegions: [{ from: 14, language: "python", to: 23 }],
+});
+session.update({
+  baseRevision: session.revision,
+  context: { ...context, engine: "remote" },
+  document: { kind: "replace", text: "SELECT * FROM remote.users" },
+  embeddedRegions: [],
+});
+session.update({
+  baseRevision: session.revision,
+  context: { ...context, engine: "remote" },
+});
+session.update({
+  baseRevision: session.revision,
+  embeddedRegions: [],
+});
+session.update({
+  baseRevision: session.revision,
+  context,
+  embeddedRegions: regions,
+});
+
+const subscription = session.onDidChange((event) => {
+  const reason: "catalog" | "catalog-availability" | "provider-configuration" =
+    event.reason;
+  session.isCurrent(event.revision);
+  void reason;
+});
+subscription.dispose();
+subscription.dispose();
+void session.complete(
+  { position: 14, trigger: "explicit" },
+  new AbortController().signal,
+);
+void session.complete({ position: 14, trigger: "automatic" }).then((result) => {
+  // @ts-expect-error scheduler work identities never enter consumer results
+  void result.workId;
+  // @ts-expect-error catalog epochs never enter consumer results
+  void result.epoch;
+});
+
+const provider: SqlRelationCatalogProvider = {
+  id: "marimo",
+  search: async (request, signal) => {
+    signal.throwIfAborted();
+    const typedRequest: SqlCatalogSearchRequest = request;
+    void typedRequest;
+    return {
+      coverage: { kind: "complete" },
+      epoch: { generation: 0, token: "initial" },
+      relations: [],
+      status: "ready",
+    };
+  },
+  subscribe: (_scope, onInvalidation) => {
+    onInvalidation({ epoch: { generation: 1, token: "tables-updated" } });
+    return { dispose: () => undefined };
+  },
+};
+void provider;
+
+const relationPath = [
+  { quoted: false, role: "catalog", value: "memory" },
+  { quoted: false, role: "schema", value: "main" },
+  { quoted: false, role: "relation", value: "users" },
+] satisfies SqlCanonicalRelationPath;
+const relation: SqlCatalogRelation = {
+  canonicalPath: relationPath,
+  completionPathStart: 1,
+  entityId: "users",
+  matchQuality: "exact",
+  relationKind: "table",
+};
+void relation;
+
+const loadingIssue: SqlCompletionIssue = {
+  reason: "catalog-loading",
+  remainingIntentLeaseMs: 1_000,
+};
+void loadingIssue;
+
+const flatSearchPath: SqlCatalogContext = {
+  scope: "local",
+  // @ts-expect-error a search path is a list of decoded components, not a dot string
+  searchPath: ["main"],
+};
+// @ts-expect-error every decoded component records whether it was quoted
+const incompleteComponent: SqlIdentifierComponent = { value: "main" };
+// @ts-expect-error the old update discriminant is not part of the transaction
+session.update({ baseRevision: session.revision, kind: "context", context });
+// @ts-expect-error a transaction must change at least one state dimension
+session.update({ baseRevision: session.revision });
+// @ts-expect-error document changes require the complete resulting region set
+session.update({
+  baseRevision: session.revision,
+  document: { kind: "replace", text: "SELECT 1" },
+});
+// @ts-expect-error present undefined is not omission
+session.update({ baseRevision: session.revision, context: undefined });
+const missingEngine: SqlRelationCompletionOpenDocument<MarimoSqlContext> = {
+  // @ts-expect-error marimo contexts always identify their engine
+  context: { dialect: "duckdb" },
+  text: "",
+};
+// @ts-expect-error embedded regions are readonly
+regions[0].from = 0;
+session.onDidChange((event) => {
+  // @ts-expect-error service-originated event data is readonly
+  event.reason = "catalog";
+});
+// @ts-expect-error session notifications use a closed reason set
+session.onDidChange((_event: { revision: typeof session.revision; reason: "text" }) => {});
+
+const missingRelation = [
+  { quoted: false, role: "schema", value: "main" },
+  // @ts-expect-error a canonical relation path must end in a relation component
+] satisfies SqlCanonicalRelationPath;
+// @ts-expect-error paginated coverage requires a continuation token
+const missingContinuation: SqlCatalogReadyCoverage = { kind: "paginated" };
+const extraContinuation = {
+  kind: "complete",
+  // @ts-expect-error complete coverage cannot contain a continuation token
+  continuationToken: "next",
+} satisfies SqlCatalogReadyCoverage;
+const leakedRequestState = {
+  continuationToken: null,
+  dialectId: "duckdb",
+  expectedEpoch: null,
+  limit: 100,
+  prefix: { quoted: false, value: "" },
+  qualifier: [],
+  scope: "local",
+  searchPaths: [],
+  // @ts-expect-error caller cancellation is passed separately
+  signal: AbortSignal.abort(),
+} satisfies SqlCatalogSearchRequest;
+const leakedDocumentText = {
+  continuationToken: null,
+  dialectId: "duckdb",
+  expectedEpoch: null,
+  limit: 100,
+  prefix: { quoted: false, value: "" },
+  qualifier: [],
+  scope: "local",
+  searchPaths: [],
+  // @ts-expect-error providers never receive document text
+  text: "SELECT * FROM ",
+} satisfies SqlCatalogSearchRequest;
+const malformedLoading = {
+  epoch: { generation: 0, token: "zero" },
+  // @ts-expect-error loading responses cannot carry relations
+  relations: [],
+  status: "loading",
+} satisfies SqlCatalogSearchResponse;
+const synchronousProvider: SqlRelationCatalogProvider = {
+  id: "sync",
+  // @ts-expect-error relation catalog providers are asynchronous
+  search: () => ({
+    epoch: { generation: 0, token: "zero" },
+    status: "loading",
+  }),
+};
+// @ts-expect-error catalog-loading always carries its remaining intent lease
+const loadingWithoutLease: SqlCompletionIssue = { reason: "catalog-loading" };
+// @ts-expect-error a document transaction cannot explicitly omit context
+const undefinedContext: SqlRelationCompletionDocumentTransaction<MarimoSqlContext> = {
+  baseRevision: session.revision,
+  context: undefined,
+  embeddedRegions: [],
+};
+
+void extraContinuation;
+void flatSearchPath;
+void incompleteComponent;
+void leakedRequestState;
+void leakedDocumentText;
+void loadingWithoutLease;
+void malformedLoading;
+void missingContinuation;
+void missingEngine;
+void missingRelation;
+void openWithRegions;
+void openWithoutRegions;
+void synchronousProvider;
+void undefinedContext;


### PR DESCRIPTION
## Summary

- add package-private provisional contracts for relation catalog search, epochs, path authority, dialect-owned decoding/rendering, completion results, and session lifecycle
- migrate catalog search paths from dot-joined strings to decoded identifier-component paths with quote provenance
- add a runtime-free marimo-shaped core fixture covering atomic document/context/region transactions, providers, subscriptions, completion results, and negative type guarantees
- add a separate CodeMirror fixture requiring explicit disposal for custom rich-info resources

These declarations intentionally remain outside the `./vnext` public export surface until the complete vertical slice, two provider shapes, hostile decoding, packed marimo integration, and lifecycle/performance gates pass.

## Design constraints

- provider authoring is strongly typed, but runtime ingress will be erased to `unknown` and strictly decoded
- providers return decoded role-bearing canonical paths and positive addressability evidence; only dialect runtime data may decode SQL identifiers or render insertion text
- provider requests contain only bounded catalog/query data; provider cancellation is passed separately
- consumer results do not expose epochs, scheduler work IDs, deadlines, configuration identity, or terminal-vs-soft loading causes
- every `catalog-loading` issue carries a bounded remaining intent lease
- custom CodeMirror rich info must return `{ dom, destroy }`, enabling late-result draining and React-root unmounting

## Validation

- `pnpm run typecheck`
- `pnpm exec oxlint`
- `pnpm run test:integrity`
- `pnpm test` — 1,248 passed, 1 expected failure
- `pnpm run test:browser` — 7 passed
- `pnpm run test:package`
- changed coverage — 100% statements, branches, functions, and lines
- exact-head adversarial approval from SQL/API and marimo ergonomics reviewers at `d5a38af2804c928bc8acf7f7a0ae91a759f3de24`

Part of #169.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds provisional, strongly typed contracts for SQL relation completion, including catalog search, dialect decoding/rendering, completion items/results, and session lifecycle. Migrates identifier handling to decoded `SqlIdentifierPath` components and adds a disposable CodeMirror resolver for custom info. Part of #169.

- New Features
  - Relation catalog contracts: search request/response, epochs, coverage (complete/partial/paginated), provider reports.
  - Dialect runtime for identifier decode/render and CTE identifier equality.
  - Completion model for CTEs and catalog relations, with issues and ready/unavailable/cancelled/failed results.
  - Session API with transactional updates, completion, change events, and disposal.
  - CodeMirror `SqlCompletionInfoResolver` returning `{ dom, destroy }`.
  - Export `SqlIdentifierComponent` and `SqlIdentifierPath` from `src/vnext/index.ts`.

- Migration
  - Replace dot-joined search paths with `SqlIdentifierPath`; use `SqlIdentifierComponent` for all name parts.
  - Providers are async, take `AbortSignal` separately, and return decoded paths (no SQL insert text); rendering moves to the dialect runtime.
  - Embedded regions are readonly; document updates must pass the full `embeddedRegions` set.
  - Incomplete completion lists must include at least one issue; `catalog-loading` issues include `remainingIntentLeaseMs`.

<sup>Written for commit 2d0bade612567ad19e0b9c41f485f74d2588df48. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marimo-team/codemirror-sql/pull/183?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

