### PR TITLE
refactor(vnext): share bounded SQL lexer

### DIFF
--- a/src/vnext/__tests__/bounded-sql-lexer.test.ts
+++ b/src/vnext/__tests__/bounded-sql-lexer.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from "vitest";
+import {
+  BoundedSqlLexer,
+  MAX_BOUNDED_SQL_LEXEMES,
+  type BoundedSqlLexeme,
+} from "../bounded-sql-lexer.js";
+import {
+  BIGQUERY_SQL_LEXICAL_PROFILE,
+  POSTGRESQL_SQL_LEXICAL_PROFILE,
+  type SqlLexicalProfile,
+} from "../lexical.js";
+import {
+  createIdentitySqlSource,
+  createMaskedSqlSource,
+  type SqlSourceSnapshot,
+} from "../source.js";
+
+function lex(
+  source: SqlSourceSnapshot,
+  profile: SqlLexicalProfile = POSTGRESQL_SQL_LEXICAL_PROFILE,
+): {
+  readonly lexemes: readonly BoundedSqlLexeme[];
+  readonly resource: BoundedSqlLexer["resource"];
+} {
+  const lexer = new BoundedSqlLexer(
+    source,
+    0,
+    source.analysisText.length,
+    profile,
+  );
+  const lexemes: BoundedSqlLexeme[] = [];
+  while (true) {
+    const lexeme = lexer.next();
+    if (!lexeme) {
+      return { lexemes, resource: lexer.resource };
+    }
+    lexemes.push(lexeme);
+  }
+}
+
+describe("bounded SQL lexer", () => {
+  it("streams words, punctuation, strings, comments, and UTF-16 ranges", () => {
+    const text = "Se😀lect . 'x' -- note\n/* nested /* x */ */ end";
+    expect(lex(createIdentitySqlSource(text))).toEqual({
+      lexemes: [
+        { closed: true, from: 0, kind: "word", to: 8 },
+        { closed: true, from: 9, kind: "punctuation", to: 10 },
+        { closed: true, from: 11, kind: "string", to: 14 },
+        { closed: true, from: 15, kind: "line-comment", to: 22 },
+        { closed: true, from: 23, kind: "comment", to: 43 },
+        { closed: true, from: 44, kind: "word", to: 47 },
+      ],
+      resource: null,
+    });
+  });
+
+  it("keeps BigQuery backticks, raw triples, and hash comments atomic", () => {
+    const text = "`a.b` R'''raw\\value''' # comment";
+    expect(
+      lex(
+        createIdentitySqlSource(text),
+        BIGQUERY_SQL_LEXICAL_PROFILE,
+      ),
+    ).toEqual({
+      lexemes: [
+        {
+          closed: true,
+          from: 0,
+          kind: "quoted-identifier",
+          to: 5,
+        },
+        { closed: true, from: 6, kind: "word", to: 7 },
+        { closed: true, from: 7, kind: "string", to: 22 },
+        {
+          closed: true,
+          from: 23,
+          kind: "line-comment",
+          to: 32,
+        },
+      ],
+      resource: null,
+    });
+  });
+
+  it("emits embedded regions as barriers and finds exact boundaries", () => {
+    const source = createMaskedSqlSource("a {value} b", [
+      { from: 2, language: "python", to: 9 },
+    ]);
+    expect(lex(source).lexemes).toEqual([
+      { closed: true, from: 0, kind: "word", to: 1 },
+      { closed: true, from: 2, kind: "barrier", to: 9 },
+      { closed: true, from: 10, kind: "word", to: 11 },
+    ]);
+  });
+
+  it("pushes back one token without spending the budget twice", () => {
+    const source = createIdentitySqlSource("one two");
+    const lexer = new BoundedSqlLexer(
+      source,
+      0,
+      source.analysisText.length,
+      POSTGRESQL_SQL_LEXICAL_PROFILE,
+    );
+    const first = lexer.next();
+    expect(first).not.toBeNull();
+    if (!first) {
+      throw new Error("Expected first lexeme");
+    }
+    lexer.pushBack(first);
+    expect(lexer.next()).toBe(first);
+    expect(lexer.next()).toEqual({
+      closed: true,
+      from: 4,
+      kind: "word",
+      to: 7,
+    });
+    expect(lexer.next()).toBeNull();
+    expect(lexer.resource).toBeNull();
+  });
+
+  it("fails closed immediately after the shared lexeme budget", () => {
+    const words = Array.from(
+      { length: MAX_BOUNDED_SQL_LEXEMES + 1 },
+      () => "x",
+    ).join(" ");
+    const result = lex(createIdentitySqlSource(words));
+    expect(result.lexemes).toHaveLength(MAX_BOUNDED_SQL_LEXEMES);
+    expect(result.resource).toBe("lexical-token");
+  });
+
+  it("reports oversized dollar-quote delimiters without emitting a token", () => {
+    const source = createIdentitySqlSource(
+      `$${"a".repeat(257)}$unterminated`,
+    );
+    expect(lex(source)).toEqual({
+      lexemes: [],
+      resource: "dollar-quote-delimiter",
+    });
+  });
+});

