### PR TITLE
refactor(vnext): share bounded lexical primitives

### DIFF
--- a/src/vnext/__tests__/lexical.test.ts
+++ b/src/vnext/__tests__/lexical.test.ts
@@ -71,4 +71,10 @@ describe("shared SQL lexical primitives", () => {
       to: 10,
     });
   });
+
+  it("classifies dollar-quote openers only from the bounded prefix", () => {
+    for (const text of ["$", "$$", "$x"]) {
+      expect(scanSqlDollarQuote(text, 0, 1)).toBeNull();
+    }
+  });
 });

--- a/src/vnext/__tests__/lexical.test.ts
+++ b/src/vnext/__tests__/lexical.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import {
+  isSqlWhitespace,
+  scanSqlBlockComment,
+  scanSqlDollarQuote,
+  scanSqlQuoted,
+  sqlIdentifierContinueLengthAt,
+  sqlIdentifierStartLengthAt,
+} from "../lexical.js";
+
+describe("shared SQL lexical primitives", () => {
+  it("uses UTF-16 identifier lengths without splitting valid pairs", () => {
+    expect(sqlIdentifierStartLengthAt("a", 0)).toBe(1);
+    expect(sqlIdentifierContinueLengthAt("1", 0)).toBe(1);
+    expect(sqlIdentifierStartLengthAt("😀", 0)).toBe(2);
+    expect(sqlIdentifierContinueLengthAt("\uD800", 0)).toBe(1);
+    expect(sqlIdentifierStartLengthAt("1", 0)).toBe(0);
+  });
+
+  it("recognizes only the SQL whitespace set", () => {
+    for (const code of [9, 10, 11, 12, 13, 32]) {
+      expect(isSqlWhitespace(code)).toBe(true);
+    }
+    expect(isSqlWhitespace(0xa0)).toBe(false);
+  });
+
+  it("never scans a quote beyond its explicit limit", () => {
+    expect(scanSqlQuoted("'abc'x", 0, 4, 39, 1, false, true, false)).toEqual({
+      closed: false,
+      to: 4,
+    });
+    expect(scanSqlQuoted("'abc'x", 0, 5, 39, 1, false, true, false)).toEqual({
+      closed: true,
+      to: 5,
+    });
+    expect(scanSqlQuoted("'a\nfar away", 0, 4, 39, 1, false, true, true)).toEqual({
+      closed: false,
+      to: 4,
+    });
+    expect(scanSqlQuoted("'\\\nfar away", 0, 4, 39, 1, true, true, true)).toEqual({
+      closed: false,
+      to: 4,
+    });
+  });
+
+  it("never scans a block comment beyond its explicit limit", () => {
+    expect(scanSqlBlockComment("/*x*/y", 0, 4, false)).toEqual({
+      closed: false,
+      to: 4,
+    });
+    expect(scanSqlBlockComment("/*x*/y", 0, 5, false)).toEqual({
+      closed: true,
+      to: 5,
+    });
+  });
+
+  it("never accepts a dollar-quote close beyond its explicit limit", () => {
+    expect(scanSqlDollarQuote("$$x$$y", 0, 4)).toEqual({
+      closed: false,
+      delimiterTooLong: false,
+      to: 4,
+    });
+    expect(scanSqlDollarQuote("$$x$$y", 0, 5)).toEqual({
+      closed: true,
+      delimiterTooLong: false,
+      to: 5,
+    });
+    expect(scanSqlDollarQuote("$tag$x$tag$far$tag$", 0, 10)).toEqual({
+      closed: false,
+      delimiterTooLong: false,
+      to: 10,
+    });
+  });
+});

