### PR TITLE
feat(vnext): make embedded regions atomic session inputs

### DIFF
--- a/docs/adr/0001-language-service-and-session.md
+++ b/docs/adr/0001-language-service-and-session.md
@@ -463,11 +463,12 @@ set for document or region updates and reuse the existing snapshot only when
 text and regions are unchanged. Non-identity generated/reordered source remains
 deferred until a concrete consumer validates the segment model.
 
-Current session edits use identity sources, so validated original-document
-changes are also trusted analysis-coordinate changes. A future transformed
-source must provide its own validated analysis-coordinate changes for
-incremental statement indexing. Without them, changed analysis text
-invalidates the index and is rebuilt lazily.
+Identity-to-identity session edits can use validated original-document changes
+as trusted analysis-coordinate changes. Masked-source edits do not make that
+claim: unchanged analysis can reuse its index, while changed analysis
+invalidates the index and rebuilds lazily. A future transformed source must
+provide its own validated analysis-coordinate changes before incremental
+indexing can consume them.
 
 Edits crossing an ambiguous or unmapped boundary are rejected. Mapping failure
 is unavailable analysis, not invalid SQL.

--- a/docs/adr/0001-language-service-and-session.md
+++ b/docs/adr/0001-language-service-and-session.md
@@ -163,7 +163,9 @@ region set for its resulting text. Without a document mutation, an explicit
 complete region set can change alone or together with context; omission
 preserves the current regions. An explicit empty set clears them. Opening a
 document accepts the same optional complete set, with omission or an empty set
-meaning identity source.
+meaning identity source. For compatibility with consumers regardless of their
+`exactOptionalPropertyTypes` setting, `undefined` on optional state fields has
+the same meaning as omission.
 
 A full-text replacement is available for simple consumers. Incremental changes
 are ordered, non-overlapping, absolute UTF-16 ranges in the current document.

--- a/docs/vnext/session-primitives.md
+++ b/docs/vnext/session-primitives.md
@@ -78,6 +78,10 @@ does not itself infer lexical behavior.
   the pre-update document.
 - Text, context, and embedded regions are validated completely before the
   session snapshot changes.
+- Public envelopes, edits, changes, and regions are structural inputs. The
+  service copies only their declared own data fields; additional host metadata
+  remains opaque and is never invoked. Removed or contradictory discriminants
+  are explicitly forbidden rather than treating every object as exact.
 - Context is structured-cloned and recursively frozen. Accepted values are
   finite primitives, arrays, and string-keyed plain objects. Cycles and shared
   references are retained. Accessors, symbols, functions, class instances,