--- a/src/vnext/__tests__/source.test.ts
+++ b/src/vnext/__tests__/source.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   createIdentitySqlSource,
   createMaskedSqlSource,
+  findSqlEmbeddedRegionAtOrAfter,
   mapAnalysisRangeToOriginal,
   mapOriginalRangeToAnalysis,
   MAX_SQL_EMBEDDED_REGIONS,
@@ -186,6 +187,20 @@ describe("SQL source snapshots", () => {
       { from: 2, language: "jinja", to: 3 },
     ]);
     expect(source.analysisText).toBe(" b ");
+  });
+
+  it("finds the first embedded region ending after a position", () => {
+    const source = createMaskedSqlSource("abcdef", [
+      { from: 1, language: "python", to: 2 },
+      { from: 3, language: "jinja", to: 5 },
+    ]);
+
+    expect(findSqlEmbeddedRegionAtOrAfter(source, 0)).toBe(0);
+    expect(findSqlEmbeddedRegionAtOrAfter(source, 1)).toBe(0);
+    expect(findSqlEmbeddedRegionAtOrAfter(source, 2)).toBe(1);
+    expect(findSqlEmbeddedRegionAtOrAfter(source, 4)).toBe(1);
+    expect(findSqlEmbeddedRegionAtOrAfter(source, 5)).toBe(2);
+    expect(findSqlEmbeddedRegionAtOrAfter(source, 6)).toBe(2);
   });
 
   it.each([

--- a/src/vnext/bounded-sql-lexer.ts
+++ b/src/vnext/bounded-sql-lexer.ts
@@ -1,0 +1,284 @@
+import {
+  hasEscapeStringPrefix,
+  isBigQueryRawString,
+  isSqlWhitespace,
+  scanSqlBlockComment,
+  scanSqlDollarQuote,
+  scanSqlQuoted,
+  sqlIdentifierContinueLengthAt,
+  sqlIdentifierStartLengthAt,
+  type SqlLexicalProfile,
+} from "./lexical.js";
+import type { SqlSourceSnapshot } from "./source.js";
+
+export const MAX_BOUNDED_SQL_LEXEMES = 16_384;
+
+export type BoundedSqlLexemeKind =
+  | "barrier"
+  | "comment"
+  | "line-comment"
+  | "other"
+  | "punctuation"
+  | "quoted-identifier"
+  | "string"
+  | "word";
+
+export interface BoundedSqlLexeme {
+  readonly closed: boolean;
+  readonly from: number;
+  readonly kind: BoundedSqlLexemeKind;
+  readonly to: number;
+}
+
+export type BoundedSqlLexerResource =
+  | "dollar-quote-delimiter"
+  | "lexical-token";
+
+function findSqlRegionAtOrAfter(
+  source: SqlSourceSnapshot,
+  position: number,
+): number {
+  let low = 0;
+  let high = source.embeddedRegions.length;
+  while (low < high) {
+    const middle = low + Math.floor((high - low) / 2);
+    const region = source.embeddedRegions[middle];
+    if (!region || region.to <= position) {
+      low = middle + 1;
+    } else {
+      high = middle;
+    }
+  }
+  return low;
+}
+
+export class BoundedSqlLexer {
+  readonly #profile: SqlLexicalProfile;
+  readonly #source: SqlSourceSnapshot;
+  readonly #to: number;
+  #cursor: number;
+  #lexemeCount = 0;
+  #pushed: BoundedSqlLexeme | null = null;
+  #regionIndex: number;
+  resource: BoundedSqlLexerResource | null = null;
+
+  constructor(
+    source: SqlSourceSnapshot,
+    from: number,
+    to: number,
+    profile: SqlLexicalProfile,
+  ) {
+    this.#source = source;
+    this.#cursor = from;
+    this.#to = to;
+    this.#profile = profile;
+    this.#regionIndex = findSqlRegionAtOrAfter(source, from);
+  }
+
+  next(): BoundedSqlLexeme | null {
+    if (this.#pushed) {
+      const lexeme = this.#pushed;
+      this.#pushed = null;
+      return lexeme;
+    }
+    const text = this.#source.analysisText;
+    while (this.#cursor < this.#to) {
+      const region = this.#source.embeddedRegions[this.#regionIndex];
+      if (region && region.from <= this.#cursor) {
+        const from = this.#cursor;
+        this.#cursor = Math.min(region.to, this.#to);
+        this.#regionIndex += 1;
+        return this.#record({
+          closed: true,
+          from,
+          kind: "barrier",
+          to: this.#cursor,
+        });
+      }
+      const lexicalLimit = Math.min(region?.from ?? this.#to, this.#to);
+      const code = text.charCodeAt(this.#cursor);
+      if (isSqlWhitespace(code)) {
+        this.#cursor += 1;
+        continue;
+      }
+      const from = this.#cursor;
+      const next = text.charCodeAt(from + 1);
+      if (code === 45 && next === 45) {
+        this.#cursor += 2;
+        while (
+          this.#cursor < this.#to &&
+          text.charCodeAt(this.#cursor) !== 10 &&
+          text.charCodeAt(this.#cursor) !== 13
+        ) {
+          this.#cursor += 1;
+        }
+        this.#advanceCoveredRegions();
+        return this.#record({
+          closed: true,
+          from,
+          kind: "line-comment",
+          to: this.#cursor,
+        });
+      }
+      if (this.#profile.hashLineComments && code === 35) {
+        this.#cursor += 1;
+        while (
+          this.#cursor < this.#to &&
+          text.charCodeAt(this.#cursor) !== 10 &&
+          text.charCodeAt(this.#cursor) !== 13
+        ) {
+          this.#cursor += 1;
+        }
+        this.#advanceCoveredRegions();
+        return this.#record({
+          closed: true,
+          from,
+          kind: "line-comment",
+          to: this.#cursor,
+        });
+      }
+      if (code === 47 && next === 42) {
+        const result = scanSqlBlockComment(
+          text,
+          from,
+          lexicalLimit,
+          this.#profile.nestedBlockComments,
+        );
+        this.#cursor = result.to;
+        return this.#record({
+          closed: result.closed,
+          from,
+          kind: "comment",
+          to: result.to,
+        });
+      }
+      if (this.#profile.dollarQuotedStrings && code === 36) {
+        const result = scanSqlDollarQuote(text, from, lexicalLimit);
+        if (result) {
+          this.#cursor = result.to;
+          if (result.delimiterTooLong) {
+            this.resource = "dollar-quote-delimiter";
+            return null;
+          }
+          return this.#record({
+            closed: result.closed,
+            from,
+            kind: "string",
+            to: result.to,
+          });
+        }
+      }
+      if (code === 96 && this.#profile.backtickQuotedIdentifiers) {
+        const result = scanSqlQuoted(
+          text,
+          from,
+          lexicalLimit,
+          code,
+          1,
+          true,
+          false,
+          false,
+        );
+        this.#cursor = result.to;
+        return this.#record({
+          closed: result.closed,
+          from,
+          kind: "quoted-identifier",
+          to: result.to,
+        });
+      }
+      if (code === 39 || code === 34) {
+        const triple =
+          this.#profile.bigQueryStrings &&
+          text.charCodeAt(from + 1) === code &&
+          text.charCodeAt(from + 2) === code;
+        const quotedIdentifier =
+          code === 34 && !this.#profile.bigQueryStrings;
+        const rawBigQueryString =
+          this.#profile.bigQueryStrings &&
+          isBigQueryRawString(text, from);
+        const backslashEscapes =
+          !rawBigQueryString &&
+          (this.#profile.bigQueryStrings ||
+            (code === 39 &&
+              (this.#profile.singleQuoteBackslash === "always" ||
+                (this.#profile.singleQuoteBackslash === "e-prefix" &&
+                  hasEscapeStringPrefix(text, from)))));
+        const result = scanSqlQuoted(
+          text,
+          from,
+          lexicalLimit,
+          code,
+          triple ? 3 : 1,
+          backslashEscapes,
+          !this.#profile.bigQueryStrings,
+          this.#profile.bigQueryStrings && !triple,
+        );
+        this.#cursor = result.to;
+        return this.#record({
+          closed: result.closed,
+          from,
+          kind: quotedIdentifier ? "quoted-identifier" : "string",
+          to: result.to,
+        });
+      }
+      const startLength = sqlIdentifierStartLengthAt(text, from);
+      if (startLength > 0) {
+        this.#cursor += startLength;
+        while (this.#cursor < lexicalLimit) {
+          const length = sqlIdentifierContinueLengthAt(
+            text,
+            this.#cursor,
+          );
+          if (length === 0) {
+            break;
+          }
+          this.#cursor += length;
+        }
+        return this.#record({
+          closed: true,
+          from,
+          kind: "word",
+          to: this.#cursor,
+        });
+      }
+      this.#cursor += 1;
+      return this.#record({
+        closed: true,
+        from,
+        kind:
+          code === 40 ||
+          code === 41 ||
+          code === 44 ||
+          code === 46 ||
+          code === 59
+            ? "punctuation"
+            : "other",
+        to: this.#cursor,
+      });
+    }
+    return null;
+  }
+
+  pushBack(lexeme: BoundedSqlLexeme): void {
+    this.#pushed = lexeme;
+  }
+
+  #advanceCoveredRegions(): void {
+    while (
+      (this.#source.embeddedRegions[this.#regionIndex]?.to ?? Infinity) <=
+      this.#cursor
+    ) {
+      this.#regionIndex += 1;
+    }
+  }
+
+  #record(lexeme: BoundedSqlLexeme): BoundedSqlLexeme | null {
+    this.#lexemeCount += 1;
+    if (this.#lexemeCount > MAX_BOUNDED_SQL_LEXEMES) {
+      this.resource = "lexical-token";
+      return null;
+    }
+    return lexeme;
+  }
+}