--- a/src/vnext/lexical.ts
+++ b/src/vnext/lexical.ts
@@ -1,0 +1,339 @@
+const MAX_DOLLAR_QUOTE_DELIMITER_LENGTH = 256;
+
+type SqlSingleQuoteBackslash = "always" | "e-prefix" | "never";
+type SqlProceduralGuards = "bigquery" | "none" | "postgresql";
+
+export interface SqlLexicalProfile {
+  readonly backtickQuotedIdentifiers: boolean;
+  readonly bigQueryStrings: boolean;
+  readonly dollarQuotedStrings: boolean;
+  readonly hashLineComments: boolean;
+  readonly nestedBlockComments: boolean;
+  readonly proceduralGuards: SqlProceduralGuards;
+  readonly singleQuoteBackslash: SqlSingleQuoteBackslash;
+}
+
+export const POSTGRESQL_SQL_LEXICAL_PROFILE: SqlLexicalProfile = Object.freeze({
+  backtickQuotedIdentifiers: false,
+  bigQueryStrings: false,
+  dollarQuotedStrings: true,
+  hashLineComments: false,
+  nestedBlockComments: true,
+  proceduralGuards: "postgresql",
+  singleQuoteBackslash: "e-prefix",
+});
+
+export const DUCKDB_SQL_LEXICAL_PROFILE: SqlLexicalProfile = Object.freeze({
+  backtickQuotedIdentifiers: false,
+  bigQueryStrings: false,
+  dollarQuotedStrings: true,
+  hashLineComments: false,
+  nestedBlockComments: true,
+  proceduralGuards: "none",
+  singleQuoteBackslash: "e-prefix",
+});
+
+export const BIGQUERY_SQL_LEXICAL_PROFILE: SqlLexicalProfile = Object.freeze({
+  backtickQuotedIdentifiers: true,
+  bigQueryStrings: true,
+  dollarQuotedStrings: false,
+  hashLineComments: true,
+  nestedBlockComments: false,
+  proceduralGuards: "bigquery",
+  singleQuoteBackslash: "always",
+});
+
+export const DREMIO_SQL_LEXICAL_PROFILE: SqlLexicalProfile = Object.freeze({
+  backtickQuotedIdentifiers: false,
+  bigQueryStrings: false,
+  dollarQuotedStrings: false,
+  hashLineComments: false,
+  nestedBlockComments: false,
+  proceduralGuards: "none",
+  singleQuoteBackslash: "never",
+});
+
+function isAsciiIdentifierStart(code: number): boolean {
+  return (
+    code === 95 ||
+    (code >= 65 && code <= 90) ||
+    (code >= 97 && code <= 122)
+  );
+}
+
+function isAsciiIdentifierContinue(code: number): boolean {
+  return isAsciiIdentifierStart(code) || (code >= 48 && code <= 57);
+}
+
+function codePointLengthAt(text: string, index: number): 0 | 1 | 2 {
+  const codePoint = text.codePointAt(index);
+  if (codePoint === undefined) {
+    return 0;
+  }
+  return codePoint > 0xffff ? 2 : 1;
+}
+
+export function sqlIdentifierStartLengthAt(
+  text: string,
+  index: number,
+): 0 | 1 | 2 {
+  const code = text.charCodeAt(index);
+  if (code <= 0x7f) {
+    return isAsciiIdentifierStart(code) ? 1 : 0;
+  }
+  return codePointLengthAt(text, index);
+}
+
+export function sqlIdentifierContinueLengthAt(
+  text: string,
+  index: number,
+): 0 | 1 | 2 {
+  const code = text.charCodeAt(index);
+  if (code <= 0x7f) {
+    return isAsciiIdentifierContinue(code) ? 1 : 0;
+  }
+  return codePointLengthAt(text, index);
+}
+
+function previousCodePointIndex(text: string, index: number): number {
+  if (index <= 0) {
+    return -1;
+  }
+  const last = text.charCodeAt(index - 1);
+  if (
+    last >= 0xdc00 &&
+    last <= 0xdfff &&
+    index >= 2
+  ) {
+    const first = text.charCodeAt(index - 2);
+    if (first >= 0xd800 && first <= 0xdbff) {
+      return index - 2;
+    }
+  }
+  return index - 1;
+}
+
+function hasSqlIdentifierBefore(text: string, index: number): boolean {
+  const previous = previousCodePointIndex(text, index);
+  if (previous < 0) {
+    return false;
+  }
+  return (
+    text.charCodeAt(previous) === 36 ||
+    sqlIdentifierContinueLengthAt(text, previous) > 0
+  );
+}
+
+export function isSqlWhitespace(code: number): boolean {
+  return (
+    code === 9 ||
+    code === 10 ||
+    code === 11 ||
+    code === 12 ||
+    code === 13 ||
+    code === 32
+  );
+}
+
+function hasPrefixAtTokenBoundary(
+  text: string,
+  quoteAt: number,
+  prefix: string,
+): boolean {
+  const prefixFrom = quoteAt - prefix.length;
+  if (prefixFrom < 0) {
+    return false;
+  }
+  for (let index = 0; index < prefix.length; index += 1) {
+    const actual = text.charCodeAt(prefixFrom + index) | 32;
+    if (actual !== prefix.charCodeAt(index)) {
+      return false;
+    }
+  }
+  return prefixFrom === 0 || !hasSqlIdentifierBefore(text, prefixFrom);
+}
+
+export function hasEscapeStringPrefix(text: string, quoteAt: number): boolean {
+  return hasPrefixAtTokenBoundary(text, quoteAt, "e");
+}
+
+export function isBigQueryRawString(text: string, quoteAt: number): boolean {
+  return (
+    hasPrefixAtTokenBoundary(text, quoteAt, "r") ||
+    hasPrefixAtTokenBoundary(text, quoteAt, "br") ||
+    hasPrefixAtTokenBoundary(text, quoteAt, "rb")
+  );
+}
+
+export interface SqlQuoteScanResult {
+  readonly closed: boolean;
+  readonly to: number;
+}
+
+export function scanSqlQuoted(
+  text: string,
+  from: number,
+  limit: number,
+  quote: number,
+  quoteLength: 1 | 3,
+  backslashEscapes: boolean,
+  doubledQuoteEscapes: boolean,
+  stopAtLineBreak: boolean,
+): SqlQuoteScanResult {
+  let cursor = from + quoteLength;
+  while (cursor < limit) {
+    const code = text.charCodeAt(cursor);
+    if (stopAtLineBreak && (code === 10 || code === 13)) {
+      return { closed: false, to: limit };
+    }
+    if (backslashEscapes && code === 92) {
+      const escapedCode = text.charCodeAt(cursor + 1);
+      if (
+        stopAtLineBreak &&
+        (escapedCode === 10 || escapedCode === 13)
+      ) {
+        return { closed: false, to: limit };
+      }
+      cursor += Math.min(2, limit - cursor);
+      continue;
+    }
+    if (code !== quote) {
+      cursor += 1;
+      continue;
+    }
+    if (quoteLength === 3) {
+      if (
+        cursor + 2 < limit &&
+        text.charCodeAt(cursor + 1) === quote &&
+        text.charCodeAt(cursor + 2) === quote
+      ) {
+        return { closed: true, to: cursor + 3 };
+      }
+      cursor += 1;
+      continue;
+    }
+    if (
+      doubledQuoteEscapes &&
+      cursor + 1 < limit &&
+      text.charCodeAt(cursor + 1) === quote
+    ) {
+      cursor += 2;
+      continue;
+    }
+    return { closed: true, to: cursor + 1 };
+  }
+  return { closed: false, to: limit };
+}
+
+export interface SqlBlockCommentScanResult {
+  readonly closed: boolean;
+  readonly to: number;
+}
+
+export function scanSqlBlockComment(
+  text: string,
+  from: number,
+  limit: number,
+  nested: boolean,
+): SqlBlockCommentScanResult {
+  let cursor = from + 2;
+  let depth = 1;
+  while (cursor < limit) {
+    const code = text.charCodeAt(cursor);
+    const next = text.charCodeAt(cursor + 1);
+    if (nested && cursor + 1 < limit && code === 47 && next === 42) {
+      depth += 1;
+      cursor += 2;
+      continue;
+    }
+    if (cursor + 1 < limit && code === 42 && next === 47) {
+      depth -= 1;
+      cursor += 2;
+      if (depth === 0) {
+        return { closed: true, to: cursor };
+      }
+      continue;
+    }
+    cursor += 1;
+  }
+  return { closed: false, to: limit };
+}
+
+export interface SqlDollarQuoteScanResult {
+  readonly closed: boolean;
+  readonly delimiterTooLong: boolean;
+  readonly to: number;
+}
+
+function findDollarQuoteClose(
+  text: string,
+  delimiter: string,
+  from: number,
+  limit: number,
+): number {
+  if (limit === text.length) {
+    return text.indexOf(delimiter, from);
+  }
+  const finalCandidate = limit - delimiter.length;
+  for (let candidate = from; candidate <= finalCandidate; candidate += 1) {
+    if (text.charCodeAt(candidate) === 36 && text.startsWith(delimiter, candidate)) {
+      return candidate;
+    }
+  }
+  return -1;
+}
+
+export function scanSqlDollarQuote(
+  text: string,
+  from: number,
+  limit: number,
+): SqlDollarQuoteScanResult | null {
+  if (hasSqlIdentifierBefore(text, from)) {
+    return null;
+  }
+  const first = text.charCodeAt(from + 1);
+  let cursor = from + 1;
+  let delimiterTooLong = false;
+  if (first !== 36) {
+    const firstLength = sqlIdentifierStartLengthAt(text, cursor);
+    if (firstLength === 0) {
+      return null;
+    }
+    cursor += firstLength;
+    while (cursor < limit) {
+      const continueLength = sqlIdentifierContinueLengthAt(text, cursor);
+      if (continueLength === 0) {
+        break;
+      }
+      if (cursor - from + 1 > MAX_DOLLAR_QUOTE_DELIMITER_LENGTH) {
+        delimiterTooLong = true;
+      }
+      cursor += continueLength;
+    }
+    if (cursor >= limit || text.charCodeAt(cursor) !== 36) {
+      return null;
+    }
+    if (delimiterTooLong) {
+      return {
+        closed: false,
+        delimiterTooLong: true,
+        to: limit,
+      };
+    }
+  }
+  const delimiterTo = cursor + 1;
+  const delimiter = text.slice(from, delimiterTo);
+  const closeAt = findDollarQuoteClose(text, delimiter, delimiterTo, limit);
+  if (closeAt < 0) {
+    return {
+      closed: false,
+      delimiterTooLong: false,
+      to: limit,
+    };
+  }
+  return {
+    closed: true,
+    delimiterTooLong: false,
+    to: closeAt + delimiter.length,
+  };
+}