--- a/docs/vnext/session-primitives.md
+++ b/docs/vnext/session-primitives.md
@@ -35,12 +35,12 @@ const session = service.openDocument({
 });
 
 const revision = session.update({
-  kind: "document",
   baseRevision: session.revision,
   document: {
     kind: "changes",
     changes: [{ from: 14, to: 19, insert: "customers" }],
   },
+  embeddedRegions: [],
 });
 
 if (session.isCurrent(revision)) {
@@ -52,7 +52,9 @@ service.dispose();
 ```
 
 Use `{ kind: "replace", text }` for full replacement and
-`{ kind: "context", baseRevision, context }` for a context-only update.
+`{ baseRevision, context }` for a context-only update. Every document mutation
+also supplies the complete embedded-region set for its resulting text. A
+region-only transaction can replace or clear that set without a fake text edit.
 
 ## Dialect registration
 
@@ -74,7 +76,8 @@ does not itself infer lexical behavior.
 - `baseRevision` is checked by identity and cannot come from another session.
 - Incremental ranges are ordered, non-overlapping, half-open UTF-16 offsets in
   the pre-update document.
-- Text and context are validated completely before the session snapshot changes.
+- Text, context, and embedded regions are validated completely before the
+  session snapshot changes.
 - Context is structured-cloned and recursively frozen. Accepted values are
   finite primitives, arrays, and string-keyed plain objects. Cycles and shared
   references are retained. Accessors, symbols, functions, class instances,
@@ -86,13 +89,15 @@ does not itself infer lexical behavior.
   platform errors are not exposed as causes.
 
 The internal statement index is built lazily per session. Context-only updates
-reuse it when the lexical-profile identity is unchanged. A no-op document
-update or same-text replacement advances the public revision and document
-sequence but can reuse the index. Trusted incremental identity-source changes
-update a populated cache; a changed replacement, profile change, or changed
-transformed source without analysis-coordinate changes clears it for a later
-full build. Invalid updates leave both the session snapshot and cache
-unchanged, and disposal clears the cache.
+reuse it when the lexical-profile identity is unchanged. Source-changing
+transactions use a separate source sequence, so region-only changes cannot
+reuse a stale index. A no-op document update or same-text replacement advances
+the public revision and document sequence but can reuse the index. Trusted
+incremental identity-source changes update a populated cache; a changed
+replacement, profile change, or changed masked source without verified
+analysis-coordinate changes clears it for a later full build. Invalid updates
+leave both the session snapshot and cache unchanged, and disposal clears the
+cache.
 
 The safety envelope currently permits at most 10,000 changes in one update, a
 16 Mi-code-unit document, 1,000 registered dialects, and bounded context graph

--- a/docs/vnext/source-coordinates.md
+++ b/docs/vnext/source-coordinates.md
@@ -35,6 +35,30 @@ The first internal transform masks explicit embedded regions:
 - `analysisText.length` always equals `originalText.length`, so range mapping is
   identity-preserving while still returning a fresh validated range.
 
+`SqlEmbeddedRegion` is the public document-coordinate input:
+
+```ts
+const session = service.openDocument({
+  text: "SELECT * FROM {df}",
+  context,
+  embeddedRegions: [{ from: 14, to: 18, language: "python" }],
+});
+
+session.update({
+  baseRevision: session.revision,
+  document: {
+    kind: "changes",
+    changes: [{ from: 15, to: 17, insert: "next_df" }],
+  },
+  embeddedRegions: [{ from: 14, to: 23, language: "python" }],
+});
+```
+
+The half-open interval covers the complete non-SQL fragment, including its
+template delimiters. For marimo, `[14, 18)` masks all of `{df}`; masking only
+`df` would leave `{}` to be analyzed as SQL. A document transaction always
+supplies the complete region set in coordinates of the resulting text.
+
 At most 10,000 regions and 16 Mi UTF-16 code units are accepted. Masking uses
 bounded 64 Ki-code-unit chunks, including for newline-dense input, rather than
 a per-code-unit or per-newline array.

--- a/docs/vnext/source-coordinates.md
+++ b/docs/vnext/source-coordinates.md
@@ -17,10 +17,10 @@ are valid. `SqlTextChange` extends this shape with `insert` and continues to use
 pre-update document coordinates.
 
 The service internally owns an immutable source snapshot with separately named
-`originalText` and `analysisText`. A document update creates a new identity
-snapshot; a context-only update reuses the same source object. This separation
-allows later analysis transforms without making providers depend on editor
-state or ambiguous coordinate spaces.
+`originalText` and `analysisText`. A source transaction builds the complete
+post-update masked snapshot; a context-only update reuses the same source
+object. This separation keeps providers independent of editor state and
+ambiguous coordinate spaces.
 
 ## Length-preserving masking
 
@@ -39,25 +39,24 @@ At most 10,000 regions and 16 Mi UTF-16 code units are accepted. Masking uses
 bounded 64 Ki-code-unit chunks, including for newline-dense input, rather than
 a per-code-unit or per-newline array.
 
-The source snapshot, embedded-region model, masking factory, and mapping
-functions remain internal. This slice intentionally does not publish a source
-transformer or source-map SPI. Generated or reordered source requires a
-versioned segment-map design and evidence from real consumers before becoming
-public.
+The source snapshot, masking factory, and mapping functions remain internal.
+Only the document-facing `SqlEmbeddedRegion` input shape is public. This slice
+intentionally does not publish a source transformer or source-map SPI.
+Generated or reordered source requires a versioned segment-map design and
+evidence from real consumers before becoming public.
 
 The internal [statement index](./statement-index.md) scans `analysisText` and
 uses its length-preserving offsets without publishing analysis-coordinate
 ranges.
 
 Statement-index reuse depends on `analysisText` value and internal lexical
-profile identity, not source-object identity. A document update therefore
-still creates a fresh source snapshot and public revision even when equal
-analysis text permits reuse. The index does not retain either the old or
-current source text.
+profile identity, not source-object identity. Every accepted source transaction
+creates a public revision, while an unchanged text-and-region value may reuse
+the immutable source snapshot and index. The index does not retain either the
+old or current source text.
 
-Current sessions create identity sources, so their validated document changes
-are also trusted analysis-coordinate changes. The masking primitive is not yet
-attached to session updates. A future transformed-source pipeline must produce
-validated analysis-coordinate changes before it can use incremental indexing;
-otherwise a changed analysis document invalidates the cache and receives a
-fresh full build on demand.
+Sessions accept complete length-preserving embedded-region sets on open and
+source transactions. Original document changes are trusted as analysis changes
+only for identity-to-identity updates. A changed masked source invalidates the
+cache unless its analysis text is unchanged; it then receives a fresh full
+build on demand.

--- a/package.json
+++ b/package.json
@@ -13,10 +13,11 @@
   },
   "scripts": {
     "dev": "vite",
-    "typecheck": "pnpm run typecheck:src && pnpm run typecheck:tests && pnpm run typecheck:vnext-tests && pnpm run typecheck:demo",
+    "typecheck": "pnpm run typecheck:src && pnpm run typecheck:tests && pnpm run typecheck:vnext-tests && pnpm run typecheck:vnext-tests:loose-optional && pnpm run typecheck:demo",
     "typecheck:src": "tsc --project tsconfig.json --noEmit",
     "typecheck:tests": "tsc --project tsconfig.tests.json",
     "typecheck:vnext-tests": "tsc --project tsconfig.vnext-tests.json",
+    "typecheck:vnext-tests:loose-optional": "tsc --project tsconfig.vnext-tests.loose-optional.json",
     "typecheck:demo": "tsc --project tsconfig.demo.json",
     "lint": "oxlint --fix",
     "test": "vitest run --config vitest.config.ts",

--- a/scripts/package-smoke.mjs
+++ b/scripts/package-smoke.mjs
@@ -199,12 +199,13 @@ const service = createSqlLanguageService({
 });
 const session = service.openDocument({
   context: { dialect: "duckdb" },
-  text: "SELECT 1",
+  embeddedRegions: [{ from: 14, language: "python", to: 18 }],
+  text: "SELECT * FROM {df}",
 });
 session.update({
-  embeddedRegions: [],
+  embeddedRegions: [{ from: 14, language: "python", to: 23 }],
   baseRevision: session.revision,
-  document: { kind: "replace", text: "SELECT 2" },
+  document: { kind: "replace", text: "SELECT * FROM {next_df}" },
 });
 service.dispose();
 `,
@@ -227,6 +228,7 @@ import {
   createSqlLanguageService,
   duckdbDialect,
   type SqlDocumentContext,
+  type SqlEmbeddedRegion,
   type SqlTextRange,
 } from "@marimo-team/codemirror-sql/vnext";
 import commonKeywords from "@marimo-team/codemirror-sql/data/common-keywords.json" with { type: "json" };
@@ -244,15 +246,19 @@ const parser = new NodeSqlParser();
 const service = createSqlLanguageService<HostContext>({
   dialects: [duckdbDialect()],
 });
+const embeddedRegions: readonly SqlEmbeddedRegion[] = [
+  { from: 14, language: "python", to: 18 },
+];
 const session = service.openDocument({
   context: { dialect: "duckdb", engine: "local" },
-  text: "SELECT 1",
+  embeddedRegions,
+  text: "SELECT * FROM {df}",
 });
 const range: SqlTextRange = { from: 0, to: 6 };
 session.update({
-  embeddedRegions: [],
+  embeddedRegions: [{ from: 14, language: "python", to: 18 }],
   baseRevision: session.revision,
-  document: { kind: "changes", changes: [{ from: 7, insert: "2", to: 8 }] },
+  document: { kind: "changes", changes: [] },
 });
 
 void extensions;
@@ -305,13 +311,14 @@ const service = vnext.createSqlLanguageService({
 });
 const session = service.openDocument({
   context: { dialect: "duckdb" },
-  text: "SELECT 1",
+  embeddedRegions: [{ from: 14, language: "python", to: 18 }],
+  text: "SELECT * FROM {df}",
 });
 const originalRevision = session.revision;
 const updatedRevision = session.update({
-  embeddedRegions: [],
+  embeddedRegions: [{ from: 14, language: "python", to: 23 }],
   baseRevision: originalRevision,
-  document: { kind: "replace", text: "SELECT 2" },
+  document: { kind: "replace", text: "SELECT * FROM {next_df}" },
 });
 if (session.isCurrent(originalRevision) || !session.isCurrent(updatedRevision)) {
   throw new Error("The packaged vNext session violated revision identity");

--- a/scripts/package-smoke.mjs
+++ b/scripts/package-smoke.mjs
@@ -202,7 +202,7 @@ const session = service.openDocument({
   text: "SELECT 1",
 });
 session.update({
-  kind: "document",
+  embeddedRegions: [],
   baseRevision: session.revision,
   document: { kind: "replace", text: "SELECT 2" },
 });
@@ -250,7 +250,7 @@ const session = service.openDocument({
 });
 const range: SqlTextRange = { from: 0, to: 6 };
 session.update({
-  kind: "document",
+  embeddedRegions: [],
   baseRevision: session.revision,
   document: { kind: "changes", changes: [{ from: 7, insert: "2", to: 8 }] },
 });
@@ -309,7 +309,7 @@ const session = service.openDocument({
 });
 const originalRevision = session.revision;
 const updatedRevision = session.update({
-  kind: "document",
+  embeddedRegions: [],
   baseRevision: originalRevision,
   document: { kind: "replace", text: "SELECT 2" },
 });

--- a/src/vnext/__tests__/session.test.ts
+++ b/src/vnext/__tests__/session.test.ts
@@ -177,7 +177,6 @@ describe("statement-index session cache", () => {
     const { session } = openSession("SELECT 1; SELECT 2");
     const index = session.getStatementIndexForTesting();
     session.update({
-      kind: "context",
       baseRevision: session.revision,
       context: { dialect: "duckdb", engine: "remote" },
     });
@@ -188,7 +187,6 @@ describe("statement-index session cache", () => {
     const { session } = openSession("SELECT $$a;b$$;");
     const index = session.getStatementIndexForTesting();
     session.update({
-      kind: "context",
       baseRevision: session.revision,
       context: { dialect: "postgresql", engine: "warehouse" },
     });
@@ -202,15 +200,15 @@ describe("statement-index session cache", () => {
     const index = session.getStatementIndexForTesting();
 
     session.update({
-      kind: "document",
+      embeddedRegions: [],
       baseRevision: session.revision,
       document: { kind: "changes", changes: [] },
     });
-    expect(session.snapshotForTesting.source).not.toBe(initialSource);
+    expect(session.snapshotForTesting.source).toBe(initialSource);
     expect(session.cachedStatementIndexForTesting).toBe(index);
 
     session.update({
-      kind: "document",
+      embeddedRegions: [],
       baseRevision: session.revision,
       document: { kind: "replace", text: "SELECT 1" },
     });
@@ -221,7 +219,7 @@ describe("statement-index session cache", () => {
     const { session } = openSession("SELECT 1; SELECT 2; SELECT 3");
     const previous = session.getStatementIndexForTesting();
     session.update({
-      kind: "document",
+      embeddedRegions: [],
       baseRevision: session.revision,
       document: {
         kind: "changes",
@@ -247,7 +245,7 @@ describe("statement-index session cache", () => {
     const revision = session.revision;
     expectSessionError("stale-revision", () => {
       session.update({
-        kind: "document",
+        embeddedRegions: [],
         baseRevision: {} as never,
         document: { kind: "replace", text: "SELECT 2" },
       });
@@ -256,7 +254,7 @@ describe("statement-index session cache", () => {
     expect(session.cachedStatementIndexForTesting).toBe(index);
 
     session.update({
-      kind: "document",
+      embeddedRegions: [],
       baseRevision: session.revision,
       document: { kind: "replace", text: "SELECT 2" },
     });
@@ -285,12 +283,12 @@ describe("document revisions", () => {
     const { session } = openSession("A");
     const first = session.revision;
     const second = session.update({
-      kind: "document",
+      embeddedRegions: [],
       baseRevision: first,
       document: { kind: "replace", text: "B" },
     });
     const third = session.update({
-      kind: "document",
+      embeddedRegions: [],
       baseRevision: second,
       document: { kind: "replace", text: "A" },
     });
@@ -308,7 +306,7 @@ describe("document revisions", () => {
     expect(first.session.isCurrent(second.session.revision)).toBe(false);
     expectSessionError("stale-revision", () => {
       first.session.update({
-        kind: "document",
+        embeddedRegions: [],
         baseRevision: second.session.revision,
         document: { kind: "replace", text: "SELECT 1" },
       });
@@ -324,7 +322,7 @@ describe("document revisions", () => {
     const { session } = openSession();
     const first = session.revision;
     const second = session.update({
-      kind: "document",
+      embeddedRegions: [],
       baseRevision: first,
       document: { kind: "changes", changes: [] },
     });
@@ -336,33 +334,463 @@ describe("document revisions", () => {
     const { session } = openSession("SELECT 1");
     const first = session.revision;
     const second = session.update({
-      kind: "document",
+      embeddedRegions: [],
       baseRevision: first,
       document: { kind: "replace", text: "SELECT 1" },
     });
     expect(second).not.toBe(first);
   });
 
-  it("reuses source snapshots only for context-only updates", () => {
+  it("reuses source snapshots when text and regions are unchanged", () => {
     const { session } = openSession("SELECT 1");
     const initialSource = session.snapshotForTesting.source;
     expect(Object.isFrozen(initialSource)).toBe(true);
     expect(initialSource.analysisText).toBe(initialSource.originalText);
 
     session.update({
-      kind: "context",
       baseRevision: session.revision,
       context: { dialect: "duckdb", engine: "remote" },
     });
     expect(session.snapshotForTesting.source).toBe(initialSource);
 
     session.update({
-      kind: "document",
+      embeddedRegions: [],
       baseRevision: session.revision,
       document: { kind: "changes", changes: [] },
     });
-    expect(session.snapshotForTesting.source).not.toBe(initialSource);
+    expect(session.snapshotForTesting.source).toBe(initialSource);
     expect(session.snapshotForTesting.source.originalText).toBe("SELECT 1");
+  });
+});
+
+describe("embedded-region session transactions", () => {
+  it("opens omitted, empty, and masked sources with owned frozen regions", () => {
+    const service = createService();
+    const omitted = service.openDocument({
+      context: { dialect: "duckdb", engine: "local" },
+      text: "SELECT 1",
+    });
+    const empty = service.openDocument({
+      context: { dialect: "duckdb", engine: "local" },
+      embeddedRegions: [],
+      text: "SELECT 1",
+    });
+    const region = { from: 14, language: "python", to: 18 };
+    const regions = [region];
+    const masked = service.openDocument({
+      context: { dialect: "duckdb", engine: "local" },
+      embeddedRegions: regions,
+      text: "SELECT * FROM {df}",
+    });
+
+    region.from = 0;
+    regions.length = 0;
+    expect(omitted.snapshotForTesting.source.analysisText).toBe("SELECT 1");
+    expect(empty.snapshotForTesting.source.analysisText).toBe("SELECT 1");
+    expect(masked.snapshotForTesting.source).toMatchObject({
+      analysisText: "SELECT * FROM     ",
+      embeddedRegions: [{ from: 14, language: "python", to: 18 }],
+      originalText: "SELECT * FROM {df}",
+    });
+    expect(Object.isFrozen(masked.snapshotForTesting.source)).toBe(true);
+    expect(Object.isFrozen(masked.snapshotForTesting.source.embeddedRegions)).toBe(
+      true,
+    );
+    expect(
+      Object.isFrozen(masked.snapshotForTesting.source.embeddedRegions[0]),
+    ).toBe(true);
+  });
+
+  it("indexes masked analysis rather than embedded SQL-like text", () => {
+    const service = createService();
+    const session = service.openDocument({
+      context: { dialect: "duckdb", engine: "local" },
+      embeddedRegions: [{ from: 7, language: "python", to: 12 }],
+      text: "SELECT {x;y}; SELECT 2",
+    });
+
+    const source = session.snapshotForTesting.source;
+    expect(session.getStatementIndexForTesting()).toEqual(
+      buildSqlStatementIndex(
+        source.analysisText,
+        DUCKDB_SQL_LEXICAL_PROFILE,
+      ),
+    );
+    expect(source.analysisText).toBe("SELECT      ; SELECT 2");
+  });
+
+  it("commits text, context, and post-edit regions in one revision", () => {
+    const service = createService();
+    const session = service.openDocument({
+      context: { dialect: "duckdb", engine: "local" },
+      embeddedRegions: [{ from: 14, language: "python", to: 18 }],
+      text: "SELECT * FROM {df}",
+    });
+    const previous = session.revision;
+
+    const revision = session.update({
+      baseRevision: previous,
+      context: { dialect: "postgresql", engine: "warehouse" },
+      document: {
+        changes: [{ from: 15, insert: "next_df", to: 17 }],
+        kind: "changes",
+      },
+      embeddedRegions: [{ from: 14, language: "python", to: 23 }],
+    });
+
+    expect(revision).not.toBe(previous);
+    expect(session.snapshotForTesting).toMatchObject({
+      context: { dialect: "postgresql", engine: "warehouse" },
+      source: {
+        analysisText: "SELECT * FROM          ",
+        embeddedRegions: [{ from: 14, language: "python", to: 23 }],
+        originalText: "SELECT * FROM {next_df}",
+      },
+    });
+  });
+
+  it("supports region-only, context-plus-region, and explicit clear updates", () => {
+    const { session } = openSession("SELECT * FROM {df}");
+    const initial = session.snapshotForTesting;
+
+    session.update({
+      baseRevision: session.revision,
+      embeddedRegions: [{ from: 14, language: "python", to: 18 }],
+    });
+    expect(session.snapshotForTesting.documentSequence).toBe(
+      initial.documentSequence,
+    );
+    expect(session.snapshotForTesting.source.analysisText).toBe(
+      "SELECT * FROM     ",
+    );
+
+    session.update({
+      baseRevision: session.revision,
+      context: { dialect: "duckdb", engine: "remote" },
+      embeddedRegions: [{ from: 14, language: "jinja", to: 18 }],
+    });
+    expect(session.snapshotForTesting.context.engine).toBe("remote");
+    expect(session.snapshotForTesting.source.embeddedRegions[0]?.language).toBe(
+      "jinja",
+    );
+
+    session.update({
+      baseRevision: session.revision,
+      embeddedRegions: [],
+    });
+    expect(session.snapshotForTesting.source.analysisText).toBe(
+      "SELECT * FROM {df}",
+    );
+  });
+
+  it("owns update regions and advances every accepted source transaction", () => {
+    const { session } = openSession("SELECT * FROM {df}");
+    const region = { from: 14, language: "python", to: 18 };
+    const regions = [region];
+    const initial = session.snapshotForTesting;
+
+    const firstRevision = session.update({
+      baseRevision: initial.revision,
+      embeddedRegions: regions,
+    });
+    const first = session.snapshotForTesting;
+    expect(first.revision).toBe(firstRevision);
+    expect(first.sourceSequence).toBe(initial.sourceSequence + 1);
+
+    region.from = 0;
+    region.language = "jinja";
+    regions.length = 0;
+    expect(first.source.embeddedRegions).toEqual([
+      { from: 14, language: "python", to: 18 },
+    ]);
+
+    const secondRevision = session.update({
+      baseRevision: firstRevision,
+      embeddedRegions: [{ from: 14, language: "python", to: 18 }],
+    });
+    const second = session.snapshotForTesting;
+    expect(secondRevision).not.toBe(firstRevision);
+    expect(second.sourceSequence).toBe(first.sourceSequence + 1);
+    expect(second.source).toBe(first.source);
+
+    session.update({
+      baseRevision: secondRevision,
+      embeddedRegions: [{ from: 14, language: "jinja", to: 18 }],
+    });
+    session.update({
+      baseRevision: session.revision,
+      embeddedRegions: [{ from: 14, language: "python", to: 18 }],
+    });
+    expect(session.snapshotForTesting.source.embeddedRegions).toEqual([
+      { from: 14, language: "python", to: 18 },
+    ]);
+  });
+
+  it("validates complete regions against the resulting document", () => {
+    const { session } = openSession("A");
+    session.update({
+      baseRevision: session.revision,
+      document: { kind: "replace", text: "ABCDE" },
+      embeddedRegions: [{ from: 1, language: "python", to: 5 }],
+    });
+    expect(session.snapshotForTesting.source.analysisText).toBe("A    ");
+
+    const snapshot = session.snapshotForTesting;
+    expectSessionError("invalid-update", () => {
+      session.update({
+        baseRevision: snapshot.revision,
+        document: { kind: "replace", text: "A" },
+        embeddedRegions: [{ from: 1, language: "python", to: 5 }],
+      });
+    });
+    expect(session.snapshotForTesting).toBe(snapshot);
+  });
+
+  it("rolls back document, context, source, revision, and cache together", () => {
+    const { session } = openSession("SELECT 1; SELECT 2");
+    const index = session.getStatementIndexForTesting();
+    const snapshot = session.snapshotForTesting;
+
+    expectSessionError("invalid-update", () => {
+      session.update({
+        baseRevision: snapshot.revision,
+        context: { dialect: "postgresql", engine: "warehouse" },
+        document: { kind: "replace", text: "SELECT {x}" },
+        embeddedRegions: [{ from: 7, language: "python", to: 100 }],
+      });
+    });
+    expect(session.snapshotForTesting).toBe(snapshot);
+    expect(session.cachedStatementIndexForTesting).toBe(index);
+
+    expectSessionError("invalid-dialect", () => {
+      session.update({
+        baseRevision: snapshot.revision,
+        context: { dialect: "unknown", engine: "warehouse" },
+        document: { kind: "replace", text: "SELECT 2" },
+        embeddedRegions: [],
+      });
+    });
+    expect(session.snapshotForTesting).toBe(snapshot);
+    expect(session.cachedStatementIndexForTesting).toBe(index);
+  });
+
+  it("checks stale revisions before inspecting candidate payloads", () => {
+    const { session } = openSession("SELECT 1");
+    const stale = session.revision;
+    session.update({
+      baseRevision: stale,
+      context: { dialect: "duckdb", engine: "remote" },
+    });
+    let invoked = false;
+    const update = {
+      baseRevision: stale,
+      get document() {
+        invoked = true;
+        return { kind: "replace", text: "SELECT 2" };
+      },
+      get embeddedRegions() {
+        invoked = true;
+        return [];
+      },
+    };
+
+    expectSessionError("stale-revision", () => {
+      session.update(update as never);
+    });
+    expect(invoked).toBe(false);
+  });
+
+  it("reuses equal analysis and invalidates changed masking", () => {
+    const service = createService();
+    const session = service.openDocument({
+      context: { dialect: "duckdb", engine: "local" },
+      embeddedRegions: [{ from: 7, language: "python", to: 12 }],
+      text: "SELECT {x;y}; SELECT 2",
+    });
+    const index = session.getStatementIndexForTesting();
+
+    session.update({
+      baseRevision: session.revision,
+      embeddedRegions: [{ from: 7, language: "jinja", to: 12 }],
+    });
+    expect(session.cachedStatementIndexForTesting).toBe(index);
+
+    session.update({
+      baseRevision: session.revision,
+      embeddedRegions: [],
+    });
+    expect(session.cachedStatementIndexForTesting).toBeNull();
+    expect(session.getStatementIndexForTesting()).toEqual(
+      buildSqlStatementIndex(
+        session.snapshotForTesting.source.analysisText,
+        DUCKDB_SQL_LEXICAL_PROFILE,
+      ),
+    );
+  });
+
+  it("does not incrementally reuse original edits across masking", () => {
+    const service = createService();
+    const session = service.openDocument({
+      context: { dialect: "duckdb", engine: "local" },
+      embeddedRegions: [{ from: 7, language: "python", to: 12 }],
+      text: "SELECT {x;y}; SELECT 2",
+    });
+    session.getStatementIndexForTesting();
+
+    session.update({
+      baseRevision: session.revision,
+      document: {
+        changes: [{ from: 8, insert: "xx", to: 9 }],
+        kind: "changes",
+      },
+      embeddedRegions: [{ from: 7, language: "python", to: 13 }],
+    });
+    expect(session.cachedStatementIndexForTesting).toBeNull();
+    expect(session.getStatementIndexForTesting()).toEqual(
+      buildSqlStatementIndex(
+        session.snapshotForTesting.source.analysisText,
+        DUCKDB_SQL_LEXICAL_PROFILE,
+      ),
+    );
+  });
+
+  it("rejects malformed open and update region contracts", () => {
+    const service = createService();
+    expectSessionError("invalid-document", () => {
+      service.openDocument({
+        context: { dialect: "duckdb", engine: "local" },
+        embeddedRegions: undefined,
+        text: "",
+      } as never);
+    });
+    expectSessionError("invalid-document", () => {
+      service.openDocument({
+        context: { dialect: "duckdb", engine: "local" },
+        embeddedRegions: [
+          { extra: true, from: 0, language: "python", to: 1 },
+        ],
+        text: "x",
+      } as never);
+    });
+    expectSessionError("invalid-document", () => {
+      service.openDocument({
+        context: { dialect: "duckdb", engine: "local" },
+        extra: true,
+        text: "x",
+      } as never);
+    });
+
+    const { session } = openSession("SELECT 1");
+    const snapshot = session.snapshotForTesting;
+    expectSessionError("invalid-update", () => {
+      session.update({
+        baseRevision: session.revision,
+        document: { kind: "replace", text: "SELECT 2" },
+        embeddedRegions: undefined,
+      } as never);
+    });
+    expectSessionError("invalid-update", () => {
+      session.update({
+        baseRevision: session.revision,
+        embeddedRegions: [],
+        extra: true,
+      } as never);
+    });
+    expectSessionError("invalid-update", () => {
+      session.update({
+        baseRevision: session.revision,
+        document: { kind: "replace", text: "SELECT 2" },
+      } as never);
+    });
+    const symbolUpdate = {
+      baseRevision: session.revision,
+      embeddedRegions: [],
+      [Symbol("hidden")]: true,
+    };
+    expectSessionError("invalid-update", () => {
+      session.update(symbolUpdate as never);
+    });
+    const nonEnumerableUpdate = {
+      embeddedRegions: [],
+    };
+    Object.defineProperty(nonEnumerableUpdate, "baseRevision", {
+      enumerable: false,
+      value: session.revision,
+    });
+    expectSessionError("invalid-update", () => {
+      session.update(nonEnumerableUpdate as never);
+    });
+    const changes = [{ from: 0, insert: "SELECT 2", to: 8 }];
+    Object.defineProperty(changes, "extra", {
+      enumerable: true,
+      value: true,
+    });
+    expectSessionError("invalid-change", () => {
+      session.update({
+        baseRevision: session.revision,
+        document: { changes, kind: "changes" },
+        embeddedRegions: [],
+      });
+    });
+    expect(session.snapshotForTesting).toBe(snapshot);
+  });
+
+  it("keeps a valid outer region update after a rejected reentrant update", () => {
+    const { session } = openSession("x");
+    let nestedError: SqlSessionError | undefined;
+    let attempted = false;
+    const region = new Proxy(
+      { from: 0, language: "python", to: 1 },
+      {
+        ownKeys(target) {
+          if (!attempted) {
+            attempted = true;
+            try {
+              session.update({
+                baseRevision: session.revision,
+                context: { dialect: "duckdb", engine: "nested" },
+              });
+            } catch (error) {
+              if (error instanceof SqlSessionError) {
+                nestedError = error;
+              }
+            }
+          }
+          return Reflect.ownKeys(target);
+        },
+      },
+    );
+
+    session.update({
+      baseRevision: session.revision,
+      embeddedRegions: [region],
+    });
+    expect(nestedError?.code).toBe("reentrant-update");
+    expect(session.snapshotForTesting.source.analysisText).toBe(" ");
+  });
+
+  it("lets disposal dominate a hostile region failure", () => {
+    const { session } = openSession("x");
+    const snapshot = session.snapshotForTesting;
+    const region = new Proxy(
+      { from: 0, language: "python", to: 1 },
+      {
+        ownKeys() {
+          session.dispose();
+          throw new Error("hostile");
+        },
+      },
+    );
+
+    expectSessionError("session-disposed", () => {
+      session.update({
+        baseRevision: session.revision,
+        embeddedRegions: [region],
+      });
+    });
+    expect(session.snapshotForTesting).toBe(snapshot);
+    expect(session.cachedStatementIndexForTesting).toBeNull();
+    expect(session.isCurrent(snapshot.revision)).toBe(false);
   });
 });
 
@@ -370,7 +798,7 @@ describe("document changes", () => {
   it("applies ordered changes in pre-update coordinates", () => {
     const { session } = openSession("SELECT users.id FROM users");
     session.update({
-      kind: "document",
+      embeddedRegions: [],
       baseRevision: session.revision,
       document: {
         kind: "changes",
@@ -389,7 +817,7 @@ describe("document changes", () => {
   it("uses JavaScript UTF-16 offsets", () => {
     const { session } = openSession("A😀B");
     session.update({
-      kind: "document",
+      embeddedRegions: [],
       baseRevision: session.revision,
       document: {
         kind: "changes",
@@ -402,7 +830,7 @@ describe("document changes", () => {
   it("keeps same-position insertions ordered", () => {
     const { session } = openSession("AB");
     session.update({
-      kind: "document",
+      embeddedRegions: [],
       baseRevision: session.revision,
       document: {
         kind: "changes",
@@ -418,7 +846,7 @@ describe("document changes", () => {
   it("supports adjacent replacements and document boundaries", () => {
     const { session } = openSession("ABCDE");
     session.update({
-      kind: "document",
+      embeddedRegions: [],
       baseRevision: session.revision,
       document: {
         kind: "changes",
@@ -436,7 +864,7 @@ describe("document changes", () => {
   it("deletes the entire document", () => {
     const { session } = openSession("SELECT 1");
     session.update({
-      kind: "document",
+      embeddedRegions: [],
       baseRevision: session.revision,
       document: { kind: "changes", changes: [{ from: 0, insert: "", to: 8 }] },
     });
@@ -446,7 +874,7 @@ describe("document changes", () => {
   it("allows edits at every UTF-16 boundary", () => {
     const { session } = openSession("A😀e\u0301\r\nZ\uD800");
     session.update({
-      kind: "document",
+      embeddedRegions: [],
       baseRevision: session.revision,
       document: {
         kind: "changes",
@@ -477,7 +905,7 @@ describe("document changes", () => {
 
     expectSessionError("invalid-change", () => {
       session.update({
-        kind: "document",
+        embeddedRegions: [],
         baseRevision: revision,
         document: { kind: "changes", changes: [change] },
       });
@@ -492,7 +920,7 @@ describe("document changes", () => {
     const revision = session.revision;
     expectSessionError("invalid-change", () => {
       session.update({
-        kind: "document",
+        embeddedRegions: [],
         baseRevision: revision,
         document: {
           kind: "changes",
@@ -511,7 +939,7 @@ describe("document changes", () => {
     const { session } = openSession("ABC");
     expectSessionError("invalid-change", () => {
       session.update({
-        kind: "document",
+        embeddedRegions: [],
         baseRevision: session.revision,
         document: {
           kind: "changes",
@@ -532,7 +960,7 @@ describe("document changes", () => {
     const { session } = openSession("ABC");
     const revision = session.revision;
     expectSessionError("invalid-update", () => {
-      session.update({ kind: "document", baseRevision: revision, document } as never);
+      session.update({ embeddedRegions: [], baseRevision: revision, document } as never);
     });
     expect(session.revision).toBe(revision);
     expect(session.snapshotForTesting.source.originalText).toBe("ABC");
@@ -541,7 +969,7 @@ describe("document changes", () => {
   it("rejects an empty JavaScript update", () => {
     const { session } = openSession("ABC");
     expectSessionError("invalid-update", () => {
-      session.update({ kind: "document", baseRevision: session.revision } as never);
+      session.update({ baseRevision: session.revision } as never);
     });
   });
 
@@ -555,28 +983,26 @@ describe("document changes", () => {
     });
     expectSessionError("invalid-update", () => {
       session.update({
-        kind: "document",
+        embeddedRegions: [],
         baseRevision: session.revision,
         document: { kind: "unknown" },
       } as never);
     });
     expectSessionError("invalid-update", () => {
       session.update({
-        kind: "document",
+        embeddedRegions: [],
         baseRevision: session.revision,
         document: { kind: "replace", text: "ABC", changes: [] },
       } as never);
     });
     expectSessionError("invalid-update", () => {
       session.update({
-        kind: "context",
         baseRevision: session.revision,
         context: undefined,
       } as never);
     });
     expectSessionError("invalid-update", () => {
       session.update({
-        kind: "context",
         baseRevision: session.revision,
         context: { dialect: "duckdb", engine: "local" },
         document: { kind: "replace", text: "lost" },
@@ -598,7 +1024,7 @@ describe("document changes", () => {
       session.update(update as never);
     });
     session.update({
-      kind: "document",
+      embeddedRegions: [],
       baseRevision: session.revision,
       document: { kind: "replace", text: "recovered" },
     });
@@ -641,7 +1067,7 @@ describe("document changes", () => {
     const revision = session.revision;
     expectSessionError("invalid-update", () => {
       session.update({
-        kind: "document",
+        embeddedRegions: [],
         baseRevision: revision,
         context: undefined,
         document: { kind: "replace", text: "changed" },
@@ -654,7 +1080,7 @@ describe("document changes", () => {
     const update = {
       baseRevision: session.revision,
       document: { kind: "replace", text: "changed" },
-      kind: "document",
+      embeddedRegions: [],
       get context() {
         invoked = true;
         return { dialect: "postgresql", engine: "warehouse" };
@@ -680,7 +1106,7 @@ describe("document changes", () => {
     };
     expectSessionError("invalid-update", () => {
       session.update({
-        kind: "document",
+        embeddedRegions: [],
         baseRevision: session.revision,
         document,
       });
@@ -702,7 +1128,7 @@ describe("document changes", () => {
       }
       expectSessionError("invalid-change", () => {
         session.update({
-          kind: "document",
+          embeddedRegions: [],
           baseRevision: session.revision,
           document: { kind: "changes", changes: [change] },
         } as never);
@@ -727,7 +1153,7 @@ describe("document changes", () => {
             attempted = true;
             try {
               session.update({
-                kind: "document",
+                embeddedRegions: [],
                 baseRevision: originalRevision,
                 document: { kind: "replace", text: "nested" },
               });
@@ -743,7 +1169,7 @@ describe("document changes", () => {
     );
 
     const revision = session.update({
-      kind: "document",
+      embeddedRegions: [],
       baseRevision: originalRevision,
       document,
     });
@@ -773,7 +1199,7 @@ describe("document changes", () => {
 
     expectSessionError("session-disposed", () => {
       session.update({
-        kind: "document",
+        embeddedRegions: [],
         baseRevision: revision,
         document,
       });
@@ -788,7 +1214,7 @@ describe("document changes", () => {
     tooManyChanges.length = 10_001;
     expectSessionError("invalid-change", () => {
       session.update({
-        kind: "document",
+        embeddedRegions: [],
         baseRevision: session.revision,
         document: { kind: "changes", changes: tooManyChanges },
       });
@@ -796,7 +1222,7 @@ describe("document changes", () => {
 
     expectSessionError("invalid-document", () => {
       session.update({
-        kind: "document",
+        embeddedRegions: [],
         baseRevision: session.revision,
         document: {
           kind: "changes",
@@ -917,7 +1343,7 @@ describe("document context", () => {
   it("updates text and context atomically", () => {
     const { session } = openSession("SELECT 1");
     session.update({
-      kind: "document",
+      embeddedRegions: [],
       baseRevision: session.revision,
       context: { dialect: "postgresql", engine: "warehouse" },
       document: { kind: "replace", text: "SELECT 2" },
@@ -931,7 +1357,7 @@ describe("document context", () => {
     const snapshot = session.snapshotForTesting;
     expectSessionError("invalid-update", () => {
       session.update({
-        kind: "document",
+        embeddedRegions: [],
         baseRevision: snapshot.revision,
         context: { dialect: "duckdb", engine: "remote" },
         document: { kind: "replace", text: 42 },
@@ -943,7 +1369,6 @@ describe("document context", () => {
   it("supports context-only updates", () => {
     const { session } = openSession("SELECT 1");
     session.update({
-      kind: "context",
       baseRevision: session.revision,
       context: { dialect: "postgresql", engine: "warehouse" },
     });
@@ -955,7 +1380,7 @@ describe("document context", () => {
     const { session } = openSession();
     const context = session.snapshotForTesting.context;
     session.update({
-      kind: "document",
+      embeddedRegions: [],
       baseRevision: session.revision,
       document: { kind: "replace", text: "SELECT 1" },
     });
@@ -965,9 +1390,9 @@ describe("document context", () => {
   it("clones a supplied context again on every update", () => {
     const { session } = openSession();
     const context: TestContext = { dialect: "duckdb", engine: "local" };
-    session.update({ kind: "context", baseRevision: session.revision, context });
+    session.update({ baseRevision: session.revision, context });
     const firstOwned = session.snapshotForTesting.context;
-    session.update({ kind: "context", baseRevision: session.revision, context });
+    session.update({ baseRevision: session.revision, context });
     expect(session.snapshotForTesting.context).not.toBe(firstOwned);
   });
 
@@ -993,7 +1418,7 @@ describe("document context", () => {
     const revision = session.revision;
     expectSessionError(error as SqlSessionError["code"], () => {
       session.update({
-        kind: "document",
+        embeddedRegions: [],
         baseRevision: revision,
         context,
         document: { kind: "replace", text: "SELECT 2" },
@@ -1171,7 +1596,7 @@ describe("document context", () => {
   it("checks a stale base before inspecting candidate context", () => {
     const { session } = openSession();
     const stale = session.revision;
-    session.update({ kind: "document", baseRevision: stale, document: { kind: "replace", text: "SELECT 1" } });
+    session.update({ embeddedRegions: [], baseRevision: stale, document: { kind: "replace", text: "SELECT 1" } });
     let inspected = false;
     const context = {
       dialect: "duckdb",
@@ -1181,7 +1606,7 @@ describe("document context", () => {
       },
     };
     expectSessionError("stale-revision", () => {
-      session.update({ kind: "context", baseRevision: stale, context });
+      session.update({ baseRevision: stale, context });
     });
     expect(inspected).toBe(false);
   });
@@ -1197,7 +1622,7 @@ describe("lifecycle", () => {
     });
     const { dispose, isCurrent, update } = session;
     const revision = update({
-      kind: "document",
+      embeddedRegions: [],
       baseRevision: session.revision,
       document: { kind: "replace", text: "SELECT 1" },
     });
@@ -1225,7 +1650,7 @@ describe("lifecycle", () => {
     expect(session.isCurrent(revision)).toBe(false);
     expectSessionError("session-disposed", () => {
       session.update({
-        kind: "document",
+        embeddedRegions: [],
         baseRevision: revision,
         document: { kind: "replace", text: "SELECT 1" },
       });

--- a/src/vnext/__tests__/session.test.ts
+++ b/src/vnext/__tests__/session.test.ts
@@ -546,6 +546,43 @@ describe("embedded-region session transactions", () => {
     expect(session.snapshotForTesting).toBe(snapshot);
   });
 
+  it("creates and removes template delimiters in atomic transactions", () => {
+    const { session } = openSession("SELECT * FROM df");
+
+    session.update({
+      baseRevision: session.revision,
+      document: {
+        changes: [
+          { from: 14, insert: "{", to: 14 },
+          { from: 16, insert: "}", to: 16 },
+        ],
+        kind: "changes",
+      },
+      embeddedRegions: [{ from: 14, language: "python", to: 18 }],
+    });
+    expect(session.snapshotForTesting.source).toMatchObject({
+      analysisText: "SELECT * FROM     ",
+      originalText: "SELECT * FROM {df}",
+    });
+
+    session.update({
+      baseRevision: session.revision,
+      document: {
+        changes: [
+          { from: 14, insert: "", to: 15 },
+          { from: 17, insert: "", to: 18 },
+        ],
+        kind: "changes",
+      },
+      embeddedRegions: [],
+    });
+    expect(session.snapshotForTesting.source).toMatchObject({
+      analysisText: "SELECT * FROM df",
+      embeddedRegions: [],
+      originalText: "SELECT * FROM df",
+    });
+  });
+
   it("rolls back document, context, source, revision, and cache together", () => {
     const { session } = openSession("SELECT 1; SELECT 2");
     const index = session.getStatementIndexForTesting();
@@ -654,6 +691,41 @@ describe("embedded-region session transactions", () => {
     );
   });
 
+  it("accepts structural supersets without inspecting host metadata", () => {
+    const service = createService();
+    let invoked = false;
+    const input = {
+      context: { dialect: "duckdb", engine: "local" },
+      embeddedRegions: [
+        { from: 0, hostNodeId: "cell-1", language: "python", to: 1 },
+      ],
+      get hostMetadata() {
+        invoked = true;
+        throw new Error("must stay opaque");
+      },
+      text: "x",
+    };
+    const session = service.openDocument(input);
+    expect(session.snapshotForTesting.source.analysisText).toBe(" ");
+
+    const update = {
+      baseRevision: session.revision,
+      embeddedRegions: [
+        { from: 0, hostNodeId: "cell-2", language: "jinja", to: 1 },
+      ],
+      get hostMetadata() {
+        invoked = true;
+        throw new Error("must stay opaque");
+      },
+      [Symbol("host")]: true,
+    };
+    session.update(update);
+    expect(session.snapshotForTesting.source.embeddedRegions).toEqual([
+      { from: 0, language: "jinja", to: 1 },
+    ]);
+    expect(invoked).toBe(false);
+  });
+
   it("rejects malformed open and update region contracts", () => {
     const service = createService();
     expectSessionError("invalid-document", () => {
@@ -661,22 +733,6 @@ describe("embedded-region session transactions", () => {
         context: { dialect: "duckdb", engine: "local" },
         embeddedRegions: undefined,
         text: "",
-      } as never);
-    });
-    expectSessionError("invalid-document", () => {
-      service.openDocument({
-        context: { dialect: "duckdb", engine: "local" },
-        embeddedRegions: [
-          { extra: true, from: 0, language: "python", to: 1 },
-        ],
-        text: "x",
-      } as never);
-    });
-    expectSessionError("invalid-document", () => {
-      service.openDocument({
-        context: { dialect: "duckdb", engine: "local" },
-        extra: true,
-        text: "x",
       } as never);
     });
 
@@ -692,45 +748,15 @@ describe("embedded-region session transactions", () => {
     expectSessionError("invalid-update", () => {
       session.update({
         baseRevision: session.revision,
-        embeddedRegions: [],
-        extra: true,
-      } as never);
-    });
-    expectSessionError("invalid-update", () => {
-      session.update({
-        baseRevision: session.revision,
         document: { kind: "replace", text: "SELECT 2" },
       } as never);
     });
-    const symbolUpdate = {
-      baseRevision: session.revision,
-      embeddedRegions: [],
-      [Symbol("hidden")]: true,
-    };
     expectSessionError("invalid-update", () => {
-      session.update(symbolUpdate as never);
-    });
-    const nonEnumerableUpdate = {
-      embeddedRegions: [],
-    };
-    Object.defineProperty(nonEnumerableUpdate, "baseRevision", {
-      enumerable: false,
-      value: session.revision,
-    });
-    expectSessionError("invalid-update", () => {
-      session.update(nonEnumerableUpdate as never);
-    });
-    const changes = [{ from: 0, insert: "SELECT 2", to: 8 }];
-    Object.defineProperty(changes, "extra", {
-      enumerable: true,
-      value: true,
-    });
-    expectSessionError("invalid-change", () => {
       session.update({
+        kind: "document",
         baseRevision: session.revision,
-        document: { changes, kind: "changes" },
         embeddedRegions: [],
-      });
+      } as never);
     });
     expect(session.snapshotForTesting).toBe(snapshot);
   });
@@ -742,8 +768,8 @@ describe("embedded-region session transactions", () => {
     const region = new Proxy(
       { from: 0, language: "python", to: 1 },
       {
-        ownKeys(target) {
-          if (!attempted) {
+        getOwnPropertyDescriptor(target, property) {
+          if (property === "from" && !attempted) {
             attempted = true;
             try {
               session.update({
@@ -756,7 +782,7 @@ describe("embedded-region session transactions", () => {
               }
             }
           }
-          return Reflect.ownKeys(target);
+          return Reflect.getOwnPropertyDescriptor(target, property);
         },
       },
     );
@@ -775,9 +801,12 @@ describe("embedded-region session transactions", () => {
     const region = new Proxy(
       { from: 0, language: "python", to: 1 },
       {
-        ownKeys() {
-          session.dispose();
-          throw new Error("hostile");
+        getOwnPropertyDescriptor(target, property) {
+          if (property === "from") {
+            session.dispose();
+            throw new Error("hostile");
+          }
+          return Reflect.getOwnPropertyDescriptor(target, property);
         },
       },
     );

--- a/src/vnext/__tests__/session.test.ts
+++ b/src/vnext/__tests__/session.test.ts
@@ -1114,19 +1114,40 @@ describe("document changes", () => {
     const contextRevision = session.update({
       baseRevision: session.revision,
       context: { dialect: "duckdb", engine: "warehouse" },
+      document: undefined,
       embeddedRegions: undefined,
     });
     expect(session.revision).toBe(contextRevision);
     expect(session.snapshotForTesting.context.engine).toBe("warehouse");
 
-    const documentRevision = session.update({
+    const regionRevision = session.update({
+      baseRevision: session.revision,
+      context: undefined,
+      document: undefined,
+      embeddedRegions: [{ from: 7, language: "python", to: 8 }],
+    });
+    expect(session.revision).toBe(regionRevision);
+    expect(session.snapshotForTesting.source.embeddedRegions).toEqual([
+      { from: 7, language: "python", to: 8 },
+    ]);
+
+    const replacementRevision = session.update({
       baseRevision: session.revision,
       context: undefined,
       document: { kind: "replace", text: "SELECT 2" },
       embeddedRegions: [],
     });
-    expect(session.revision).toBe(documentRevision);
+    expect(session.revision).toBe(replacementRevision);
     expect(session.snapshotForTesting.source.originalText).toBe("SELECT 2");
+
+    expectSessionError("invalid-update", () => {
+      session.update({
+        baseRevision: session.revision,
+        context: undefined,
+        document: undefined,
+        embeddedRegions: undefined,
+      } as never);
+    });
   });
 
   it("rejects accessor document fields without invoking them", () => {

--- a/src/vnext/__tests__/session.test.ts
+++ b/src/vnext/__tests__/session.test.ts
@@ -727,15 +727,6 @@ describe("embedded-region session transactions", () => {
   });
 
   it("rejects malformed open and update region contracts", () => {
-    const service = createService();
-    expectSessionError("invalid-document", () => {
-      service.openDocument({
-        context: { dialect: "duckdb", engine: "local" },
-        embeddedRegions: undefined,
-        text: "",
-      } as never);
-    });
-
     const { session } = openSession("SELECT 1");
     const snapshot = session.snapshotForTesting;
     expectSessionError("invalid-update", () => {
@@ -1091,20 +1082,9 @@ describe("document changes", () => {
     expect(session.snapshotForTesting.source.originalText).toBe("ABC");
   });
 
-  it("rejects undefined and accessor optional update fields", () => {
+  it("rejects accessor optional update fields", () => {
     const { session } = openSession("ABC");
     const revision = session.revision;
-    expectSessionError("invalid-update", () => {
-      session.update({
-        embeddedRegions: [],
-        baseRevision: revision,
-        context: undefined,
-        document: { kind: "replace", text: "changed" },
-      } as never);
-    });
-    expect(session.revision).toBe(revision);
-    expect(session.snapshotForTesting.source.originalText).toBe("ABC");
-
     let invoked = false;
     const update = {
       baseRevision: session.revision,
@@ -1121,6 +1101,32 @@ describe("document changes", () => {
     expect(invoked).toBe(false);
     expect(session.revision).toBe(revision);
     expect(session.snapshotForTesting.source.originalText).toBe("ABC");
+  });
+
+  it("treats undefined optional state fields as omission", () => {
+    const service = createService();
+    const session = service.openDocument({
+      context: { dialect: "duckdb", engine: "local" },
+      embeddedRegions: undefined,
+      text: "SELECT 1",
+    });
+
+    const contextRevision = session.update({
+      baseRevision: session.revision,
+      context: { dialect: "duckdb", engine: "warehouse" },
+      embeddedRegions: undefined,
+    });
+    expect(session.revision).toBe(contextRevision);
+    expect(session.snapshotForTesting.context.engine).toBe("warehouse");
+
+    const documentRevision = session.update({
+      baseRevision: session.revision,
+      context: undefined,
+      document: { kind: "replace", text: "SELECT 2" },
+      embeddedRegions: [],
+    });
+    expect(session.revision).toBe(documentRevision);
+    expect(session.snapshotForTesting.source.originalText).toBe("SELECT 2");
   });
 
   it("rejects accessor document fields without invoking them", () => {
@@ -1471,6 +1477,18 @@ describe("document context", () => {
       createService().openDocument({ context, text: "" });
     });
     expect(invoked).toBe(false);
+  });
+
+  it("reports non-enumerable context properties accurately", () => {
+    const context = { dialect: "duckdb" };
+    Object.defineProperty(context, "engine", {
+      enumerable: false,
+      value: "local",
+    });
+
+    expect(() => {
+      createService().openDocument({ context: context as TestContext, text: "" });
+    }).toThrowError("SQL document context cannot contain non-enumerable properties");
   });
 
   it("rejects symbol keys", () => {

--- a/src/vnext/__tests__/source.test.ts
+++ b/src/vnext/__tests__/source.test.ts
@@ -210,7 +210,7 @@ describe("SQL source snapshots", () => {
     });
   });
 
-  it("rejects sparse, oversized, and extended region arrays", () => {
+  it("rejects sparse and oversized region arrays", () => {
     const sparse: unknown[] = [];
     sparse.length = 1;
     expectSourceError("invalid-source", () => {
@@ -222,36 +222,56 @@ describe("SQL source snapshots", () => {
     expectSourceError("invalid-region", () => {
       createMaskedSqlSource("a", oversized);
     });
+  });
 
+  it("copies declared region fields and ignores structural extras", () => {
     const extended = [{ from: 0, language: "python", to: 1 }];
-    Object.defineProperty(extended, "custom", { value: true });
-    expectSourceError("invalid-region", () => {
-      createMaskedSqlSource("a", extended);
+    Object.defineProperty(extended, "custom", {
+      get() {
+        throw new Error("must stay opaque");
+      },
     });
+    expect(createMaskedSqlSource("a", extended).analysisText).toBe(" ");
 
     const nonEnumerableRegion = { from: 0, language: "python", to: 1 };
     Object.defineProperty(nonEnumerableRegion, "language", {
       enumerable: false,
       value: "python",
     });
-    expectSourceError("invalid-region", () => {
-      createMaskedSqlSource("a", [nonEnumerableRegion]);
-    });
+    expect(createMaskedSqlSource("a", [nonEnumerableRegion]).analysisText).toBe(
+      " ",
+    );
 
+    let invoked = false;
     const symbolRegion = {
       from: 0,
+      get hostMetadata() {
+        invoked = true;
+        throw new Error("must stay opaque");
+      },
       language: "python",
       to: 1,
       [Symbol("hidden")]: true,
     };
-    expectSourceError("invalid-region", () => {
-      createMaskedSqlSource("a", [symbolRegion]);
-    });
+    expect(createMaskedSqlSource("a", [symbolRegion]).analysisText).toBe(" ");
+    expect(invoked).toBe(false);
+
+    const proxiedRegion = new Proxy(
+      { from: 0, language: "python", to: 1 },
+      {
+        ownKeys() {
+          invoked = true;
+          throw new Error("must stay opaque");
+        },
+      },
+    );
+    expect(createMaskedSqlSource("a", [proxiedRegion]).analysisText).toBe(" ");
+    expect(invoked).toBe(false);
   });
 
   it("does not invoke region accessors or array get traps", () => {
     let accessorInvoked = false;
-    expectSourceError("invalid-region", () => {
+    expectSourceError("invalid-source", () => {
       createMaskedSqlSource("a", [
         {
           get from() {
@@ -265,7 +285,7 @@ describe("SQL source snapshots", () => {
     });
     expect(accessorInvoked).toBe(false);
 
-    expectSourceError("invalid-region", () => {
+    expectSourceError("invalid-source", () => {
       createMaskedSqlSource("a", [
         {
           from: 0,
@@ -297,7 +317,7 @@ describe("SQL source snapshots", () => {
         new Proxy(
           [],
           {
-            ownKeys() {
+            getOwnPropertyDescriptor() {
               throw new Error("hostile");
             },
           },
@@ -321,7 +341,7 @@ describe("SQL source snapshots", () => {
         new Proxy(
           [],
           {
-            ownKeys() {
+            getOwnPropertyDescriptor() {
               throw hostileError;
             },
           },

--- a/src/vnext/__tests__/source.test.ts
+++ b/src/vnext/__tests__/source.test.ts
@@ -228,11 +228,30 @@ describe("SQL source snapshots", () => {
     expectSourceError("invalid-region", () => {
       createMaskedSqlSource("a", extended);
     });
+
+    const nonEnumerableRegion = { from: 0, language: "python", to: 1 };
+    Object.defineProperty(nonEnumerableRegion, "language", {
+      enumerable: false,
+      value: "python",
+    });
+    expectSourceError("invalid-region", () => {
+      createMaskedSqlSource("a", [nonEnumerableRegion]);
+    });
+
+    const symbolRegion = {
+      from: 0,
+      language: "python",
+      to: 1,
+      [Symbol("hidden")]: true,
+    };
+    expectSourceError("invalid-region", () => {
+      createMaskedSqlSource("a", [symbolRegion]);
+    });
   });
 
   it("does not invoke region accessors or array get traps", () => {
     let accessorInvoked = false;
-    expectSourceError("invalid-source", () => {
+    expectSourceError("invalid-region", () => {
       createMaskedSqlSource("a", [
         {
           get from() {
@@ -246,7 +265,7 @@ describe("SQL source snapshots", () => {
     });
     expect(accessorInvoked).toBe(false);
 
-    expectSourceError("invalid-source", () => {
+    expectSourceError("invalid-region", () => {
       createMaskedSqlSource("a", [
         {
           from: 0,

--- a/src/vnext/index.ts
+++ b/src/vnext/index.ts
@@ -13,6 +13,7 @@ export type {
   SqlDocumentChanges,
   SqlDocumentContext,
   SqlDocumentEdit,
+  SqlEmbeddedRegion,
   SqlDocumentReplacement,
   SqlDocumentSession,
   SqlDocumentUpdate,

--- a/src/vnext/relation-completion-types.ts
+++ b/src/vnext/relation-completion-types.ts
@@ -1,8 +1,6 @@
-import type { SqlEmbeddedRegion } from "./source.js";
 import type {
-  SqlContextInput,
   SqlDocumentContext,
-  SqlDocumentEdit,
+  SqlDocumentUpdate,
   SqlIdentifierComponent,
   SqlIdentifierPath,
   SqlRevision,
@@ -165,48 +163,6 @@ export interface SqlRelationCompletionDialectRuntime {
     right: SqlIdentifierComponent,
   ) => boolean;
 }
-
-export interface SqlRelationCompletionOpenDocument<
-  Context extends SqlDocumentContext,
-> {
-  readonly text: string;
-  readonly context: SqlContextInput<Context>;
-  readonly embeddedRegions?: readonly SqlEmbeddedRegion[];
-}
-
-interface SqlRelationCompletionUpdateBase {
-  readonly baseRevision: SqlRevision;
-}
-
-type SqlRelationCompletionDocumentUpdate<
-  Context extends SqlDocumentContext,
-> = SqlRelationCompletionUpdateBase & {
-  readonly document: SqlDocumentEdit;
-  readonly embeddedRegions: readonly SqlEmbeddedRegion[];
-  readonly context?: SqlContextInput<Context>;
-};
-
-type SqlRelationCompletionContextUpdate<
-  Context extends SqlDocumentContext,
-> = SqlRelationCompletionUpdateBase & {
-  readonly document?: never;
-  readonly context: SqlContextInput<Context>;
-  readonly embeddedRegions?: readonly SqlEmbeddedRegion[];
-};
-
-type SqlRelationCompletionRegionUpdate =
-  SqlRelationCompletionUpdateBase & {
-    readonly document?: never;
-    readonly context?: never;
-    readonly embeddedRegions: readonly SqlEmbeddedRegion[];
-  };
-
-export type SqlRelationCompletionDocumentTransaction<
-  Context extends SqlDocumentContext,
-> =
-  | SqlRelationCompletionDocumentUpdate<Context>
-  | SqlRelationCompletionContextUpdate<Context>
-  | SqlRelationCompletionRegionUpdate;
 
 export type SqlSessionChangeReason =
   | "catalog"
@@ -372,7 +328,7 @@ export interface SqlRelationCompletionSession<
 > {
   readonly revision: SqlRevision;
   readonly update: (
-    transaction: SqlRelationCompletionDocumentTransaction<Context>,
+    transaction: SqlDocumentUpdate<Context>,
   ) => SqlRevision;
   readonly complete: (
     request: SqlCompletionRequest,

--- a/src/vnext/session.ts
+++ b/src/vnext/session.ts
@@ -42,30 +42,6 @@ const MAX_CONTEXT_STRING_LENGTH = 1_000_000;
 const MAX_CONTEXT_ARRAY_LENGTH = 50_000;
 const MAX_CHANGES_PER_UPDATE = 10_000;
 const MAX_DIALECTS = 1_000;
-const DOCUMENT_CHANGE_KEYS: ReadonlySet<string> = new Set([
-  "from",
-  "insert",
-  "to",
-]);
-const DOCUMENT_CHANGES_KEYS: ReadonlySet<string> = new Set([
-  "changes",
-  "kind",
-]);
-const DOCUMENT_REPLACEMENT_KEYS: ReadonlySet<string> = new Set([
-  "kind",
-  "text",
-]);
-const DOCUMENT_UPDATE_KEYS: ReadonlySet<string> = new Set([
-  "baseRevision",
-  "context",
-  "document",
-  "embeddedRegions",
-]);
-const OPEN_DOCUMENT_KEYS: ReadonlySet<string> = new Set([
-  "context",
-  "embeddedRegions",
-  "text",
-]);
 
 interface SqlDialectRuntime {
   readonly dialect: SqlDialect;
@@ -424,30 +400,17 @@ function readRequiredDataProperty(
   return property.value;
 }
 
-function validateOwnDataKeys(
+function rejectOwnProperty(
   value: object,
-  allowedKeys: ReadonlySet<string>,
+  key: PropertyKey,
   code: SqlSessionError["code"],
   subject: string,
 ): void {
-  for (const key of Reflect.ownKeys(value)) {
-    if (typeof key !== "string" || !allowedKeys.has(key)) {
-      throw new SqlSessionError(
-        code,
-        `${subject} contains an unexpected property`,
-      );
-    }
-    const descriptor = Object.getOwnPropertyDescriptor(value, key);
-    if (
-      !descriptor ||
-      !descriptor.enumerable ||
-      !("value" in descriptor)
-    ) {
-      throw new SqlSessionError(
-        code,
-        `${subject} property ${key} must be an enumerable data property`,
-      );
-    }
+  if (readOwnDataProperty(value, key, code, subject).found) {
+    throw new SqlSessionError(
+      code,
+      `${subject} cannot contain ${String(key)}`,
+    );
   }
 }
 
@@ -472,33 +435,6 @@ function readArrayLength(
   return length;
 }
 
-function validateDenseArrayEntries(
-  value: readonly unknown[],
-  length: number,
-  code: SqlSessionError["code"],
-  subject: string,
-): void {
-  for (const key of Reflect.ownKeys(value)) {
-    if (key === "length") {
-      continue;
-    }
-    const descriptor = Object.getOwnPropertyDescriptor(value, key);
-    if (
-      typeof key !== "string" ||
-      !/^(0|[1-9]\d*)$/.test(key) ||
-      Number(key) >= length ||
-      !descriptor ||
-      !descriptor.enumerable ||
-      !("value" in descriptor)
-    ) {
-      throw new SqlSessionError(
-        code,
-        `${subject} must be a dense array of enumerable data entries`,
-      );
-    }
-  }
-}
-
 function normalizeChanges(text: string, changes: readonly unknown[]): SqlTextChange[] {
   const changeCount = readArrayLength(
     changes,
@@ -511,12 +447,6 @@ function normalizeChanges(text: string, changes: readonly unknown[]): SqlTextCha
       `SQL document updates cannot contain more than ${MAX_CHANGES_PER_UPDATE} changes`,
     );
   }
-  validateDenseArrayEntries(
-    changes,
-    changeCount,
-    "invalid-change",
-    "SQL document changes",
-  );
   const normalized: SqlTextChange[] = [];
   let previousEnd = 0;
   let nextLength = text.length;
@@ -534,12 +464,6 @@ function normalizeChanges(text: string, changes: readonly unknown[]): SqlTextCha
         `SQL change ${index} must be an object`,
       );
     }
-    validateOwnDataKeys(
-      change,
-      DOCUMENT_CHANGE_KEYS,
-      "invalid-change",
-      `SQL change ${index}`,
-    );
     let range: SqlTextRange;
     try {
       range = normalizeSqlTextRange(
@@ -764,9 +688,9 @@ export class DefaultSqlDocumentSession<Context extends SqlDocumentContext>
     if (baseRevision !== this.#snapshot.revision) {
       throw new SqlSessionError("stale-revision", "SQL document revision is stale");
     }
-    validateOwnDataKeys(
+    rejectOwnProperty(
       update,
-      DOCUMENT_UPDATE_KEYS,
+      "kind",
       "invalid-update",
       "SQL document update",
     );
@@ -835,9 +759,9 @@ export class DefaultSqlDocumentSession<Context extends SqlDocumentContext>
         "SQL document mutation",
       );
       if (documentKind === "replace") {
-        validateOwnDataKeys(
+        rejectOwnProperty(
           document.value,
-          DOCUMENT_REPLACEMENT_KEYS,
+          "changes",
           "invalid-update",
           "SQL document replacement",
         );
@@ -857,9 +781,9 @@ export class DefaultSqlDocumentSession<Context extends SqlDocumentContext>
         nextText = text;
         documentMutation = "replace";
       } else if (documentKind === "changes") {
-        validateOwnDataKeys(
+        rejectOwnProperty(
           document.value,
-          DOCUMENT_CHANGES_KEYS,
+          "text",
           "invalid-update",
           "SQL document changes",
         );
@@ -1092,12 +1016,6 @@ export class DefaultSqlLanguageService<Context extends SqlDocumentContext>
           "Open SQL document input must be an object",
         );
       }
-      validateOwnDataKeys(
-        input,
-        OPEN_DOCUMENT_KEYS,
-        "invalid-document",
-        "Open SQL document input",
-      );
       const text = readRequiredDataProperty(
         input,
         "text",

--- a/src/vnext/session.ts
+++ b/src/vnext/session.ts
@@ -155,14 +155,16 @@ function getDataProperties(value: object): DataProperties {
       );
     }
     const descriptor = Object.getOwnPropertyDescriptor(value, key);
-    if (
-      !descriptor ||
-      !descriptor.enumerable ||
-      !("value" in descriptor)
-    ) {
+    if (!descriptor || !("value" in descriptor)) {
       throw new SqlSessionError(
         "invalid-context",
         "SQL document context cannot contain accessors",
+      );
+    }
+    if (!descriptor.enumerable) {
+      throw new SqlSessionError(
+        "invalid-context",
+        "SQL document context cannot contain non-enumerable properties",
       );
     }
     values.push(descriptor.value);
@@ -713,26 +715,20 @@ export class DefaultSqlDocumentSession<Context extends SqlDocumentContext>
       "invalid-update",
       "SQL document update",
     );
-    if (!document.found && !context.found && !embeddedRegions.found) {
+    const hasDocument = document.found && document.value !== undefined;
+    const hasContext = context.found && context.value !== undefined;
+    const hasEmbeddedRegions =
+      embeddedRegions.found && embeddedRegions.value !== undefined;
+    if (!hasDocument && !hasContext && !hasEmbeddedRegions) {
       throw new SqlSessionError(
         "invalid-update",
         "SQL document update must change document, context, or embedded regions",
       );
     }
-    if (document.found && !embeddedRegions.found) {
+    if (hasDocument && !hasEmbeddedRegions) {
       throw new SqlSessionError(
         "invalid-update",
         "SQL document mutations require the complete resulting embedded regions",
-      );
-    }
-    if (
-      (document.found && document.value === undefined) ||
-      (context.found && context.value === undefined) ||
-      (embeddedRegions.found && embeddedRegions.value === undefined)
-    ) {
-      throw new SqlSessionError(
-        "invalid-update",
-        "SQL document update values cannot be undefined",
       );
     }
 
@@ -745,7 +741,7 @@ export class DefaultSqlDocumentSession<Context extends SqlDocumentContext>
     let trustedAnalysisChanges: readonly SqlTextChange[] | null = null;
 
     let nextText = this.#snapshot.source.originalText;
-    if (document.found) {
+    if (hasDocument) {
       if (document.value === null || typeof document.value !== "object") {
         throw new SqlSessionError(
           "invalid-update",
@@ -818,7 +814,7 @@ export class DefaultSqlDocumentSession<Context extends SqlDocumentContext>
       nextDocumentSequence += 1;
     }
 
-    if (embeddedRegions.found) {
+    if (hasEmbeddedRegions) {
       const candidateSource = createMaskedSqlSource(
         nextText,
         embeddedRegions.value,
@@ -841,13 +837,7 @@ export class DefaultSqlDocumentSession<Context extends SqlDocumentContext>
       }
     }
 
-    if (context.found) {
-      if (context.value === undefined) {
-        throw new SqlSessionError(
-          "invalid-update",
-          "SQL document update context cannot be undefined",
-        );
-      }
+    if (hasContext) {
       nextContext = cloneContext<Context>(context.value);
       nextContextSequence += 1;
     }
@@ -1035,13 +1025,7 @@ export class DefaultSqlLanguageService<Context extends SqlDocumentContext>
         "invalid-document",
         "Open SQL document input",
       );
-      if (embeddedRegions.found && embeddedRegions.value === undefined) {
-        throw new SqlSessionError(
-          "invalid-document",
-          "Open SQL document embedded regions cannot be undefined",
-        );
-      }
-      const source = embeddedRegions.found
+      const source = embeddedRegions.found && embeddedRegions.value !== undefined
         ? createMaskedSqlSource(text, embeddedRegions.value)
         : createIdentitySqlSource(text);
       const candidateContext = readRequiredDataProperty(

--- a/src/vnext/session.ts
+++ b/src/vnext/session.ts
@@ -21,6 +21,7 @@ import {
 } from "./statement-index.js";
 import {
   createIdentitySqlSource,
+  createMaskedSqlSource,
   isSqlSourceError,
   MAX_SQL_SOURCE_LENGTH,
   normalizeSqlTextRange,
@@ -41,6 +42,30 @@ const MAX_CONTEXT_STRING_LENGTH = 1_000_000;
 const MAX_CONTEXT_ARRAY_LENGTH = 50_000;
 const MAX_CHANGES_PER_UPDATE = 10_000;
 const MAX_DIALECTS = 1_000;
+const DOCUMENT_CHANGE_KEYS: ReadonlySet<string> = new Set([
+  "from",
+  "insert",
+  "to",
+]);
+const DOCUMENT_CHANGES_KEYS: ReadonlySet<string> = new Set([
+  "changes",
+  "kind",
+]);
+const DOCUMENT_REPLACEMENT_KEYS: ReadonlySet<string> = new Set([
+  "kind",
+  "text",
+]);
+const DOCUMENT_UPDATE_KEYS: ReadonlySet<string> = new Set([
+  "baseRevision",
+  "context",
+  "document",
+  "embeddedRegions",
+]);
+const OPEN_DOCUMENT_KEYS: ReadonlySet<string> = new Set([
+  "context",
+  "embeddedRegions",
+  "text",
+]);
 
 interface SqlDialectRuntime {
   readonly dialect: SqlDialect;
@@ -154,7 +179,11 @@ function getDataProperties(value: object): DataProperties {
       );
     }
     const descriptor = Object.getOwnPropertyDescriptor(value, key);
-    if (!descriptor || !("value" in descriptor)) {
+    if (
+      !descriptor ||
+      !descriptor.enumerable ||
+      !("value" in descriptor)
+    ) {
       throw new SqlSessionError(
         "invalid-context",
         "SQL document context cannot contain accessors",
@@ -395,6 +424,33 @@ function readRequiredDataProperty(
   return property.value;
 }
 
+function validateOwnDataKeys(
+  value: object,
+  allowedKeys: ReadonlySet<string>,
+  code: SqlSessionError["code"],
+  subject: string,
+): void {
+  for (const key of Reflect.ownKeys(value)) {
+    if (typeof key !== "string" || !allowedKeys.has(key)) {
+      throw new SqlSessionError(
+        code,
+        `${subject} contains an unexpected property`,
+      );
+    }
+    const descriptor = Object.getOwnPropertyDescriptor(value, key);
+    if (
+      !descriptor ||
+      !descriptor.enumerable ||
+      !("value" in descriptor)
+    ) {
+      throw new SqlSessionError(
+        code,
+        `${subject} property ${key} must be an enumerable data property`,
+      );
+    }
+  }
+}
+
 function validateDocumentLength(text: string): void {
   if (text.length > MAX_SQL_SOURCE_LENGTH) {
     throw new SqlSessionError(
@@ -416,6 +472,33 @@ function readArrayLength(
   return length;
 }
 
+function validateDenseArrayEntries(
+  value: readonly unknown[],
+  length: number,
+  code: SqlSessionError["code"],
+  subject: string,
+): void {
+  for (const key of Reflect.ownKeys(value)) {
+    if (key === "length") {
+      continue;
+    }
+    const descriptor = Object.getOwnPropertyDescriptor(value, key);
+    if (
+      typeof key !== "string" ||
+      !/^(0|[1-9]\d*)$/.test(key) ||
+      Number(key) >= length ||
+      !descriptor ||
+      !descriptor.enumerable ||
+      !("value" in descriptor)
+    ) {
+      throw new SqlSessionError(
+        code,
+        `${subject} must be a dense array of enumerable data entries`,
+      );
+    }
+  }
+}
+
 function normalizeChanges(text: string, changes: readonly unknown[]): SqlTextChange[] {
   const changeCount = readArrayLength(
     changes,
@@ -428,6 +511,12 @@ function normalizeChanges(text: string, changes: readonly unknown[]): SqlTextCha
       `SQL document updates cannot contain more than ${MAX_CHANGES_PER_UPDATE} changes`,
     );
   }
+  validateDenseArrayEntries(
+    changes,
+    changeCount,
+    "invalid-change",
+    "SQL document changes",
+  );
   const normalized: SqlTextChange[] = [];
   let previousEnd = 0;
   let nextLength = text.length;
@@ -445,6 +534,12 @@ function normalizeChanges(text: string, changes: readonly unknown[]): SqlTextCha
         `SQL change ${index} must be an object`,
       );
     }
+    validateOwnDataKeys(
+      change,
+      DOCUMENT_CHANGE_KEYS,
+      "invalid-change",
+      `SQL change ${index}`,
+    );
     let range: SqlTextRange;
     try {
       range = normalizeSqlTextRange(
@@ -507,6 +602,29 @@ function applyChanges(text: string, changes: readonly SqlTextChange[]): string {
   return output.join("");
 }
 
+function haveEqualEmbeddedRegions(
+  left: SqlSourceSnapshot,
+  right: SqlSourceSnapshot,
+): boolean {
+  if (left.embeddedRegions.length !== right.embeddedRegions.length) {
+    return false;
+  }
+  for (let index = 0; index < left.embeddedRegions.length; index += 1) {
+    const leftRegion = left.embeddedRegions[index];
+    const rightRegion = right.embeddedRegions[index];
+    if (
+      !leftRegion ||
+      !rightRegion ||
+      leftRegion.from !== rightRegion.from ||
+      leftRegion.to !== rightRegion.to ||
+      leftRegion.language !== rightRegion.language
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
 interface SessionSnapshot<Context extends SqlDocumentContext> {
   readonly contextSequence: number;
   readonly context: Context;
@@ -515,12 +633,13 @@ interface SessionSnapshot<Context extends SqlDocumentContext> {
   readonly revision: SqlRevision;
   readonly sequence: number;
   readonly source: SqlSourceSnapshot;
+  readonly sourceSequence: number;
 }
 
 interface StatementIndexCache {
-  readonly documentSequence: number;
   readonly index: SqlStatementIndex;
   readonly lexicalProfile: SqlLexicalProfile;
+  readonly sourceSequence: number;
 }
 
 export class DefaultSqlDocumentSession<Context extends SqlDocumentContext>
@@ -544,6 +663,7 @@ export class DefaultSqlDocumentSession<Context extends SqlDocumentContext>
     const sequence = 0;
     const contextSequence = 0;
     const documentSequence = 0;
+    const sourceSequence = 0;
     const dialect = resolveDialectRuntime(context, dialects);
     this.#snapshot = Object.freeze({
       contextSequence,
@@ -553,6 +673,7 @@ export class DefaultSqlDocumentSession<Context extends SqlDocumentContext>
       revision: createSqlRevisionToken(),
       sequence,
       source,
+      sourceSequence,
     });
   }
 
@@ -578,7 +699,7 @@ export class DefaultSqlDocumentSession<Context extends SqlDocumentContext>
     const cached = this.#statementIndexCache;
     if (
       cached &&
-      cached.documentSequence === this.#snapshot.documentSequence &&
+      cached.sourceSequence === this.#snapshot.sourceSequence &&
       cached.lexicalProfile === this.#snapshot.dialect.lexicalProfile
     ) {
       return cached.index;
@@ -588,9 +709,9 @@ export class DefaultSqlDocumentSession<Context extends SqlDocumentContext>
       this.#snapshot.dialect.lexicalProfile,
     );
     this.#statementIndexCache = Object.freeze({
-      documentSequence: this.#snapshot.documentSequence,
       index,
       lexicalProfile: this.#snapshot.dialect.lexicalProfile,
+      sourceSequence: this.#snapshot.sourceSequence,
     });
     return index;
   }
@@ -609,6 +730,12 @@ export class DefaultSqlDocumentSession<Context extends SqlDocumentContext>
     try {
       return this.#applyUpdate(update);
     } catch (error) {
+      if (this.#disposed) {
+        throw new SqlSessionError(
+          "session-disposed",
+          "SQL document session was disposed during the update",
+        );
+      }
       if (error instanceof SqlSessionError) {
         throw error;
       }
@@ -628,12 +755,6 @@ export class DefaultSqlDocumentSession<Context extends SqlDocumentContext>
         "SQL document update must be an object",
       );
     }
-    const kind = readRequiredDataProperty(
-      update,
-      "kind",
-      "invalid-update",
-      "SQL document update",
-    );
     const baseRevision = readRequiredDataProperty(
       update,
       "baseRevision",
@@ -643,99 +764,85 @@ export class DefaultSqlDocumentSession<Context extends SqlDocumentContext>
     if (baseRevision !== this.#snapshot.revision) {
       throw new SqlSessionError("stale-revision", "SQL document revision is stale");
     }
-    if (kind !== "document" && kind !== "context") {
+    validateOwnDataKeys(
+      update,
+      DOCUMENT_UPDATE_KEYS,
+      "invalid-update",
+      "SQL document update",
+    );
+
+    const document = readOwnDataProperty(
+      update,
+      "document",
+      "invalid-update",
+      "SQL document update",
+    );
+    const context = readOwnDataProperty(
+      update,
+      "context",
+      "invalid-update",
+      "SQL document update",
+    );
+    const embeddedRegions = readOwnDataProperty(
+      update,
+      "embeddedRegions",
+      "invalid-update",
+      "SQL document update",
+    );
+    if (!document.found && !context.found && !embeddedRegions.found) {
       throw new SqlSessionError(
         "invalid-update",
-        "SQL document update kind must be document or context",
+        "SQL document update must change document, context, or embedded regions",
+      );
+    }
+    if (document.found && !embeddedRegions.found) {
+      throw new SqlSessionError(
+        "invalid-update",
+        "SQL document mutations require the complete resulting embedded regions",
+      );
+    }
+    if (
+      (document.found && document.value === undefined) ||
+      (context.found && context.value === undefined) ||
+      (embeddedRegions.found && embeddedRegions.value === undefined)
+    ) {
+      throw new SqlSessionError(
+        "invalid-update",
+        "SQL document update values cannot be undefined",
       );
     }
 
     let nextContextSequence = this.#snapshot.contextSequence;
     let nextContext = this.#snapshot.context;
     let nextDocumentSequence = this.#snapshot.documentSequence;
+    let nextSourceSequence = this.#snapshot.sourceSequence;
     let nextSource = this.#snapshot.source;
     let documentMutation: "changes" | "none" | "replace" = "none";
     let trustedAnalysisChanges: readonly SqlTextChange[] | null = null;
 
-    if (kind === "context") {
-      if (
-        readOwnDataProperty(
-          update,
-          "document",
-          "invalid-update",
-          "SQL context update",
-        ).found
-      ) {
-        throw new SqlSessionError(
-          "invalid-update",
-          "SQL context update cannot contain a document mutation",
-        );
-      }
-      const context = readRequiredDataProperty(
-        update,
-        "context",
-        "invalid-update",
-        "SQL context update",
-      );
-      if (context === undefined) {
-        throw new SqlSessionError(
-          "invalid-update",
-          "SQL context update requires a context value",
-        );
-      }
-      nextContext = cloneContext(context);
-      nextContextSequence += 1;
-    } else {
-      const document = readRequiredDataProperty(
-        update,
-        "document",
-        "invalid-update",
-        "SQL document update",
-      );
-      const context = readOwnDataProperty(
-        update,
-        "context",
-        "invalid-update",
-        "SQL document update",
-      );
-      if (context.found) {
-        if (context.value === undefined) {
-          throw new SqlSessionError(
-            "invalid-update",
-            "SQL document update context cannot be undefined",
-          );
-        }
-        nextContext = cloneContext(context.value);
-        nextContextSequence += 1;
-      }
-      if (document === null || typeof document !== "object") {
+    let nextText = this.#snapshot.source.originalText;
+    if (document.found) {
+      if (document.value === null || typeof document.value !== "object") {
         throw new SqlSessionError(
           "invalid-update",
           "SQL document mutation must be an object",
         );
       }
       const documentKind = readRequiredDataProperty(
-        document,
+        document.value,
         "kind",
         "invalid-update",
         "SQL document mutation",
       );
       if (documentKind === "replace") {
-        if (
-          readOwnDataProperty(
-            document,
-            "changes",
-            "invalid-update",
-            "SQL document replacement",
-          ).found
-        ) {
-          throw new SqlSessionError(
-            "invalid-update",
-            "SQL document replacement cannot also contain changes",
-          );
-        }
+        validateOwnDataKeys(
+          document.value,
+          DOCUMENT_REPLACEMENT_KEYS,
+          "invalid-update",
+          "SQL document replacement",
+        );
         const text = readRequiredDataProperty(
-          document,
+          document.value,
           "text",
           "invalid-update",
           "SQL document replacement",
@@ -747,24 +854,17 @@ export class DefaultSqlDocumentSession<Context extends SqlDocumentContext>
           );
         }
         validateDocumentLength(text);
-        nextSource = createIdentitySqlSource(text);
+        nextText = text;
         documentMutation = "replace";
       } else if (documentKind === "changes") {
-        if (
-          readOwnDataProperty(
-            document,
-            "text",
-            "invalid-update",
-            "SQL document changes",
-          ).found
-        ) {
-          throw new SqlSessionError(
-            "invalid-update",
-            "SQL document changes cannot also contain replacement text",
-          );
-        }
+        validateOwnDataKeys(
+          document.value,
+          DOCUMENT_CHANGES_KEYS,
+          "invalid-update",
+          "SQL document changes",
+        );
         const changes = readRequiredDataProperty(
-          document,
+          document.value,
           "changes",
           "invalid-update",
           "SQL document changes",
@@ -776,12 +876,13 @@ export class DefaultSqlDocumentSession<Context extends SqlDocumentContext>
           );
         }
         const normalizedChanges = normalizeChanges(
-          nextSource.originalText,
+          this.#snapshot.source.originalText,
           changes,
         );
         trustedAnalysisChanges = normalizedChanges;
-        nextSource = createIdentitySqlSource(
-          applyChanges(nextSource.originalText, normalizedChanges),
+        nextText = applyChanges(
+          this.#snapshot.source.originalText,
+          normalizedChanges,
         );
         documentMutation = "changes";
       } else {
@@ -791,6 +892,40 @@ export class DefaultSqlDocumentSession<Context extends SqlDocumentContext>
         );
       }
       nextDocumentSequence += 1;
+    }
+
+    if (embeddedRegions.found) {
+      const candidateSource = createMaskedSqlSource(
+        nextText,
+        embeddedRegions.value,
+      );
+      if (
+        candidateSource.originalText === this.#snapshot.source.originalText &&
+        haveEqualEmbeddedRegions(candidateSource, this.#snapshot.source)
+      ) {
+        nextSource = this.#snapshot.source;
+      } else {
+        nextSource = candidateSource;
+      }
+      nextSourceSequence += 1;
+      if (
+        documentMutation !== "changes" ||
+        this.#snapshot.source.embeddedRegions.length !== 0 ||
+        nextSource.embeddedRegions.length !== 0
+      ) {
+        trustedAnalysisChanges = null;
+      }
+    }
+
+    if (context.found) {
+      if (context.value === undefined) {
+        throw new SqlSessionError(
+          "invalid-update",
+          "SQL document update context cannot be undefined",
+        );
+      }
+      nextContext = cloneContext<Context>(context.value);
+      nextContextSequence += 1;
     }
 
     const nextDialect = resolveDialectRuntime(
@@ -814,6 +949,7 @@ export class DefaultSqlDocumentSession<Context extends SqlDocumentContext>
       revision,
       sequence,
       source: nextSource,
+      sourceSequence: nextSourceSequence,
     });
     let nextStatementIndexCache = this.#statementIndexCache;
     if (
@@ -821,7 +957,10 @@ export class DefaultSqlDocumentSession<Context extends SqlDocumentContext>
       nextLexicalProfile !== this.#snapshot.dialect.lexicalProfile
     ) {
       nextStatementIndexCache = null;
-    } else if (nextStatementIndexCache && documentMutation !== "none") {
+    } else if (
+      nextStatementIndexCache &&
+      nextSourceSequence !== this.#snapshot.sourceSequence
+    ) {
       let nextIndex: SqlStatementIndex | null = null;
       if (
         nextSource.analysisText === this.#snapshot.source.analysisText
@@ -840,9 +979,9 @@ export class DefaultSqlDocumentSession<Context extends SqlDocumentContext>
       }
       nextStatementIndexCache = nextIndex
         ? Object.freeze({
-            documentSequence: nextDocumentSequence,
             index: nextIndex,
             lexicalProfile: nextLexicalProfile,
+            sourceSequence: nextSourceSequence,
           })
         : null;
     }
@@ -953,6 +1092,12 @@ export class DefaultSqlLanguageService<Context extends SqlDocumentContext>
           "Open SQL document input must be an object",
         );
       }
+      validateOwnDataKeys(
+        input,
+        OPEN_DOCUMENT_KEYS,
+        "invalid-document",
+        "Open SQL document input",
+      );
       const text = readRequiredDataProperty(
         input,
         "text",
@@ -966,7 +1111,21 @@ export class DefaultSqlLanguageService<Context extends SqlDocumentContext>
         );
       }
       validateDocumentLength(text);
-      const source = createIdentitySqlSource(text);
+      const embeddedRegions = readOwnDataProperty(
+        input,
+        "embeddedRegions",
+        "invalid-document",
+        "Open SQL document input",
+      );
+      if (embeddedRegions.found && embeddedRegions.value === undefined) {
+        throw new SqlSessionError(
+          "invalid-document",
+          "Open SQL document embedded regions cannot be undefined",
+        );
+      }
+      const source = embeddedRegions.found
+        ? createMaskedSqlSource(text, embeddedRegions.value)
+        : createIdentitySqlSource(text);
       const candidateContext = readRequiredDataProperty(
         input,
         "context",

--- a/src/vnext/source.ts
+++ b/src/vnext/source.ts
@@ -6,11 +6,6 @@ export const MAX_SQL_EMBEDDED_REGIONS = 10_000;
 const MAX_EMBEDDED_LANGUAGE_LENGTH = 256;
 const MASK_CHUNK_LENGTH = 64 * 1024;
 const EMPTY_EMBEDDED_REGIONS: readonly SqlEmbeddedRegion[] = Object.freeze([]);
-const EMBEDDED_REGION_KEYS: ReadonlySet<string> = new Set([
-  "from",
-  "language",
-  "to",
-]);
 const sourceErrors = new WeakSet<object>();
 
 export type SqlSourceErrorCode =
@@ -172,56 +167,6 @@ function readArrayLength(value: readonly unknown[]): number {
   return length;
 }
 
-function validateRegionArrayKeys(
-  regions: readonly unknown[],
-  length: number,
-): void {
-  for (const key of Reflect.ownKeys(regions)) {
-    if (key === "length") {
-      continue;
-    }
-    if (
-      typeof key !== "string" ||
-      !/^(0|[1-9]\d*)$/.test(key) ||
-      Number(key) >= length
-    ) {
-      throw new SqlSourceError(
-        "invalid-region",
-        "SQL embedded regions cannot contain custom properties",
-      );
-    }
-    const descriptor = Object.getOwnPropertyDescriptor(regions, key);
-    if (
-      !descriptor ||
-      !descriptor.enumerable ||
-      !("value" in descriptor)
-    ) {
-      throw new SqlSourceError(
-        "invalid-region",
-        "SQL embedded regions must contain enumerable data entries",
-      );
-    }
-  }
-}
-
-function validateRegionObjectKeys(candidate: object, index: number): void {
-  for (const key of Reflect.ownKeys(candidate)) {
-    const descriptor = Object.getOwnPropertyDescriptor(candidate, key);
-    if (
-      typeof key !== "string" ||
-      !EMBEDDED_REGION_KEYS.has(key) ||
-      !descriptor ||
-      !descriptor.enumerable ||
-      !("value" in descriptor)
-    ) {
-      throw new SqlSourceError(
-        "invalid-region",
-        `SQL embedded region ${index} must contain only enumerable data properties`,
-      );
-    }
-  }
-}
-
 function normalizeEmbeddedRegions(
   regions: unknown,
   sourceLength: number,
@@ -240,8 +185,6 @@ function normalizeEmbeddedRegions(
         `SQL source cannot contain more than ${MAX_SQL_EMBEDDED_REGIONS} embedded regions`,
       );
     }
-    validateRegionArrayKeys(regions, length);
-
     const normalized: SqlEmbeddedRegion[] = [];
     let previousEnd = 0;
     for (let index = 0; index < length; index += 1) {
@@ -256,7 +199,6 @@ function normalizeEmbeddedRegions(
           `SQL embedded region ${index} must be an object`,
         );
       }
-      validateRegionObjectKeys(candidate, index);
       let range: SqlTextRange;
       try {
         range = normalizeSqlTextRange(

--- a/src/vnext/source.ts
+++ b/src/vnext/source.ts
@@ -1,4 +1,4 @@
-import type { SqlTextRange } from "./types.js";
+import type { SqlEmbeddedRegion, SqlTextRange } from "./types.js";
 
 export const MAX_SQL_SOURCE_LENGTH = 16 * 1024 * 1024;
 export const MAX_SQL_EMBEDDED_REGIONS = 10_000;
@@ -6,6 +6,11 @@ export const MAX_SQL_EMBEDDED_REGIONS = 10_000;
 const MAX_EMBEDDED_LANGUAGE_LENGTH = 256;
 const MASK_CHUNK_LENGTH = 64 * 1024;
 const EMPTY_EMBEDDED_REGIONS: readonly SqlEmbeddedRegion[] = Object.freeze([]);
+const EMBEDDED_REGION_KEYS: ReadonlySet<string> = new Set([
+  "from",
+  "language",
+  "to",
+]);
 const sourceErrors = new WeakSet<object>();
 
 export type SqlSourceErrorCode =
@@ -30,10 +35,6 @@ export function isSqlSourceError(error: unknown): error is SqlSourceError {
     typeof error === "object" &&
     sourceErrors.has(error)
   );
-}
-
-export interface SqlEmbeddedRegion extends SqlTextRange {
-  readonly language: string;
 }
 
 export interface SqlSourceSnapshot {
@@ -189,6 +190,35 @@ function validateRegionArrayKeys(
         "SQL embedded regions cannot contain custom properties",
       );
     }
+    const descriptor = Object.getOwnPropertyDescriptor(regions, key);
+    if (
+      !descriptor ||
+      !descriptor.enumerable ||
+      !("value" in descriptor)
+    ) {
+      throw new SqlSourceError(
+        "invalid-region",
+        "SQL embedded regions must contain enumerable data entries",
+      );
+    }
+  }
+}
+
+function validateRegionObjectKeys(candidate: object, index: number): void {
+  for (const key of Reflect.ownKeys(candidate)) {
+    const descriptor = Object.getOwnPropertyDescriptor(candidate, key);
+    if (
+      typeof key !== "string" ||
+      !EMBEDDED_REGION_KEYS.has(key) ||
+      !descriptor ||
+      !descriptor.enumerable ||
+      !("value" in descriptor)
+    ) {
+      throw new SqlSourceError(
+        "invalid-region",
+        `SQL embedded region ${index} must contain only enumerable data properties`,
+      );
+    }
   }
 }
 
@@ -226,6 +256,7 @@ function normalizeEmbeddedRegions(
           `SQL embedded region ${index} must be an object`,
         );
       }
+      validateRegionObjectKeys(candidate, index);
       let range: SqlTextRange;
       try {
         range = normalizeSqlTextRange(

--- a/src/vnext/types.ts
+++ b/src/vnext/types.ts
@@ -96,23 +96,45 @@ export interface SqlDocumentChanges {
 
 export type SqlDocumentEdit = SqlDocumentReplacement | SqlDocumentChanges;
 
-/** An atomic document or context transaction against one base revision. */
+export interface SqlEmbeddedRegion extends SqlTextRange {
+  readonly language: string;
+}
+
+interface SqlDocumentUpdateBase {
+  readonly baseRevision: SqlRevision;
+}
+
+type SqlDocumentMutationUpdate<Context extends SqlDocumentContext> =
+  SqlDocumentUpdateBase & {
+    readonly document: SqlDocumentEdit;
+    readonly embeddedRegions: readonly SqlEmbeddedRegion[];
+    readonly context?: SqlContextInput<Context>;
+  };
+
+type SqlContextUpdate<Context extends SqlDocumentContext> =
+  SqlDocumentUpdateBase & {
+    readonly document?: never;
+    readonly context: SqlContextInput<Context>;
+    readonly embeddedRegions?: readonly SqlEmbeddedRegion[];
+  };
+
+type SqlEmbeddedRegionUpdate =
+  SqlDocumentUpdateBase & {
+    readonly document?: never;
+    readonly context?: never;
+    readonly embeddedRegions: readonly SqlEmbeddedRegion[];
+  };
+
+/** An atomic transaction changing any non-empty subset of session inputs. */
 export type SqlDocumentUpdate<Context extends SqlDocumentContext> =
-  | {
-      readonly kind: "document";
-      readonly baseRevision: SqlRevision;
-      readonly document: SqlDocumentEdit;
-      readonly context?: SqlContextInput<Context>;
-    }
-  | {
-      readonly kind: "context";
-      readonly baseRevision: SqlRevision;
-      readonly context: SqlContextInput<Context>;
-    };
+  | SqlDocumentMutationUpdate<Context>
+  | SqlContextUpdate<Context>
+  | SqlEmbeddedRegionUpdate;
 
 export interface OpenSqlDocument<Context extends SqlDocumentContext> {
   readonly text: string;
   readonly context: SqlContextInput<Context>;
+  readonly embeddedRegions?: readonly SqlEmbeddedRegion[];
 }
 
 /** Owns all mutable state for one open SQL document. */

--- a/src/vnext/types.ts
+++ b/src/vnext/types.ts
@@ -85,6 +85,7 @@ export interface SqlTextChange extends SqlTextRange {
 }
 
 export interface SqlDocumentReplacement {
+  readonly changes?: never;
   readonly kind: "replace";
   readonly text: string;
 }
@@ -92,6 +93,7 @@ export interface SqlDocumentReplacement {
 export interface SqlDocumentChanges {
   readonly kind: "changes";
   readonly changes: readonly SqlTextChange[];
+  readonly text?: never;
 }
 
 export type SqlDocumentEdit = SqlDocumentReplacement | SqlDocumentChanges;
@@ -102,6 +104,7 @@ export interface SqlEmbeddedRegion extends SqlTextRange {
 
 interface SqlDocumentUpdateBase {
   readonly baseRevision: SqlRevision;
+  readonly kind?: never;
 }
 
 type SqlDocumentMutationUpdate<Context extends SqlDocumentContext> =

--- a/src/vnext/types.ts
+++ b/src/vnext/types.ts
@@ -107,9 +107,9 @@ interface SqlDocumentUpdateBase {
   readonly kind?: never;
 }
 
-type SqlDocumentMutationUpdate<Context extends SqlDocumentContext> =
+type SqlSourceUpdate<Context extends SqlDocumentContext> =
   SqlDocumentUpdateBase & {
-    readonly document: SqlDocumentEdit;
+    readonly document?: SqlDocumentEdit | undefined;
     readonly embeddedRegions: readonly SqlEmbeddedRegion[];
     readonly context?: SqlContextInput<Context> | undefined;
   };
@@ -121,18 +121,10 @@ type SqlContextUpdate<Context extends SqlDocumentContext> =
     readonly embeddedRegions?: readonly SqlEmbeddedRegion[] | undefined;
   };
 
-type SqlEmbeddedRegionUpdate =
-  SqlDocumentUpdateBase & {
-    readonly document?: undefined;
-    readonly context?: undefined;
-    readonly embeddedRegions: readonly SqlEmbeddedRegion[];
-  };
-
 /** An atomic transaction changing any non-empty subset of session inputs. */
 export type SqlDocumentUpdate<Context extends SqlDocumentContext> =
-  | SqlDocumentMutationUpdate<Context>
-  | SqlContextUpdate<Context>
-  | SqlEmbeddedRegionUpdate;
+  | SqlSourceUpdate<Context>
+  | SqlContextUpdate<Context>;
 
 export interface OpenSqlDocument<Context extends SqlDocumentContext> {
   readonly text: string;

--- a/src/vnext/types.ts
+++ b/src/vnext/types.ts
@@ -111,14 +111,14 @@ type SqlDocumentMutationUpdate<Context extends SqlDocumentContext> =
   SqlDocumentUpdateBase & {
     readonly document: SqlDocumentEdit;
     readonly embeddedRegions: readonly SqlEmbeddedRegion[];
-    readonly context?: SqlContextInput<Context>;
+    readonly context?: SqlContextInput<Context> | undefined;
   };
 
 type SqlContextUpdate<Context extends SqlDocumentContext> =
   SqlDocumentUpdateBase & {
     readonly document?: never;
     readonly context: SqlContextInput<Context>;
-    readonly embeddedRegions?: readonly SqlEmbeddedRegion[];
+    readonly embeddedRegions?: readonly SqlEmbeddedRegion[] | undefined;
   };
 
 type SqlEmbeddedRegionUpdate =
@@ -137,7 +137,7 @@ export type SqlDocumentUpdate<Context extends SqlDocumentContext> =
 export interface OpenSqlDocument<Context extends SqlDocumentContext> {
   readonly text: string;
   readonly context: SqlContextInput<Context>;
-  readonly embeddedRegions?: readonly SqlEmbeddedRegion[];
+  readonly embeddedRegions?: readonly SqlEmbeddedRegion[] | undefined;
 }
 
 /** Owns all mutable state for one open SQL document. */

--- a/src/vnext/types.ts
+++ b/src/vnext/types.ts
@@ -116,15 +116,15 @@ type SqlDocumentMutationUpdate<Context extends SqlDocumentContext> =
 
 type SqlContextUpdate<Context extends SqlDocumentContext> =
   SqlDocumentUpdateBase & {
-    readonly document?: never;
+    readonly document?: undefined;
     readonly context: SqlContextInput<Context>;
     readonly embeddedRegions?: readonly SqlEmbeddedRegion[] | undefined;
   };
 
 type SqlEmbeddedRegionUpdate =
   SqlDocumentUpdateBase & {
-    readonly document?: never;
-    readonly context?: never;
+    readonly document?: undefined;
+    readonly context?: undefined;
     readonly embeddedRegions: readonly SqlEmbeddedRegion[];
   };
 

--- a/test/vnext-types/marimo-relation-completion.test-d.ts
+++ b/test/vnext-types/marimo-relation-completion.test-d.ts
@@ -289,10 +289,10 @@ const contradictoryIncompleteList = {
 } satisfies SqlRelationCompletionList;
 // @ts-expect-error timeouts are unavailable evidence, not cancellation
 const invalidCancellation: SqlCompletionCancellationReason = "timeout";
-// @ts-expect-error a document transaction cannot explicitly omit context
 const undefinedContext: SqlDocumentUpdate<MarimoSqlContext> = {
   baseRevision: session.revision,
   context: undefined,
+  document: undefined,
   embeddedRegions: [],
 };
 

--- a/test/vnext-types/marimo-relation-completion.test-d.ts
+++ b/test/vnext-types/marimo-relation-completion.test-d.ts
@@ -1,6 +1,7 @@
 import type {
   SqlCatalogContext,
   SqlDocumentContext,
+  SqlDocumentEdit,
   SqlDocumentUpdate,
   SqlEmbeddedRegion,
   SqlIdentifierComponent,
@@ -40,6 +41,8 @@ const context: MarimoSqlContext = {
   dialect: "duckdb",
   engine: "local",
 };
+declare const maybeContext: MarimoSqlContext | undefined;
+declare const maybeDocument: SqlDocumentEdit | undefined;
 const regions: readonly SqlEmbeddedRegion[] = [
   { from: 14, language: "python", to: 18 },
 ];
@@ -76,6 +79,12 @@ session.update({
 session.update({
   baseRevision: session.revision,
   context,
+  embeddedRegions: regions,
+});
+session.update({
+  baseRevision: session.revision,
+  context: maybeContext,
+  document: maybeDocument,
   embeddedRegions: regions,
 });
 
@@ -179,7 +188,7 @@ session.update({
   baseRevision: session.revision,
   document: { kind: "replace", text: "SELECT 1" },
 });
-// @ts-expect-error present undefined is not omission
+// @ts-expect-error undefined omission leaves an empty transaction
 session.update({ baseRevision: session.revision, context: undefined });
 const missingEngine: OpenSqlDocument<MarimoSqlContext> = {
   // @ts-expect-error marimo contexts always identify their engine

--- a/test/vnext-types/marimo-relation-completion.test-d.ts
+++ b/test/vnext-types/marimo-relation-completion.test-d.ts
@@ -1,8 +1,10 @@
-import type { SqlEmbeddedRegion } from "../../src/vnext/source.js";
 import type {
   SqlCatalogContext,
   SqlDocumentContext,
+  SqlDocumentUpdate,
+  SqlEmbeddedRegion,
   SqlIdentifierComponent,
+  OpenSqlDocument,
 } from "../../src/vnext/index.js";
 import type {
   SqlCanonicalRelationPath,
@@ -16,9 +18,7 @@ import type {
   SqlRelationCompletionItem,
   SqlRelationCompletionList,
   SqlRelationCatalogProvider,
-  SqlRelationCompletionDocumentTransaction,
   SqlRelationCompletionDialectRuntime,
-  SqlRelationCompletionOpenDocument,
   SqlRelationCompletionSession,
 } from "../../src/vnext/relation-completion-types.js";
 
@@ -43,11 +43,11 @@ const context: MarimoSqlContext = {
 const regions: readonly SqlEmbeddedRegion[] = [
   { from: 14, language: "python", to: 18 },
 ];
-const openWithoutRegions: SqlRelationCompletionOpenDocument<MarimoSqlContext> = {
+const openWithoutRegions: OpenSqlDocument<MarimoSqlContext> = {
   context,
   text: "SELECT * FROM users",
 };
-const openWithRegions: SqlRelationCompletionOpenDocument<MarimoSqlContext> = {
+const openWithRegions: OpenSqlDocument<MarimoSqlContext> = {
   context,
   embeddedRegions: regions,
   text: "SELECT * FROM {df}",
@@ -181,7 +181,7 @@ session.update({
 });
 // @ts-expect-error present undefined is not omission
 session.update({ baseRevision: session.revision, context: undefined });
-const missingEngine: SqlRelationCompletionOpenDocument<MarimoSqlContext> = {
+const missingEngine: OpenSqlDocument<MarimoSqlContext> = {
   // @ts-expect-error marimo contexts always identify their engine
   context: { dialect: "duckdb" },
   text: "",
@@ -290,7 +290,7 @@ const contradictoryIncompleteList = {
 // @ts-expect-error timeouts are unavailable evidence, not cancellation
 const invalidCancellation: SqlCompletionCancellationReason = "timeout";
 // @ts-expect-error a document transaction cannot explicitly omit context
-const undefinedContext: SqlRelationCompletionDocumentTransaction<MarimoSqlContext> = {
+const undefinedContext: SqlDocumentUpdate<MarimoSqlContext> = {
   baseRevision: session.revision,
   context: undefined,
   embeddedRegions: [],

--- a/test/vnext-types/session.test-d.ts
+++ b/test/vnext-types/session.test-d.ts
@@ -77,7 +77,6 @@ const hostUpdate = {
   hostMetadata: { cellId: "cell-1" },
 };
 session.update(hostUpdate);
-// @ts-expect-error an explicitly undefined context is not an omitted context
 session.update({
   embeddedRegions: [],
   baseRevision: session.revision,
@@ -106,7 +105,7 @@ session.update({
   baseRevision: session.revision,
   document: { kind: "replace", text: "SELECT 2" },
 });
-// @ts-expect-error present undefined regions are not omission
+// @ts-expect-error document mutations require defined post-edit regions
 session.update({
   baseRevision: session.revision,
   document: { kind: "replace", text: "SELECT 2" },

--- a/test/vnext-types/session.test-d.ts
+++ b/test/vnext-types/session.test-d.ts
@@ -3,6 +3,7 @@ import {
   duckdbDialect,
   type SqlDialect,
   type SqlDocumentContext,
+  type SqlDocumentEdit,
   type SqlDocumentSession,
   type SqlEmbeddedRegion,
   type SqlLanguageService,
@@ -46,6 +47,8 @@ const hostOpen = {
 };
 service.openDocument(hostOpen);
 const revision: SqlRevision = session.revision;
+declare const maybeContext: HostContext | undefined;
+declare const maybeDocument: SqlDocumentEdit | undefined;
 
 // @ts-expect-error host service cannot be widened and fed a weaker context
 const widenedService: SqlLanguageService<SqlDocumentContext> = service;
@@ -94,6 +97,12 @@ session.update({
   context: undefined,
   document: undefined,
   embeddedRegions: [],
+});
+session.update({
+  baseRevision: session.revision,
+  context: maybeContext,
+  document: maybeDocument,
+  embeddedRegions: hostRegions,
 });
 
 const change: SqlTextChange = { from: 0, insert: "", to: 0 };

--- a/test/vnext-types/session.test-d.ts
+++ b/test/vnext-types/session.test-d.ts
@@ -19,6 +19,10 @@ interface DateContext extends HostContext {
   readonly lastUsed: Date;
 }
 
+interface HostEmbeddedRegion extends SqlEmbeddedRegion {
+  readonly hostNodeId: string;
+}
+
 const dialect = duckdbDialect();
 const typedDialect: SqlDialect = dialect;
 const service = createSqlLanguageService<HostContext>({ dialects: [dialect] });
@@ -31,6 +35,16 @@ const identitySession = service.openDocument({
   context: { dialect: "duckdb", engine: "local" },
   text: "",
 });
+const hostRegions: readonly HostEmbeddedRegion[] = [
+  { from: 0, hostNodeId: "cell-1", language: "python", to: 1 },
+];
+const hostOpen = {
+  context: { dialect: "duckdb", engine: "local" },
+  embeddedRegions: hostRegions,
+  hostMetadata: { cellId: "cell-1" },
+  text: "x",
+};
+service.openDocument(hostOpen);
 const revision: SqlRevision = session.revision;
 
 // @ts-expect-error host service cannot be widened and fed a weaker context
@@ -57,6 +71,12 @@ session.update({
   baseRevision: session.revision,
   embeddedRegions: [],
 });
+const hostUpdate = {
+  baseRevision: session.revision,
+  embeddedRegions: hostRegions,
+  hostMetadata: { cellId: "cell-1" },
+};
+session.update(hostUpdate);
 // @ts-expect-error an explicitly undefined context is not an omitted context
 session.update({
   embeddedRegions: [],
@@ -74,6 +94,13 @@ const objectRevision: SqlRevision = {};
 const numberRevision: SqlRevision = 1;
 // @ts-expect-error updates require a non-empty state change
 session.update({ baseRevision: revision });
+const legacyUpdate = {
+  baseRevision: revision,
+  context: { dialect: "duckdb", engine: "local" },
+  kind: "context" as const,
+};
+// @ts-expect-error the removed update discriminant stays forbidden through variables
+session.update(legacyUpdate);
 // @ts-expect-error document mutations require complete post-edit regions
 session.update({
   baseRevision: session.revision,

--- a/test/vnext-types/session.test-d.ts
+++ b/test/vnext-types/session.test-d.ts
@@ -83,6 +83,18 @@ session.update({
   context: undefined,
   document: { kind: "replace", text: "SELECT 1" },
 });
+session.update({
+  baseRevision: session.revision,
+  context: { dialect: "duckdb", engine: "local" },
+  document: undefined,
+  embeddedRegions: undefined,
+});
+session.update({
+  baseRevision: session.revision,
+  context: undefined,
+  document: undefined,
+  embeddedRegions: [],
+});
 
 const change: SqlTextChange = { from: 0, insert: "", to: 0 };
 const range: SqlTextRange = change;

--- a/test/vnext-types/session.test-d.ts
+++ b/test/vnext-types/session.test-d.ts
@@ -4,6 +4,7 @@ import {
   type SqlDialect,
   type SqlDocumentContext,
   type SqlDocumentSession,
+  type SqlEmbeddedRegion,
   type SqlLanguageService,
   type SqlRevision,
   type SqlTextChange,
@@ -23,6 +24,11 @@ const typedDialect: SqlDialect = dialect;
 const service = createSqlLanguageService<HostContext>({ dialects: [dialect] });
 const session = service.openDocument({
   context: { dialect: "duckdb", engine: "local" },
+  embeddedRegions: [{ from: 0, language: "python", to: 1 }],
+  text: "x",
+});
+const identitySession = service.openDocument({
+  context: { dialect: "duckdb", engine: "local" },
   text: "",
 });
 const revision: SqlRevision = session.revision;
@@ -33,24 +39,27 @@ const widenedService: SqlLanguageService<SqlDocumentContext> = service;
 const widenedSession: SqlDocumentSession<SqlDocumentContext> = session;
 
 session.update({
-  kind: "context",
   baseRevision: revision,
   context: { dialect: "duckdb", engine: "remote" },
 });
 session.update({
-  kind: "document",
+  embeddedRegions: [],
   baseRevision: session.revision,
   document: { kind: "replace", text: "SELECT 1" },
 });
 session.update({
-  kind: "document",
+  embeddedRegions: [],
   baseRevision: session.revision,
   context: { dialect: "duckdb", engine: "local" },
   document: { kind: "changes", changes: [{ from: 0, insert: "SELECT 1", to: 0 }] },
 });
+session.update({
+  baseRevision: session.revision,
+  embeddedRegions: [],
+});
 // @ts-expect-error an explicitly undefined context is not an omitted context
 session.update({
-  kind: "document",
+  embeddedRegions: [],
   baseRevision: session.revision,
   context: undefined,
   document: { kind: "replace", text: "SELECT 1" },
@@ -63,10 +72,21 @@ const range: SqlTextRange = change;
 const objectRevision: SqlRevision = {};
 // @ts-expect-error revisions cannot be numbers
 const numberRevision: SqlRevision = 1;
-// @ts-expect-error updates require document or context
-session.update({ kind: "document", baseRevision: revision });
+// @ts-expect-error updates require a non-empty state change
+session.update({ baseRevision: revision });
+// @ts-expect-error document mutations require complete post-edit regions
+session.update({
+  baseRevision: session.revision,
+  document: { kind: "replace", text: "SELECT 2" },
+});
+// @ts-expect-error present undefined regions are not omission
+session.update({
+  baseRevision: session.revision,
+  document: { kind: "replace", text: "SELECT 2" },
+  embeddedRegions: undefined,
+});
 // @ts-expect-error document mutation forms are mutually exclusive
-session.update({ kind: "document", baseRevision: revision, document: { kind: "changes", changes: [], text: "" } });
+session.update({ embeddedRegions: [], baseRevision: revision, document: { kind: "changes", changes: [], text: "" } });
 // @ts-expect-error host context requires engine
 service.openDocument({ context: { dialect: "duckdb" }, text: "" });
 const dateService = createSqlLanguageService<DateContext>({ dialects: [dialect] });
@@ -79,6 +99,13 @@ dateService.openDocument({
 change.from = 1;
 // @ts-expect-error ranges are readonly
 range.to = 1;
+const embeddedRegion: SqlEmbeddedRegion = {
+  from: 0,
+  language: "python",
+  to: 1,
+};
+// @ts-expect-error embedded regions are readonly
+embeddedRegion.language = "jinja";
 // @ts-expect-error session revision is readonly
 session.revision = revision;
 // @ts-expect-error statement indexes remain an internal session detail
@@ -91,6 +118,8 @@ createSqlLanguageService({ dialects: [{ id: "duckdb", displayName: "DuckDB" }] }
 void objectRevision;
 void numberRevision;
 void range;
+void embeddedRegion;
+void identitySession;
 void typedDialect;
 void widenedService;
 void widenedSession;

--- a/tsconfig.vnext-tests.loose-optional.json
+++ b/tsconfig.vnext-tests.loose-optional.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.vnext-tests.json",
+  "compilerOptions": {
+    "exactOptionalPropertyTypes": false
+  }
+}


### PR DESCRIPTION
## Summary

- make embedded regions a public, atomic input to document open and update transactions
- require every text mutation to carry the complete post-edit region set while preserving omission and explicit-clear semantics for non-document updates
- mask embedded regions before statement analysis, with separate source sequencing and conservative cache reuse
- align runtime decoding with TypeScript structural typing by copying only declared own data fields and leaving host metadata opaque
- migrate the provisional completion contract and packed consumers to the real session transaction types

## Correctness and consumer behavior

- text, context, dialect, regions, revision, sequences, and statement cache commit or roll back together
- stale revisions are rejected before candidate payload inspection; disposal dominates hostile/reentrant failures
- region ranges use resulting-document UTF-16 coordinates and include complete non-SQL delimiters such as marimo's `{df}`
- source snapshots and normalized regions are owned and frozen; same-value source transactions still advance revision/source sequence
- incremental statement indexing remains limited to identity-to-identity edits; changed masked analysis rebuilds lazily
- structurally richer marimo region/envelope values compile and run without invoking or retaining extra host fields
- removed outer `kind` and contradictory document fields remain explicitly forbidden in both types and runtime

## Validation

- `pnpm run typecheck`
- `pnpm exec oxlint`
- `pnpm run test:integrity`
- `pnpm test` — 1,264 passed, 1 expected failure
- `pnpm run test:browser` — 7 passed
- `pnpm run test:package` with typed and runtime nonempty embedded regions
- `pnpm run test:worker-placement`
- `pnpm run demo`
- changed coverage — 98.70% statements, 97.42% branches, 100% functions, 98.69% lines
- pre-rebase review/fix/re-review loop across SQL/API, marimo ergonomics, and concurrency/performance perspectives
- fresh exact-head approval from all three reviewers at `ff35130197fcf69a10d42d195c8dd6324f6d5ed9`

Part of #169.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make embedded regions a first-class, atomic session input in vNext. Document edits now require the complete post-edit region set, masking happens before analysis, and cache reuse is tied to a separate source sequence. Part of #169.

- **New Features**
  - Embedded regions are accepted on open and update; document mutations must include the full resulting `embeddedRegions`. Region-only and context-only updates are supported.
  - Region ranges use resulting-document UTF-16 and include full non-SQL delimiters (e.g., marimo `{df}`); masking is length-preserving and runs before statement analysis.
  - Unchanged text+regions reuse the immutable source and statement index via a separate source sequence; only identity-to-identity edits reuse incrementally. Changed masked analysis invalidates the cache unless analysis text is equal.
  - Inputs are structural: only declared own data fields are read; host metadata and extras stay opaque. Context accessors and non-enumerable properties are rejected. Stale revisions are rejected before payload inspection; disposal dominates hostile/reentrant failures.
  - Optional `document`/`embeddedRegions`/`context` fields: `undefined` is treated as omission at runtime for compatibility with and without `exactOptionalPropertyTypes`.

- **Migration**
  - Update `session.update` calls:
    - Context-only: `{ baseRevision, context }` (no `kind`; `context` must be defined by types).
    - Document mutation: `{ baseRevision, document: {...}, embeddedRegions: [...] }` (regions required).
    - Region-only: `{ baseRevision, embeddedRegions: [...] }`.
  - Open with regions: `service.openDocument({ text, context, embeddedRegions })`.
  - Use `SqlEmbeddedRegion` and `SqlDocumentUpdate` from `@marimo-team/codemirror-sql/vnext`; stop importing `SqlEmbeddedRegion` from `./source`.

<sup>Written for commit db6eeee8dd6b31560a327c36e57f2900fa91e4c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marimo-team/codemirror-sql/pull/184?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