--- a/src/vnext/bounded-sql-lexer.ts
+++ b/src/vnext/bounded-sql-lexer.ts
@@ -9,7 +9,10 @@ import {
   sqlIdentifierStartLengthAt,
   type SqlLexicalProfile,
 } from "./lexical.js";
-import type { SqlSourceSnapshot } from "./source.js";
+import {
+  findSqlEmbeddedRegionAtOrAfter,
+  type SqlSourceSnapshot,
+} from "./source.js";
 
 export const MAX_BOUNDED_SQL_LEXEMES = 16_384;
 
@@ -34,24 +37,6 @@ export type BoundedSqlLexerResource =
   | "dollar-quote-delimiter"
   | "lexical-token";
 
-function findSqlRegionAtOrAfter(
-  source: SqlSourceSnapshot,
-  position: number,
-): number {
-  let low = 0;
-  let high = source.embeddedRegions.length;
-  while (low < high) {
-    const middle = low + Math.floor((high - low) / 2);
-    const region = source.embeddedRegions[middle];
-    if (!region || region.to <= position) {
-      low = middle + 1;
-    } else {
-      high = middle;
-    }
-  }
-  return low;
-}
-
 export class BoundedSqlLexer {
   readonly #profile: SqlLexicalProfile;
   readonly #source: SqlSourceSnapshot;
@@ -72,7 +57,7 @@ export class BoundedSqlLexer {
     this.#cursor = from;
     this.#to = to;
     this.#profile = profile;
-    this.#regionIndex = findSqlRegionAtOrAfter(source, from);
+    this.#regionIndex = findSqlEmbeddedRegionAtOrAfter(source, from);
   }
 
   next(): BoundedSqlLexeme | null {

--- a/src/vnext/query-site.ts
+++ b/src/vnext/query-site.ts
@@ -1,14 +1,10 @@
 import {
-  hasEscapeStringPrefix,
-  isBigQueryRawString,
-  isSqlWhitespace,
-  scanSqlBlockComment,
-  scanSqlDollarQuote,
-  scanSqlQuoted,
-  sqlIdentifierContinueLengthAt,
-  sqlIdentifierStartLengthAt,
-  type SqlLexicalProfile,
-} from "./lexical.js";
+  BoundedSqlLexer,
+  MAX_BOUNDED_SQL_LEXEMES,
+  type BoundedSqlLexeme as Lexeme,
+  type BoundedSqlLexerResource,
+} from "./bounded-sql-lexer.js";
+import type { SqlLexicalProfile } from "./lexical.js";
 import type { SqlSourceSnapshot } from "./source.js";
 import type {
   ExactSqlStatementSlot,
@@ -22,7 +18,7 @@ import type {
 const querySiteRangeBrand: unique symbol = Symbol("SqlQuerySiteRange");
 
 export const MAX_QUERY_SITE_STATEMENT_LENGTH = 65_536;
-export const MAX_QUERY_SITE_LEXEMES = 16_384;
+export const MAX_QUERY_SITE_LEXEMES = MAX_BOUNDED_SQL_LEXEMES;
 export const MAX_QUERY_SITE_DEPTH = 128;
 export const MAX_QUERY_SITE_PATH_COMPONENTS = 32;
 export const MAX_QUERY_SITE_IDENTIFIER_LENGTH = 256;
@@ -129,23 +125,6 @@ export interface SqlQuerySiteDialect {
   ) => SqlDecodedQueryPath;
 }
 
-type LexemeKind =
-  | "barrier"
-  | "comment"
-  | "line-comment"
-  | "other"
-  | "punctuation"
-  | "quoted-identifier"
-  | "string"
-  | "word";
-
-interface Lexeme {
-  readonly closed: boolean;
-  readonly from: number;
-  readonly kind: LexemeKind;
-  readonly to: number;
-}
-
 type FrameState =
   | "after-alias"
   | "after-relation"
@@ -221,7 +200,10 @@ function createRange(from: number, to: number): SqlQuerySiteRange {
   return Object.freeze(range);
 }
 
-function findRegionAtOrAfter(source: SqlSourceSnapshot, position: number): number {
+function findRegionAtOrAfter(
+  source: SqlSourceSnapshot,
+  position: number,
+): number {
   let low = 0;
   let high = source.embeddedRegions.length;
   while (low < high) {
@@ -236,241 +218,22 @@ function findRegionAtOrAfter(source: SqlSourceSnapshot, position: number): numbe
   return low;
 }
 
-function regionContains(source: SqlSourceSnapshot, position: number): boolean {
-  const region = source.embeddedRegions[
-    findRegionAtOrAfter(source, position)
-  ];
-  return Boolean(region && region.from <= position && position < region.to);
+function regionContains(
+  source: SqlSourceSnapshot,
+  position: number,
+): boolean {
+  const region =
+    source.embeddedRegions[findRegionAtOrAfter(source, position)];
+  return Boolean(
+    region && region.from <= position && position < region.to,
+  );
 }
 
-class QueryLexer {
-  readonly #profile: SqlLexicalProfile;
-  readonly #source: SqlSourceSnapshot;
-  readonly #to: number;
-  #cursor: number;
-  #lexemeCount = 0;
-  #pushed: Lexeme | null = null;
-  #regionIndex: number;
-  resource: SqlQuerySiteResource | null = null;
-
-  constructor(
-    source: SqlSourceSnapshot,
-    from: number,
-    to: number,
-    profile: SqlLexicalProfile,
-  ) {
-    this.#source = source;
-    this.#cursor = from;
-    this.#to = to;
-    this.#profile = profile;
-    this.#regionIndex = findRegionAtOrAfter(source, from);
-  }
-
-  next(): Lexeme | null {
-    if (this.#pushed) {
-      const lexeme = this.#pushed;
-      this.#pushed = null;
-      return lexeme;
-    }
-    const text = this.#source.analysisText;
-    while (this.#cursor < this.#to) {
-      const region = this.#source.embeddedRegions[this.#regionIndex];
-      if (region && region.from <= this.#cursor) {
-        const from = this.#cursor;
-        this.#cursor = Math.min(region.to, this.#to);
-        this.#regionIndex += 1;
-        return this.#record({
-          closed: true,
-          from,
-          kind: "barrier",
-          to: this.#cursor,
-        });
-      }
-      const lexicalLimit = Math.min(region?.from ?? this.#to, this.#to);
-      const code = text.charCodeAt(this.#cursor);
-      if (isSqlWhitespace(code)) {
-        this.#cursor += 1;
-        continue;
-      }
-      const from = this.#cursor;
-      const next = text.charCodeAt(from + 1);
-      if (code === 45 && next === 45) {
-        this.#cursor += 2;
-        while (
-          this.#cursor < this.#to &&
-          text.charCodeAt(this.#cursor) !== 10 &&
-          text.charCodeAt(this.#cursor) !== 13
-        ) {
-          this.#cursor += 1;
-        }
-        this.#advanceCoveredRegions();
-        return this.#record({
-          closed: true,
-          from,
-          kind: "line-comment",
-          to: this.#cursor,
-        });
-      }
-      if (this.#profile.hashLineComments && code === 35) {
-        this.#cursor += 1;
-        while (
-          this.#cursor < this.#to &&
-          text.charCodeAt(this.#cursor) !== 10 &&
-          text.charCodeAt(this.#cursor) !== 13
-        ) {
-          this.#cursor += 1;
-        }
-        this.#advanceCoveredRegions();
-        return this.#record({
-          closed: true,
-          from,
-          kind: "line-comment",
-          to: this.#cursor,
-        });
-      }
-      if (code === 47 && next === 42) {
-        const result = scanSqlBlockComment(
-          text,
-          from,
-          lexicalLimit,
-          this.#profile.nestedBlockComments,
-        );
-        this.#cursor = result.to;
-        return this.#record({
-          closed: result.closed,
-          from,
-          kind: "comment",
-          to: result.to,
-        });
-      }
-      if (this.#profile.dollarQuotedStrings && code === 36) {
-        const result = scanSqlDollarQuote(text, from, lexicalLimit);
-        if (result) {
-          this.#cursor = result.to;
-          if (result.delimiterTooLong) {
-            this.resource = "identifier-segment";
-            return null;
-          }
-          return this.#record({
-            closed: result.closed,
-            from,
-            kind: "string",
-            to: result.to,
-          });
-        }
-      }
-      if (code === 96 && this.#profile.backtickQuotedIdentifiers) {
-        const result = scanSqlQuoted(
-          text,
-          from,
-          lexicalLimit,
-          code,
-          1,
-          true,
-          false,
-          false,
-        );
-        this.#cursor = result.to;
-        return this.#record({
-          closed: result.closed,
-          from,
-          kind: "quoted-identifier",
-          to: result.to,
-        });
-      }
-      if (code === 39 || code === 34) {
-        const triple =
-          this.#profile.bigQueryStrings &&
-          text.charCodeAt(from + 1) === code &&
-          text.charCodeAt(from + 2) === code;
-        const quotedIdentifier = code === 34 && !this.#profile.bigQueryStrings;
-        const rawBigQueryString =
-          this.#profile.bigQueryStrings &&
-          isBigQueryRawString(text, from);
-        const backslashEscapes =
-          !rawBigQueryString &&
-          (this.#profile.bigQueryStrings ||
-          (code === 39 &&
-            (this.#profile.singleQuoteBackslash === "always" ||
-              (this.#profile.singleQuoteBackslash === "e-prefix" &&
-                hasEscapeStringPrefix(text, from)))));
-        const result = scanSqlQuoted(
-          text,
-          from,
-          lexicalLimit,
-          code,
-          triple ? 3 : 1,
-          backslashEscapes,
-          !this.#profile.bigQueryStrings,
-          this.#profile.bigQueryStrings && !triple,
-        );
-        this.#cursor = result.to;
-        return this.#record({
-          closed: result.closed,
-          from,
-          kind: quotedIdentifier ? "quoted-identifier" : "string",
-          to: result.to,
-        });
-      }
-      const startLength = sqlIdentifierStartLengthAt(text, from);
-      if (startLength > 0) {
-        this.#cursor += startLength;
-        while (this.#cursor < lexicalLimit) {
-          const length = sqlIdentifierContinueLengthAt(text, this.#cursor);
-          if (length === 0) {
-            break;
-          }
-          this.#cursor += length;
-        }
-        return this.#record({
-          closed: true,
-          from,
-          kind: "word",
-          to: this.#cursor,
-        });
-      }
-      this.#cursor += 1;
-      return this.#record({
-        closed: true,
-        from,
-        kind:
-          code === 40 ||
-          code === 41 ||
-          code === 44 ||
-          code === 46 ||
-          code === 59
-            ? "punctuation"
-            : "other",
-        to: this.#cursor,
-      });
-    }
-    return null;
-  }
-
-  pushBack(lexeme: Lexeme): void {
-    this.#pushed = lexeme;
-  }
-
-  #advanceCoveredRegions(): void {
-    while (
-      (this.#source.embeddedRegions[this.#regionIndex]?.to ?? Infinity) <=
-      this.#cursor
-    ) {
-      this.#regionIndex += 1;
-    }
-  }
-
-  #record(lexeme: Lexeme): Lexeme | null {
-    this.#lexemeCount += 1;
-    if (this.#lexemeCount > MAX_QUERY_SITE_LEXEMES) {
-      this.resource = "lexical-token";
-      return null;
-    }
-    return lexeme;
-  }
-}
-
-function wordEquals(text: string, token: Lexeme, expected: string): boolean {
+function wordEquals(
+  text: string,
+  token: Lexeme,
+  expected: string,
+): boolean {
   if (token.to - token.from !== expected.length) {
     return false;
   }
@@ -491,6 +254,19 @@ function wordValue(text: string, token: Lexeme): string {
     : "";
 }
 
+const QUERY_SITE_LEXER_RESOURCES: Readonly<
+  Record<BoundedSqlLexerResource, SqlQuerySiteResource>
+> = Object.freeze({
+  "dollar-quote-delimiter": "identifier-segment",
+  "lexical-token": "lexical-token",
+});
+
+function querySiteLexerResource(
+  resource: BoundedSqlLexerResource,
+): SqlQuerySiteResource {
+  return QUERY_SITE_LEXER_RESOURCES[resource];
+}
+
 function topFrame(frames: readonly QueryFrame[]): QueryFrame | null {
   return frames[frames.length - 1] ?? null;
 }
@@ -499,7 +275,10 @@ function isCommentLexeme(token: Lexeme): boolean {
   return token.kind === "comment" || token.kind === "line-comment";
 }
 
-function cursorIsInComment(token: Lexeme, position: number): boolean {
+function cursorIsInComment(
+  token: Lexeme,
+  position: number,
+): boolean {
   return (
     token.from <= position &&
     (position < token.to ||
@@ -1155,7 +934,7 @@ function decodeReadyPath(
 }
 
 function recognizePath(
-  lexer: QueryLexer,
+  lexer: BoundedSqlLexer,
   source: SqlSourceSnapshot,
   slot: ExactSqlStatementSlot,
   frame: QueryFrame,
@@ -1172,7 +951,10 @@ function recognizePath(
   while (true) {
     const next = lexer.next();
     if (lexer.resource) {
-      return unavailable("resource-limit", lexer.resource);
+      return unavailable(
+        "resource-limit",
+        querySiteLexerResource(lexer.resource),
+      );
     }
     if (next?.from === rawTo) {
       if (expectingSegment) {
@@ -1232,7 +1014,10 @@ function recognizePath(
         separated = true;
         terminator = lexer.next();
         if (lexer.resource) {
-          return unavailable("resource-limit", lexer.resource);
+          return unavailable(
+            "resource-limit",
+            querySiteLexerResource(lexer.resource),
+          );
         }
       }
       if (terminator?.kind === "barrier") {
@@ -1337,7 +1122,7 @@ export function recognizeSqlRelationQuerySite(
   ) {
     return unavailable("ambiguous-query-site");
   }
-  const lexer = new QueryLexer(
+  const lexer = new BoundedSqlLexer(
     source,
     slot.source.from,
     slot.source.to,
@@ -1352,7 +1137,10 @@ export function recognizeSqlRelationQuerySite(
   while (true) {
     const token = lexer.next();
     if (lexer.resource) {
-      return unavailable("resource-limit", lexer.resource);
+      return unavailable(
+        "resource-limit",
+        querySiteLexerResource(lexer.resource),
+      );
     }
     const frame = topFrame(frames);
     if (!token || token.from > position) {

--- a/src/vnext/query-site.ts
+++ b/src/vnext/query-site.ts
@@ -5,7 +5,10 @@ import {
   type BoundedSqlLexerResource,
 } from "./bounded-sql-lexer.js";
 import type { SqlLexicalProfile } from "./lexical.js";
-import type { SqlSourceSnapshot } from "./source.js";
+import {
+  findSqlEmbeddedRegionAtOrAfter,
+  type SqlSourceSnapshot,
+} from "./source.js";
 import type {
   ExactSqlStatementSlot,
   SqlStatementSlot,
@@ -200,30 +203,14 @@ function createRange(from: number, to: number): SqlQuerySiteRange {
   return Object.freeze(range);
 }
 
-function findRegionAtOrAfter(
-  source: SqlSourceSnapshot,
-  position: number,
-): number {
-  let low = 0;
-  let high = source.embeddedRegions.length;
-  while (low < high) {
-    const middle = low + Math.floor((high - low) / 2);
-    const region = source.embeddedRegions[middle];
-    if (!region || region.to <= position) {
-      low = middle + 1;
-    } else {
-      high = middle;
-    }
-  }
-  return low;
-}
-
 function regionContains(
   source: SqlSourceSnapshot,
   position: number,
 ): boolean {
   const region =
-    source.embeddedRegions[findRegionAtOrAfter(source, position)];
+    source.embeddedRegions[
+      findSqlEmbeddedRegionAtOrAfter(source, position)
+    ];
   return Boolean(
     region && region.from <= position && position < region.to,
   );
@@ -672,7 +659,10 @@ function intersectsRegion(
   from: number,
   to: number,
 ): boolean {
-  const region = source.embeddedRegions[findRegionAtOrAfter(source, from)];
+  const region =
+    source.embeddedRegions[
+      findSqlEmbeddedRegionAtOrAfter(source, from)
+    ];
   return Boolean(region && region.from < to && from < region.to);
 }
 

--- a/src/vnext/source.ts
+++ b/src/vnext/source.ts
@@ -38,6 +38,24 @@ export interface SqlSourceSnapshot {
   readonly originalText: string;
 }
 
+export function findSqlEmbeddedRegionAtOrAfter(
+  source: SqlSourceSnapshot,
+  position: number,
+): number {
+  let low = 0;
+  let high = source.embeddedRegions.length;
+  while (low < high) {
+    const middle = low + Math.floor((high - low) / 2);
+    const region = source.embeddedRegions[middle];
+    if (!region || region.to <= position) {
+      low = middle + 1;
+    } else {
+      high = middle;
+    }
+  }
+  return low;
+}
+
 interface MissingDataProperty {
   readonly found: false;
 }


### PR DESCRIPTION
## Summary

- extract the streaming bounded SQL lexer from the relation-site state machine into one package-private module
- preserve the exact PostgreSQL, DuckDB, BigQuery, and Dremio lexical profiles, UTF-16 offsets, embedded-region barriers, quote/comment behavior, one-token pushback, and 16,384-lexeme ceiling
- keep query-site keyword, comment-cursor, region, and resource semantics local to the consumer
- translate generic lexer resource evidence through an exhaustive package-owned map
- add direct boundary tests without exposing tokens or lexer APIs from the package

This is a zero-semantics prerequisite for the separate bounded CTE layout/visibility recognizer. The recognizers will initially use separate streaming traversals over the same lexical implementation; any traversal fusion remains benchmark-driven.

## Performance

An initial broader helper extraction caused a reproducible Vite SSR namespace-call regression on the hot path. The boundary was narrowed before commit.

Stable means at the exact head are back at the PR #186 baseline:

- exact 10 KiB statement: about 0.56–0.59 ms
- 1,000 classified aliases: about 0.36–0.38 ms
- 1,000 authenticated `USING` columns: about 0.21 ms

The lexer remains streaming and does not allocate a token tape.

## Verification

- 1,543 tests passed plus 1 expected failure
- changed coverage: 97.05% statements, 95.79% branches, 100% functions, 97.04% lines
- bounded lexer coverage: 98.92% statements/lines, 98.78% branches, 100% functions
- repository coverage: 95.34% statements, 92.05% branches, 96.15% functions, 95.33% lines
- source, test, loose-optional, and demo typechecks pass
- repository oxlint, test-integrity, and diff checks pass
- browser, package, worker-placement, demo, and benchmark gates pass
- 20,000 deterministic differential lexer comparisons passed across dialects, masked regions, subranges, UTF-16, comments, quotes, punctuation, and pushback
- independent SQL/API and concurrency/performance reviewers approved exact commit `ed079df0f68aadaf8957a7ca5e6c497e91b74860`

Part of #169.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored vNext to share a streaming bounded SQL lexer and the embedded-region lookup, and switched `query-site` to use them. Behavior is unchanged across PostgreSQL, DuckDB, BigQuery, and Dremio; this unblocks the bounded CTE recognizer in #169.

- **Refactors**
  - Moved the lexer into package-private `src/vnext/bounded-sql-lexer.ts`.
  - Centralized `findSqlEmbeddedRegionAtOrAfter` in `src/vnext/source.ts` and reused it in the lexer and `query-site` (with tests).
  - Preserves lexical profiles, UTF-16 offsets, embedded-region barriers, quote/comment rules, one-token pushback, and the 16,384-lexeme cap.
  - Kept consumer-specific semantics in `query-site`; mapped lexer resource signals to local `query-site` resources.
  - Removed duplicated lexer and region-lookup code from `src/vnext/query-site.ts` and wired it to the shared modules.

<sup>Written for commit 76190f9f50a17ddad5ca52ba4d2731932530b045. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marimo-team/codemirror-sql/pull/187?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