--- a/src/vnext/lexical.ts
+++ b/src/vnext/lexical.ts
@@ -291,6 +291,9 @@ export function scanSqlDollarQuote(
   if (hasSqlIdentifierBefore(text, from)) {
     return null;
   }
+  if (from + 1 >= limit) {
+    return null;
+  }
   const first = text.charCodeAt(from + 1);
   let cursor = from + 1;
   let delimiterTooLong = false;

--- a/src/vnext/statement-index.ts
+++ b/src/vnext/statement-index.ts
@@ -1,9 +1,27 @@
 import type { SqlTextChange } from "./types.js";
+import {
+  hasEscapeStringPrefix,
+  isBigQueryRawString,
+  isSqlWhitespace,
+  scanSqlBlockComment,
+  scanSqlDollarQuote,
+  scanSqlQuoted,
+  sqlIdentifierContinueLengthAt,
+  sqlIdentifierStartLengthAt,
+  type SqlLexicalProfile,
+} from "./lexical.js";
+
+export {
+  BIGQUERY_SQL_LEXICAL_PROFILE,
+  DREMIO_SQL_LEXICAL_PROFILE,
+  DUCKDB_SQL_LEXICAL_PROFILE,
+  POSTGRESQL_SQL_LEXICAL_PROFILE,
+} from "./lexical.js";
+export type { SqlLexicalProfile } from "./lexical.js";
 
 const analysisRangeBrand: unique symbol = Symbol("SqlAnalysisRange");
 
 export const MAX_SQL_STATEMENT_SLOTS = 10_000;
-const MAX_DOLLAR_QUOTE_DELIMITER_LENGTH = 256;
 const MAX_PREFIX_TOKENS = 6;
 
 export interface SqlAnalysisRange {
@@ -69,59 +87,6 @@ export interface SqlStatementIndex {
   readonly slots: readonly SqlStatementSlot[];
 }
 
-type SqlSingleQuoteBackslash = "always" | "e-prefix" | "never";
-type SqlProceduralGuards = "bigquery" | "none" | "postgresql";
-
-export interface SqlLexicalProfile {
-  readonly backtickQuotedIdentifiers: boolean;
-  readonly bigQueryStrings: boolean;
-  readonly dollarQuotedStrings: boolean;
-  readonly hashLineComments: boolean;
-  readonly nestedBlockComments: boolean;
-  readonly proceduralGuards: SqlProceduralGuards;
-  readonly singleQuoteBackslash: SqlSingleQuoteBackslash;
-}
-
-export const POSTGRESQL_SQL_LEXICAL_PROFILE: SqlLexicalProfile = Object.freeze({
-  backtickQuotedIdentifiers: false,
-  bigQueryStrings: false,
-  dollarQuotedStrings: true,
-  hashLineComments: false,
-  nestedBlockComments: true,
-  proceduralGuards: "postgresql",
-  singleQuoteBackslash: "e-prefix",
-});
-
-export const DUCKDB_SQL_LEXICAL_PROFILE: SqlLexicalProfile = Object.freeze({
-  backtickQuotedIdentifiers: false,
-  bigQueryStrings: false,
-  dollarQuotedStrings: true,
-  hashLineComments: false,
-  nestedBlockComments: true,
-  proceduralGuards: "none",
-  singleQuoteBackslash: "e-prefix",
-});
-
-export const BIGQUERY_SQL_LEXICAL_PROFILE: SqlLexicalProfile = Object.freeze({
-  backtickQuotedIdentifiers: true,
-  bigQueryStrings: true,
-  dollarQuotedStrings: false,
-  hashLineComments: true,
-  nestedBlockComments: false,
-  proceduralGuards: "bigquery",
-  singleQuoteBackslash: "always",
-});
-
-export const DREMIO_SQL_LEXICAL_PROFILE: SqlLexicalProfile = Object.freeze({
-  backtickQuotedIdentifiers: false,
-  bigQueryStrings: false,
-  dollarQuotedStrings: false,
-  hashLineComments: false,
-  nestedBlockComments: false,
-  proceduralGuards: "none",
-  singleQuoteBackslash: "never",
-});
-
 const NORMAL_END_STATE: Extract<
   SqlLexicalEndState,
   { readonly kind: "normal" }
@@ -181,271 +146,8 @@ function createOpaqueSlot(
   });
 }
 
-function isAsciiIdentifierStart(code: number): boolean {
-  return (
-    code === 95 ||
-    (code >= 65 && code <= 90) ||
-    (code >= 97 && code <= 122)
-  );
-}
-
-function isAsciiIdentifierContinue(code: number): boolean {
-  return isAsciiIdentifierStart(code) || (code >= 48 && code <= 57);
-}
-
-function codePointLengthAt(text: string, index: number): 0 | 1 | 2 {
-  const codePoint = text.codePointAt(index);
-  if (codePoint === undefined) {
-    return 0;
-  }
-  return codePoint > 0xffff ? 2 : 1;
-}
-
-function sqlIdentifierStartLengthAt(text: string, index: number): 0 | 1 | 2 {
-  const code = text.charCodeAt(index);
-  if (code <= 0x7f) {
-    return isAsciiIdentifierStart(code) ? 1 : 0;
-  }
-  return codePointLengthAt(text, index);
-}
-
-function sqlIdentifierContinueLengthAt(
-  text: string,
-  index: number,
-): 0 | 1 | 2 {
-  const code = text.charCodeAt(index);
-  if (code <= 0x7f) {
-    return isAsciiIdentifierContinue(code) ? 1 : 0;
-  }
-  return codePointLengthAt(text, index);
-}
-
-function previousCodePointIndex(text: string, index: number): number {
-  if (index <= 0) {
-    return -1;
-  }
-  const last = text.charCodeAt(index - 1);
-  if (
-    last >= 0xdc00 &&
-    last <= 0xdfff &&
-    index >= 2
-  ) {
-    const first = text.charCodeAt(index - 2);
-    if (first >= 0xd800 && first <= 0xdbff) {
-      return index - 2;
-    }
-  }
-  return index - 1;
-}
-
-function hasSqlIdentifierBefore(text: string, index: number): boolean {
-  const previous = previousCodePointIndex(text, index);
-  if (previous < 0) {
-    return false;
-  }
-  return (
-    text.charCodeAt(previous) === 36 ||
-    sqlIdentifierContinueLengthAt(text, previous) > 0
-  );
-}
-
-function isSqlWhitespace(code: number): boolean {
-  return (
-    code === 9 ||
-    code === 10 ||
-    code === 11 ||
-    code === 12 ||
-    code === 13 ||
-    code === 32
-  );
-}
-
-function hasPrefixAtTokenBoundary(
-  text: string,
-  quoteAt: number,
-  prefix: string,
-): boolean {
-  const prefixFrom = quoteAt - prefix.length;
-  if (prefixFrom < 0) {
-    return false;
-  }
-  for (let index = 0; index < prefix.length; index += 1) {
-    const actual = text.charCodeAt(prefixFrom + index) | 32;
-    if (actual !== prefix.charCodeAt(index)) {
-      return false;
-    }
-  }
-  return (
-    prefixFrom === 0 ||
-    !hasSqlIdentifierBefore(text, prefixFrom)
-  );
-}
-
-function hasEscapeStringPrefix(text: string, quoteAt: number): boolean {
-  return hasPrefixAtTokenBoundary(text, quoteAt, "e");
-}
-
-function isBigQueryRawString(text: string, quoteAt: number): boolean {
-  return (
-    hasPrefixAtTokenBoundary(text, quoteAt, "r") ||
-    hasPrefixAtTokenBoundary(text, quoteAt, "br") ||
-    hasPrefixAtTokenBoundary(text, quoteAt, "rb")
-  );
-}
-
-interface QuoteScanResult {
-  readonly closed: boolean;
-  readonly to: number;
-}
-
-function scanQuoted(
-  text: string,
-  from: number,
-  quote: number,
-  quoteLength: 1 | 3,
-  backslashEscapes: boolean,
-  doubledQuoteEscapes: boolean,
-  stopAtLineBreak: boolean,
-): QuoteScanResult {
-  let cursor = from + quoteLength;
-  while (cursor < text.length) {
-    const code = text.charCodeAt(cursor);
-    if (stopAtLineBreak && (code === 10 || code === 13)) {
-      return { closed: false, to: text.length };
-    }
-    if (backslashEscapes && code === 92) {
-      const escapedCode = text.charCodeAt(cursor + 1);
-      if (
-        stopAtLineBreak &&
-        (escapedCode === 10 || escapedCode === 13)
-      ) {
-        return { closed: false, to: text.length };
-      }
-      cursor += Math.min(2, text.length - cursor);
-      continue;
-    }
-    if (code !== quote) {
-      cursor += 1;
-      continue;
-    }
-    if (quoteLength === 3) {
-      if (
-        text.charCodeAt(cursor + 1) === quote &&
-        text.charCodeAt(cursor + 2) === quote
-      ) {
-        return { closed: true, to: cursor + 3 };
-      }
-      cursor += 1;
-      continue;
-    }
-    if (doubledQuoteEscapes && text.charCodeAt(cursor + 1) === quote) {
-      cursor += 2;
-      continue;
-    }
-    return { closed: true, to: cursor + 1 };
-  }
-  return { closed: false, to: text.length };
-}
-
-interface BlockCommentScanResult {
-  readonly closed: boolean;
-  readonly to: number;
-}
-
-function scanBlockComment(
-  text: string,
-  from: number,
-  nested: boolean,
-): BlockCommentScanResult {
-  let cursor = from + 2;
-  let depth = 1;
-  while (cursor < text.length) {
-    const code = text.charCodeAt(cursor);
-    const next = text.charCodeAt(cursor + 1);
-    if (nested && code === 47 && next === 42) {
-      depth += 1;
-      cursor += 2;
-      continue;
-    }
-    if (code === 42 && next === 47) {
-      depth -= 1;
-      cursor += 2;
-      if (depth === 0) {
-        return { closed: true, to: cursor };
-      }
-      continue;
-    }
-    cursor += 1;
-  }
-  return { closed: false, to: text.length };
-}
-
-interface DollarQuoteScanResult {
-  readonly detectedAt: number;
-  readonly endState: ExactSqlStatementSlot["endState"] | null;
-  readonly opaqueReason: SqlOpaqueBoundaryReason | null;
-  readonly to: number;
-}
-
-function scanDollarQuote(
-  text: string,
-  from: number,
-): DollarQuoteScanResult | null {
-  if (hasSqlIdentifierBefore(text, from)) {
-    return null;
-  }
-  const first = text.charCodeAt(from + 1);
-  let cursor = from + 1;
-  let delimiterTooLong = false;
-  if (first !== 36) {
-    const firstLength = sqlIdentifierStartLengthAt(text, cursor);
-    if (firstLength === 0) {
-      return null;
-    }
-    cursor += firstLength;
-    while (cursor < text.length) {
-      const continueLength = sqlIdentifierContinueLengthAt(text, cursor);
-      if (continueLength === 0) {
-        break;
-      }
-      if (cursor - from + 1 > MAX_DOLLAR_QUOTE_DELIMITER_LENGTH) {
-        delimiterTooLong = true;
-      }
-      cursor += continueLength;
-    }
-    if (text.charCodeAt(cursor) !== 36) {
-      return null;
-    }
-    if (delimiterTooLong) {
-      return {
-        detectedAt: from,
-        endState: null,
-        opaqueReason: "resource-limit",
-        to: text.length,
-      };
-    }
-  }
-  const delimiterTo = cursor + 1;
-  const delimiter = text.slice(from, delimiterTo);
-  const closeAt = text.indexOf(delimiter, delimiterTo);
-  if (closeAt < 0) {
-    return {
-      detectedAt: from,
-      endState: createUnterminatedEndState("dollar-quoted-string", from),
-      opaqueReason: null,
-      to: text.length,
-    };
-  }
-  return {
-    detectedAt: from,
-    endState: NORMAL_END_STATE,
-    opaqueReason: null,
-    to: closeAt + delimiter.length,
-  };
-}
-
 class SqlPrefixGuard {
-  readonly #mode: SqlProceduralGuards;
+  readonly #mode: SqlLexicalProfile["proceduralGuards"];
   readonly #tokens: string[] = [];
   #labelColonAt: number | null = null;
   #parenthesisDepth = 0;
@@ -455,7 +157,7 @@ class SqlPrefixGuard {
   #reason: SqlOpaqueBoundaryReason | null = null;
   #reasonAt = 0;
 
-  constructor(mode: SqlProceduralGuards) {
+  constructor(mode: SqlLexicalProfile["proceduralGuards"]) {
     this.#mode = mode;
   }
 
@@ -725,9 +427,10 @@ function scanSqlStatementIndex(
       continue;
     }
     if (code === 47 && next === 42) {
-      const comment = scanBlockComment(
+      const comment = scanSqlBlockComment(
         analysisText,
         cursor,
+        analysisText.length,
         profile.nestedBlockComments,
       );
       if (!comment.closed) {
@@ -741,18 +444,22 @@ function scanSqlStatementIndex(
       profile.dollarQuotedStrings &&
       code === 36
     ) {
-      const dollarQuote = scanDollarQuote(analysisText, cursor);
+      const dollarQuote = scanSqlDollarQuote(
+        analysisText,
+        cursor,
+        analysisText.length,
+      );
       if (dollarQuote) {
         hasCode = true;
         prefixGuard.recordNonWord(code);
-        if (dollarQuote.opaqueReason !== null) {
-          return finishOpaque(
-            dollarQuote.opaqueReason,
-            dollarQuote.detectedAt,
-          );
+        if (dollarQuote.delimiterTooLong) {
+          return finishOpaque("resource-limit", cursor);
         }
-        if (dollarQuote.endState?.kind === "unterminated") {
-          finalEndState = dollarQuote.endState;
+        if (!dollarQuote.closed) {
+          finalEndState = createUnterminatedEndState(
+            "dollar-quoted-string",
+            cursor,
+          );
         }
         cursor = dollarQuote.to;
         continue;
@@ -768,9 +475,10 @@ function scanSqlStatementIndex(
       if (code === 96) {
         prefixGuard.recordQuotedIdentifier();
         prefixGuard.recordNonWord(code);
-        const quote = scanQuoted(
+        const quote = scanSqlQuoted(
           analysisText,
           cursor,
+          analysisText.length,
           code,
           1,
           true,
@@ -806,9 +514,10 @@ function scanSqlStatementIndex(
         prefixGuard.recordQuotedIdentifier();
       }
       prefixGuard.recordNonWord(code);
-      const quote = scanQuoted(
+      const quote = scanSqlQuoted(
         analysisText,
         cursor,
+        analysisText.length,
         code,
         quoteLength,
         backslashEscapes,

--- a/src/vnext/statement-index.ts
+++ b/src/vnext/statement-index.ts
@@ -539,6 +539,19 @@ function scanSqlStatementIndex(
       const wordFrom = cursor;
       cursor += wordStartLength;
       while (cursor < analysisText.length) {
+        const continueCode = analysisText.charCodeAt(cursor);
+        if (
+          continueCode === 95 ||
+          (continueCode >= 48 && continueCode <= 57) ||
+          (continueCode >= 65 && continueCode <= 90) ||
+          (continueCode >= 97 && continueCode <= 122)
+        ) {
+          cursor += 1;
+          continue;
+        }
+        if (continueCode <= 0x7f) {
+          break;
+        }
         const continueLength = sqlIdentifierContinueLengthAt(
           analysisText,
           cursor,


### PR DESCRIPTION
## Summary

- extract dialect lexical profiles and shared UTF-16 identifier, quote, block-comment, and dollar-quote scanners from the statement index
- preserve statement-index behavior while adding explicit upper bounds needed by the parser-independent query-site recognizer
- make bounded dollar-quote opener/closer classification prefix-deterministic and keep partial close search bounded
- add direct boundary regressions for quotes, block comments, dollar quotes, UTF-16 identifiers, and SQL whitespace

This is a private prerequisite for ADR 0005 step 3; it adds no public package export.

## Validation

- `pnpm run typecheck` (strict and loose optional-property modes)
- `pnpm exec oxlint`
- `pnpm run test:integrity`
- 1,272 Node tests passed + 1 expected failure
- 7 Chromium tests passed
- packed-package smoke passed
- worker-placement/runtime evidence passed
- demo build passed
- changed coverage: 98.51% statements, 96.75% branches, 100% functions, 98.50% lines
- three independent exact-head adversarial approvals at `652b108`

## Review history

Adversarial review found a dollar-opener read beyond an explicit scan limit. The final head guards the opener before inspecting a suffix and includes bounded-prefix equivalence coverage. No additional Copilot request will be made after the one request for this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shares SQL lexical primitives and adds explicit scan limits to prevent over-reads while keeping statement-index behavior. Also preserves fast, bounded ASCII word scans and fixes dollar-quote opener detection.

- **Refactors**
  - Moved scanners for quotes, block comments, dollar quotes, UTF‑16 identifiers, and SQL whitespace into `src/vnext/lexical.ts` with explicit `limit` handling; preserved fast ASCII word scanning in `statement-index.ts` for performance.
  - Centralized dialect profiles and helpers; `statement-index.ts` now imports these and drops duplicate logic.

- **Bug Fixes**
  - Dollar-quote opener classification is now prefix-bounded; no suffix reads beyond the scan limit.
  - Quote and block comment scanners respect limits, including line-break and backslash cases.
  - Dollar-quote tags over 256 chars return `delimiterTooLong` instead of scanning unbounded.

<sup>Written for commit 360026948b4351970080a35a576fc95b80296698. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marimo-team/codemirror-sql/pull/185?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

