### PR TITLE
feat(vnext): unify built-in relation dialect policy

### DIFF
--- a/scripts/package-smoke.mjs
+++ b/scripts/package-smoke.mjs
@@ -296,6 +296,22 @@ if (
 ) {
   throw new Error("vNext package exports are incomplete");
 }
+for (const dialect of [
+  vnext.bigQueryDialect(),
+  vnext.dremioDialect(),
+  vnext.duckdbDialect(),
+  vnext.postgresDialect(),
+]) {
+  if (
+    Object.keys(dialect).join(",") !== "displayName,id" ||
+    "decodeIdentifier" in dialect ||
+    "grammar" in dialect ||
+    "relationDialect" in dialect ||
+    "renderRelationPath" in dialect
+  ) {
+    throw new Error("vNext dialect implementation policy leaked publicly");
+  }
+}
 if (!commonKeywords.keywords || !duckdbKeywords.keywords) {
   throw new Error("Keyword data exports are incomplete");
 }

--- a/scripts/worker-placement.mjs
+++ b/scripts/worker-placement.mjs
@@ -35,8 +35,10 @@ const PARSER_MARKERS = [
   "tableList",
 ];
 const BIGQUERY_GZIP_LIMIT = 50 * 1024;
+const CORE_TOTAL_GZIP_LIMIT = 16 * 1024;
+const CORE_TOTAL_RAW_LIMIT = 52 * 1024;
 const POSTGRESQL_GZIP_LIMIT = 68 * 1024;
-const WORKER_TOTAL_GZIP_LIMIT = 120 * 1024;
+const WORKER_TOTAL_GZIP_LIMIT = 128 * 1024;
 const WORKER_TOTAL_RAW_LIMIT = 570 * 1024;
 const MIME_TYPES = new Map([
   [".css", "text/css; charset=utf-8"],
@@ -485,6 +487,27 @@ function verifyCoreExcludesParser(coreDirectory) {
   return new Set(moduleIds).size;
 }
 
+function verifyCoreSize(coreDirectory) {
+  const report = bundleReport(coreDirectory);
+  if (report.gzipBytes > CORE_TOTAL_GZIP_LIMIT) {
+    throw new Error(
+      `Core output exceeded ${CORE_TOTAL_GZIP_LIMIT} gzip bytes: ${report.gzipBytes}`,
+    );
+  }
+  if (report.rawBytes > CORE_TOTAL_RAW_LIMIT) {
+    throw new Error(
+      `Core output exceeded ${CORE_TOTAL_RAW_LIMIT} raw bytes: ${report.rawBytes}`,
+    );
+  }
+  return {
+    ...report,
+    limits: {
+      gzipBytes: CORE_TOTAL_GZIP_LIMIT,
+      rawBytes: CORE_TOTAL_RAW_LIMIT,
+    },
+  };
+}
+
 function verifySsrImport(fixtureDirectory) {
   const source = `
 Object.defineProperty(globalThis, "window", {
@@ -751,6 +774,7 @@ try {
   const coreDirectory = join(fixtureDirectory, "core-dist");
   const workersDirectory = join(fixtureDirectory, "workers-dist");
   const coreModuleCount = verifyCoreExcludesParser(coreDirectory);
+  const coreBundle = verifyCoreSize(coreDirectory);
   const chromiumResult = await runChromium(
     fixtureDirectory,
     workersDirectory,
@@ -763,7 +787,7 @@ try {
   }
   const report = {
     bundles: {
-      core: bundleReport(coreDirectory),
+      core: coreBundle,
       workers: workerBundles,
     },
     evidence: {

--- a/src/vnext/__tests__/cte-layout.bench.ts
+++ b/src/vnext/__tests__/cte-layout.bench.ts
@@ -4,35 +4,16 @@ import {
   MAX_CTE_DECLARATIONS,
   MAX_CTE_DEPTH,
   MAX_CTE_FRAMES,
-  type SqlCteLayoutDialect,
   visibleSqlCtesAt,
 } from "../cte-layout.js";
-import { DUCKDB_SQL_LEXICAL_PROFILE } from "../lexical.js";
+import { DUCKDB_SQL_RELATION_DIALECT } from "../relation-dialect.js";
 import { createIdentitySqlSource } from "../source.js";
 import {
   buildSqlStatementIndex,
   type ExactSqlStatementSlot,
 } from "../statement-index.js";
 
-const dialect: SqlCteLayoutDialect = {
-  classifyIdentifierToken: (rawIdentifier, quoted) => ({
-    status: "identifier",
-    value: {
-      component: { quoted, value: rawIdentifier },
-    },
-  }),
-  compareCteIdentifiers: (left, right) =>
-    left.value.toLowerCase() === right.value.toLowerCase()
-      ? "equal"
-      : "distinct",
-  grammar: {
-    declaredColumns: true,
-    materialization: true,
-    maximumDeclarationsPerFrame: MAX_CTE_DECLARATIONS,
-    recursive: true,
-  },
-  lexicalProfile: DUCKDB_SQL_LEXICAL_PROFILE,
-};
+const dialect = DUCKDB_SQL_RELATION_DIALECT.cteLayout;
 
 function fixture(text: string): {
   readonly source: ReturnType<typeof createIdentitySqlSource>;

--- a/src/vnext/__tests__/cte-layout.test.ts
+++ b/src/vnext/__tests__/cte-layout.test.ts
@@ -5,6 +5,7 @@ import {
   MAX_CTE_DEPTH,
   MAX_CTE_FRAMES,
   MAX_CTE_IDENTIFIER_LENGTH,
+  MAX_CTE_QUOTED_IDENTIFIER_LENGTH,
   MAX_CTE_STATEMENT_LENGTH,
   type SqlCteLayout,
   type SqlCteLayoutDialect,
@@ -13,11 +14,11 @@ import {
   visibleSqlCtesAt,
 } from "../cte-layout.js";
 import {
-  BIGQUERY_SQL_LEXICAL_PROFILE,
-  DREMIO_SQL_LEXICAL_PROFILE,
-  DUCKDB_SQL_LEXICAL_PROFILE,
-  POSTGRESQL_SQL_LEXICAL_PROFILE,
-} from "../lexical.js";
+  BIGQUERY_SQL_RELATION_DIALECT,
+  DREMIO_SQL_RELATION_DIALECT,
+  DUCKDB_SQL_RELATION_DIALECT,
+  POSTGRESQL_SQL_RELATION_DIALECT,
+} from "../relation-dialect.js";
 import {
   createIdentitySqlSource,
   createMaskedSqlSource,
@@ -28,94 +29,10 @@ import {
   type ExactSqlStatementSlot,
 } from "../statement-index.js";
 
-function decodeQuoted(raw: string): string {
-  const quote = raw.at(0) ?? "";
-  return raw
-    .slice(1, -1)
-    .replaceAll(`${quote}${quote}`, quote)
-    .replaceAll(`\\${quote}`, quote);
-}
-
-function isAscii(value: string): boolean {
-  for (let index = 0; index < value.length; index += 1) {
-    if (value.charCodeAt(index) > 0x7f) {
-      return false;
-    }
-  }
-  return true;
-}
-
-function createDialect(
-  kind: "bigquery" | "dremio" | "duckdb" | "postgresql",
-): SqlCteLayoutDialect {
-  const lexicalProfile =
-    kind === "bigquery"
-      ? BIGQUERY_SQL_LEXICAL_PROFILE
-      : kind === "dremio"
-        ? DREMIO_SQL_LEXICAL_PROFILE
-        : kind === "duckdb"
-          ? DUCKDB_SQL_LEXICAL_PROFILE
-          : POSTGRESQL_SQL_LEXICAL_PROFILE;
-  return {
-    classifyIdentifierToken: (raw, quoted) => {
-      const value = quoted ? decodeQuoted(raw) : raw;
-      if (
-        value.length === 0 ||
-        (!quoted &&
-          /^(?:as|materialized|not|recursive|select|with)$/i.test(
-            value,
-          ))
-      ) {
-        return { status: "unsupported" };
-      }
-      return {
-        status: "identifier",
-        value: {
-          component: { quoted, value },
-        },
-      };
-    },
-    compareCteIdentifiers: (left, right) => {
-      const leftKey =
-        kind === "postgresql" && left.quoted
-          ? isAscii(left.value)
-            ? left.value
-            : null
-          : isAscii(left.value)
-            ? left.value.toLowerCase()
-            : null;
-      const rightKey =
-        kind === "postgresql" && right.quoted
-          ? isAscii(right.value)
-            ? right.value
-            : null
-          : isAscii(right.value)
-            ? right.value.toLowerCase()
-            : null;
-      if (leftKey !== null && rightKey !== null) {
-        return leftKey === rightKey ? "equal" : "distinct";
-      }
-      return left.quoted === right.quoted &&
-        left.value === right.value
-        ? "equal"
-        : "unknown";
-    },
-    grammar: {
-      declaredColumns: kind !== "bigquery",
-      materialization:
-        kind === "duckdb" || kind === "postgresql",
-      maximumDeclarationsPerFrame:
-        kind === "dremio" ? 1 : MAX_CTE_DECLARATIONS,
-      recursive: kind !== "dremio",
-    },
-    lexicalProfile,
-  };
-}
-
-const postgres = createDialect("postgresql");
-const duckdb = createDialect("duckdb");
-const bigquery = createDialect("bigquery");
-const dremio = createDialect("dremio");
+const postgres = POSTGRESQL_SQL_RELATION_DIALECT.cteLayout;
+const duckdb = DUCKDB_SQL_RELATION_DIALECT.cteLayout;
+const bigquery = BIGQUERY_SQL_RELATION_DIALECT.cteLayout;
+const dremio = DREMIO_SQL_RELATION_DIALECT.cteLayout;
 
 function analyze(
   text: string,
@@ -787,7 +704,7 @@ describe("bounded CTE layout", () => {
     expect(calls).toBe(0);
 
     const oversizedQuoted = `"${"a".repeat(
-      MAX_CTE_IDENTIFIER_LENGTH * 2 + 1,
+      MAX_CTE_QUOTED_IDENTIFIER_LENGTH,
     )}"`;
     expectPartial(
       `WITH ${oversizedQuoted} AS (SELECT 1) SELECT 1`,

--- a/src/vnext/__tests__/query-site.bench.ts
+++ b/src/vnext/__tests__/query-site.bench.ts
@@ -1,34 +1,15 @@
 import { bench, describe } from "vitest";
 import {
   recognizeSqlRelationQuerySite,
-  type SqlQuerySiteDialect,
 } from "../query-site.js";
+import { DUCKDB_SQL_RELATION_DIALECT } from "../relation-dialect.js";
 import { createIdentitySqlSource } from "../source.js";
 import {
   buildSqlStatementIndex,
-  DUCKDB_SQL_LEXICAL_PROFILE,
   findSqlStatementSlot,
 } from "../statement-index.js";
 
-const dialect: SqlQuerySiteDialect = {
-  classifyIdentifierToken: (rawIdentifier) => ({
-    status: "identifier",
-    value: rawIdentifier,
-  }),
-  decodeRelationPath: (rawPath, cursorOffset) => ({
-    finalSegment: { from: 0, to: rawPath.length },
-    prefix: {
-      quoted: false,
-      value: rawPath.slice(0, cursorOffset),
-    },
-    qualifier: [],
-    quality: "exact",
-    status: "decoded",
-  }),
-  lexicalProfile: DUCKDB_SQL_LEXICAL_PROFILE,
-  maximumPathDepth: 16,
-  supportsNaturalJoin: true,
-};
+const dialect = DUCKDB_SQL_RELATION_DIALECT.querySite;
 const TEN_KIBIBYTES = 10 * 1_024;
 const queryPrefix = "SELECT ";
 const querySuffix = " FROM schema_prefix";

--- a/src/vnext/__tests__/query-site.test.ts
+++ b/src/vnext/__tests__/query-site.test.ts
@@ -11,231 +11,26 @@ import {
   type SqlQuerySiteResult,
 } from "../query-site.js";
 import {
+  BIGQUERY_SQL_RELATION_DIALECT,
+  DUCKDB_SQL_RELATION_DIALECT,
+  POSTGRESQL_SQL_RELATION_DIALECT,
+} from "../relation-dialect.js";
+import {
   createIdentitySqlSource,
   createMaskedSqlSource,
   type SqlSourceSnapshot,
 } from "../source.js";
 import {
-  BIGQUERY_SQL_LEXICAL_PROFILE,
   buildSqlStatementIndex,
-  DUCKDB_SQL_LEXICAL_PROFILE,
   findSqlStatementSlot,
   POSTGRESQL_SQL_LEXICAL_PROFILE,
 } from "../statement-index.js";
 
-function decodeSegment(raw: string, prefix = false): {
-  readonly quoted: boolean;
-  readonly value: string;
-  readonly recovered: boolean;
-} | null {
-  if (raw.startsWith("\"")) {
-    const closed = raw.endsWith("\"") && raw.length > 1;
-    if (!closed && !prefix) {
-      return null;
-    }
-    const content = raw.slice(1, closed ? -1 : undefined);
-    return {
-      quoted: true,
-      recovered: !closed,
-      value: content.replaceAll("\"\"", "\""),
-    };
-  }
-  if (raw.length === 0 && prefix) {
-    return { quoted: false, recovered: false, value: "" };
-  }
-  return /^[\p{L}_][\p{L}\p{N}_$]*$/u.test(raw)
-    ? { quoted: false, recovered: false, value: raw }
-    : null;
-}
-
-function decodeStandardPath(
-  rawPath: string,
-  cursorOffset: number,
-): SqlDecodedQueryPath {
-  const rawSegments = rawPath.split(".");
-  const qualifier = [];
-  let segmentFrom = 0;
-  for (let index = 0; index < rawSegments.length - 1; index += 1) {
-    const raw = rawSegments[index] ?? "";
-    const decoded = decodeSegment(raw);
-    if (!decoded) {
-      return { reason: "invalid-identifier", status: "unavailable" };
-    }
-    qualifier.push({ quoted: decoded.quoted, value: decoded.value });
-    segmentFrom += raw.length + 1;
-  }
-  const finalRaw = rawSegments[rawSegments.length - 1] ?? "";
-  const cursorInFinal = cursorOffset - segmentFrom;
-  if (cursorInFinal < 0 || cursorInFinal > finalRaw.length) {
-    return { reason: "invalid-identifier", status: "unavailable" };
-  }
-  let prefixRaw = finalRaw.slice(0, cursorInFinal);
-  if (finalRaw.startsWith("\"") && finalRaw.endsWith("\"")) {
-    prefixRaw = `${prefixRaw}"`;
-  }
-  const prefix = decodeSegment(prefixRaw, true);
-  if (!prefix) {
-    return { reason: "invalid-identifier", status: "unavailable" };
-  }
-  return {
-    finalSegment: {
-      from: segmentFrom,
-      to: segmentFrom + finalRaw.length,
-    },
-    prefix: { quoted: prefix.quoted, value: prefix.value },
-    qualifier,
-    quality:
-      prefix.recovered ||
-      (finalRaw.startsWith("\"") && !finalRaw.endsWith("\""))
-        ? "recovered"
-        : "exact",
-    status: "decoded",
-  };
-}
-
-function classifyIdentifierToken(
-  rawIdentifier: string,
-  quoted: boolean,
-):
-  | {
-      readonly status: "identifier";
-      readonly value: string;
-    }
-  | {
-      readonly status: "unsupported";
-    } {
-  if (quoted) {
-    const delimiter = rawIdentifier.at(0) ?? "";
-    const value = rawIdentifier
-      .slice(1, -1)
-      .replaceAll(`${delimiter}${delimiter}`, delimiter);
-    return value.length > 0
-      ? { status: "identifier", value }
-      : { status: "unsupported" };
-  }
-  const word = rawIdentifier.toLowerCase();
-  const unsupported =
-    word === "assert_rows_modified" ||
-    word === "as" ||
-    word === "collate" ||
-    word === "cross" ||
-    word === "default" ||
-    word === "distinct" ||
-    word === "end" ||
-    word === "escape" ||
-    word === "except" ||
-    word === "fetch" ||
-    word === "filter" ||
-    word === "for" ||
-    word === "from" ||
-    word === "full" ||
-    word === "group" ||
-    word === "having" ||
-    word === "inner" ||
-    word === "intersect" ||
-    word === "join" ||
-    word === "lateral" ||
-    word === "left" ||
-    word === "limit" ||
-    word === "match_recognize" ||
-    word === "natural" ||
-    word === "on" ||
-    word === "offset" ||
-    word === "order" ||
-    word === "outer" ||
-    word === "over" ||
-    word === "pivot" ||
-    word === "qualify" ||
-    word === "right" ||
-    word === "select" ||
-    word === "tablesample" ||
-    word === "unpivot" ||
-    word === "union" ||
-    word === "using" ||
-    word === "where" ||
-    word === "window" ||
-    word === "within";
-  return unsupported
-    ? { status: "unsupported" }
-    : { status: "identifier", value: rawIdentifier };
-}
-
-const postgresDialect: SqlQuerySiteDialect = {
-  classifyIdentifierToken,
-  decodeRelationPath: decodeStandardPath,
-  lexicalProfile: POSTGRESQL_SQL_LEXICAL_PROFILE,
-  maximumPathDepth: 4,
-  supportsNaturalJoin: true,
-};
-
-const duckdbDialect: SqlQuerySiteDialect = {
-  classifyIdentifierToken,
-  decodeRelationPath: decodeStandardPath,
-  lexicalProfile: DUCKDB_SQL_LEXICAL_PROFILE,
-  maximumPathDepth: 16,
-  supportsNaturalJoin: true,
-};
-
-const bigQueryDialect: SqlQuerySiteDialect = {
-  classifyIdentifierToken,
-  decodeRelationPath: (rawPath, cursorOffset) => {
-    if (!rawPath.startsWith("`")) {
-      if (!rawPath.includes("-")) {
-        return decodeStandardPath(rawPath, cursorOffset);
-      }
-      const segments = rawPath.split(".");
-      const finalRaw = segments.pop() ?? "";
-      const segmentFrom = rawPath.length - finalRaw.length;
-      const cursorInFinal = cursorOffset - segmentFrom;
-      if (
-        cursorInFinal < 0 ||
-        cursorInFinal > finalRaw.length ||
-        !/^[\p{L}_][\p{L}\p{N}_-]*$/u.test(segments[0] ?? "") ||
-        segments.slice(1).some((segment) => !decodeSegment(segment))
-      ) {
-        return { reason: "invalid-identifier", status: "unavailable" };
-      }
-      const prefix = decodeSegment(finalRaw.slice(0, cursorInFinal), true);
-      if (!prefix) {
-        return { reason: "invalid-identifier", status: "unavailable" };
-      }
-      return {
-        finalSegment: { from: segmentFrom, to: rawPath.length },
-        prefix: { quoted: prefix.quoted, value: prefix.value },
-        qualifier: segments.map((value) => ({ quoted: false, value })),
-        quality: "exact",
-        status: "decoded",
-      };
-    }
-    const closed = rawPath.endsWith("`") && rawPath.length > 1;
-    const contentTo = closed ? rawPath.length - 1 : rawPath.length;
-    const content = rawPath.slice(1, contentTo);
-    const lastDot = content.lastIndexOf(".");
-    const finalFrom = lastDot + 2;
-    const cursorInContent = Math.min(cursorOffset, contentTo) - 1;
-    if (cursorInContent < finalFrom - 1) {
-      return { reason: "invalid-identifier", status: "unavailable" };
-    }
-    const qualifier =
-      lastDot < 0
-        ? []
-        : content
-            .slice(0, lastDot)
-            .split(".")
-            .map((value) => ({ quoted: true, value }));
-    const prefix = content.slice(finalFrom - 1, cursorInContent);
-    return {
-      finalSegment: { from: finalFrom, to: rawPath.length },
-      prefix: { quoted: true, value: prefix },
-      qualifier,
-      quality: closed ? "exact" : "recovered",
-      status: "decoded",
-    };
-  },
-  lexicalProfile: BIGQUERY_SQL_LEXICAL_PROFILE,
-  maximumPathDepth: 3,
-  supportsNaturalJoin: false,
-};
+const postgresDialect = POSTGRESQL_SQL_RELATION_DIALECT.querySite;
+const duckdbDialect = DUCKDB_SQL_RELATION_DIALECT.querySite;
+const bigQueryDialect = BIGQUERY_SQL_RELATION_DIALECT.querySite;
+const classifyIdentifierToken =
+  postgresDialect.classifyIdentifierToken;
 
 function markedSource(marked: string): {
   readonly position: number;
@@ -407,7 +202,7 @@ describe("partial SELECT relation query sites", () => {
     })).prefix.value).toBe("us");
   });
 
-  it("collects a bounded dialect-neutral identifier superset", () => {
+  it("applies each built-in identifier and path policy", () => {
     expect(
       expectReady(recognize("SELECT * FROM foo$use|r")).prefix.value,
     ).toBe("foo$use");
@@ -422,10 +217,19 @@ describe("partial SELECT relation query sites", () => {
       { quoted: false, value: "dataset" },
     ]);
     expect(
-      recognize("SELECT * FROM a.b.c.d.e.f|", {
+      recognize("SELECT * FROM memory.main.users|", {
         dialect: duckdbDialect,
       }).status,
     ).toBe("ready");
+    expect(
+      recognize("SELECT * FROM a.b.c.d|", {
+        dialect: duckdbDialect,
+      }),
+    ).toEqual({
+      reason: "resource-limit",
+      resource: "identifier-path",
+      status: "unavailable",
+    });
   });
 
   it.each([
@@ -968,10 +772,18 @@ describe("fail-closed query-site behavior", () => {
     "SELECT * FROM users AS SELECT JOIN |",
     "SELECT * FROM users AS OFFSET JOIN |",
     "SELECT * FROM users AS UNION JOIN |",
-    "SELECT * FROM users AS QUALIFY JOIN |",
     "SELECT * FROM users AS LATERAL JOIN |",
   ])("classifies a structural word in explicit-alias state for %s", (marked) => {
     expect(recognize(marked).status).toBe("unavailable");
+  });
+
+  it("accepts a dialect-unreserved structural word after AS", () => {
+    expect(
+      recognize("SELECT * FROM users AS QUALIFY JOIN |").status,
+    ).toBe("ready");
+    expect(
+      recognize("SELECT * FROM users PIVOT JOIN |").status,
+    ).toBe("ready");
   });
 
   it.each([
@@ -1454,7 +1266,7 @@ describe("query-site resource limits", () => {
         if (role === "using-column") {
           usingColumnCalls += 1;
         }
-        return classifyIdentifierToken(rawIdentifier, quoted);
+        return classifyIdentifierToken(rawIdentifier, quoted, role);
       },
     };
     const columns = Array.from(
@@ -1471,8 +1283,10 @@ describe("query-site resource limits", () => {
   });
 
   it("bounds path depth and decoded identifier length", () => {
-    expect(recognize("SELECT * FROM a.b.c.d|").status).toBe("ready");
-    expect(recognize("SELECT * FROM a.b.c.d.e|")).toEqual({
+    expect(recognize("SELECT * FROM public.users|").status).toBe(
+      "ready",
+    );
+    expect(recognize("SELECT * FROM a.b.c|")).toEqual({
       reason: "resource-limit",
       resource: "identifier-path",
       status: "unavailable",
@@ -1487,8 +1301,7 @@ describe("query-site resource limits", () => {
         MAX_QUERY_SITE_IDENTIFIER_LENGTH + 1,
       )}|`),
     ).toEqual({
-      reason: "resource-limit",
-      resource: "identifier-segment",
+      reason: "ambiguous-query-site",
       status: "unavailable",
     });
 
@@ -1498,6 +1311,28 @@ describe("query-site resource limits", () => {
     ).join(".");
     const globalDialect: SqlQuerySiteDialect = {
       ...postgresDialect,
+      decodeRelationPath: (rawPath, cursorOffset) => {
+        if (cursorOffset !== rawPath.length) {
+          return {
+            reason: "invalid-identifier",
+            status: "unavailable",
+          };
+        }
+        const parts = rawPath.split(".");
+        const prefix = parts.at(-1) ?? "";
+        return {
+          finalSegment: {
+            from: rawPath.length - prefix.length,
+            to: rawPath.length,
+          },
+          prefix: { quoted: false, value: prefix },
+          qualifier: parts
+            .slice(0, -1)
+            .map((value) => ({ quoted: false, value })),
+          quality: "exact",
+          status: "decoded",
+        };
+      },
       maximumPathDepth: MAX_QUERY_SITE_PATH_COMPONENTS,
     };
     expect(

--- a/src/vnext/__tests__/relation-dialect-boundaries.test.ts
+++ b/src/vnext/__tests__/relation-dialect-boundaries.test.ts
@@ -1,0 +1,520 @@
+import { describe, expect, it } from "vitest";
+import {
+  BIGQUERY_SQL_RELATION_DIALECT,
+  DREMIO_SQL_RELATION_DIALECT,
+  DUCKDB_SQL_RELATION_DIALECT,
+  POSTGRESQL_SQL_RELATION_DIALECT,
+} from "../relation-dialect.js";
+
+const INVALID_IDENTIFIER = {
+  reason: "invalid-identifier",
+  status: "unavailable",
+};
+const UNSUPPORTED_PATH = {
+  reason: "illegal-role-sequence",
+  status: "unsupported",
+};
+
+function identifier(value: string, quoted = false) {
+  return { quoted, value };
+}
+
+describe("relation dialect boundary behavior", () => {
+  it("rejects malformed standard quoted identifiers at every boundary", () => {
+    const decode =
+      POSTGRESQL_SQL_RELATION_DIALECT.completion.decodeIdentifier;
+    for (const token of [
+      "\"\"",
+      "\"nul\0name\"",
+      "\"bad\"quote\"",
+      `"${"x".repeat(257)}"`,
+      "\"\ud800\"",
+      "\"\udc00\"",
+    ]) {
+      expect(decode(token, "complete")).toEqual(INVALID_IDENTIFIER);
+    }
+    expect(decode("\"a😀z\"", "complete")).toMatchObject({
+      component: { quoted: true, value: "a😀z" },
+      status: "decoded",
+    });
+  });
+
+  it("accepts all BigQuery escape classes and rejects invalid values", () => {
+    const decode =
+      BIGQUERY_SQL_RELATION_DIALECT.completion.decodeIdentifier;
+    expect(
+      decode(
+        "`\\\"\\'\\?\\\\\\`\\a\\b\\f\\n\\r\\t\\v\\101\\x42\\X43\\u0044\\U0001F600`",
+        "complete",
+      ),
+    ).toMatchObject({
+      component: {
+        quoted: true,
+        value: "\"'?\\`\u0007\b\f\n\r\t\vABCD😀",
+      },
+      quality: "exact",
+      status: "decoded",
+    });
+    for (const token of [
+      "``",
+      "`line\nbreak`",
+      "`line\rbreak`",
+      "`nul\0byte`",
+      "`trailing\\`",
+      "`\\8`",
+      "`\\xGG`",
+      "`\\u0g00`",
+      "`\\U0000D800`",
+      `\`${"x".repeat(257)}\``,
+    ]) {
+      expect(decode(token, "complete")).toEqual(INVALID_IDENTIFIER);
+    }
+    expect(decode("`ends\\\\`", "complete")).toMatchObject({
+      component: { quoted: true, value: "ends\\" },
+      status: "decoded",
+    });
+    expect(decode("`\\777`", "complete")).toMatchObject({
+      component: { quoted: true, value: "ǿ" },
+      status: "decoded",
+    });
+  });
+
+  it("bounds hostile raw identifier inputs before decoding", () => {
+    const oversized = "x".repeat(100_000);
+    expect(
+      POSTGRESQL_SQL_RELATION_DIALECT.completion.decodeIdentifier(
+        `"${oversized}`,
+        "completion-prefix",
+      ),
+    ).toEqual(INVALID_IDENTIFIER);
+    expect(
+      BIGQUERY_SQL_RELATION_DIALECT.completion.decodeIdentifier(
+        `\`${oversized}`,
+        "completion-prefix",
+      ),
+    ).toEqual(INVALID_IDENTIFIER);
+  });
+
+  it("keeps classification fail-closed across raw runtime calls", () => {
+    const query =
+      POSTGRESQL_SQL_RELATION_DIALECT.querySite
+        .classifyIdentifierToken;
+    const cte =
+      POSTGRESQL_SQL_RELATION_DIALECT.cteLayout
+        .classifyIdentifierToken;
+
+    expect(
+      Reflect.apply(query, undefined, [null, false, "explicit-alias"]),
+    ).toEqual({ status: "unsupported" });
+    expect(
+      Reflect.apply(query, undefined, ["users", "false", "explicit-alias"]),
+    ).toEqual({ status: "unsupported" });
+    expect(
+      Reflect.apply(query, undefined, ["users", false, "bad-role"]),
+    ).toEqual({ status: "unsupported" });
+    expect(query("Users", false, "explicit-alias")).toEqual({
+      status: "identifier",
+      value: "Users",
+    });
+    expect(query("Users", false, "using-column")).toEqual({
+      status: "identifier",
+      value: "Users",
+    });
+    expect(query("\"Users\"", false, "implicit-alias")).toEqual({
+      status: "unsupported",
+    });
+    expect(query("Éclair", false, "implicit-alias")).toEqual({
+      status: "identifier",
+      value: "Éclair",
+    });
+
+    expect(
+      Reflect.apply(cte, undefined, [null, false, "cte-name"]),
+    ).toEqual({ status: "unsupported" });
+    expect(
+      Reflect.apply(cte, undefined, ["users", "false", "cte-name"]),
+    ).toEqual({ status: "unsupported" });
+    expect(
+      Reflect.apply(cte, undefined, ["users", false, "bad-role"]),
+    ).toEqual({ status: "unsupported" });
+    expect(cte("not", false, "cte-column")).toEqual({
+      status: "unsupported",
+    });
+    expect(cte("Users", false, "cte-column")).toMatchObject({
+      status: "identifier",
+      value: { component: { quoted: false, value: "Users" } },
+    });
+    expect(cte("\"Users\"", false, "cte-name")).toEqual({
+      status: "unsupported",
+    });
+  });
+});
+
+describe("relation path boundary behavior", () => {
+  it("handles quoted cursor edges and rejects malformed qualifiers", () => {
+    const decode =
+      POSTGRESQL_SQL_RELATION_DIALECT.querySite.decodeRelationPath;
+    expect(decode("\"Users\"", 0)).toMatchObject({
+      finalSegment: { from: 0, to: 7 },
+      prefix: { quoted: true, value: "" },
+      quality: "exact",
+      status: "decoded",
+    });
+    expect(decode("\"a\"\"b\".us", 9)).toMatchObject({
+      prefix: { value: "us" },
+      qualifier: [{ quoted: true, value: "a\"b" }],
+      status: "decoded",
+    });
+    expect(decode("public.\"unterminated.users", 26)).toMatchObject({
+      prefix: { quoted: true, value: "unterminated.users" },
+      qualifier: [{ value: "public" }],
+      quality: "recovered",
+      status: "decoded",
+    });
+    for (const path of [
+      "public.us\"ers",
+      "\"public\"x.users",
+      "select.users",
+      "\ud800.users",
+    ]) {
+      expect(decode(path, path.length)).toEqual(INVALID_IDENTIFIER);
+    }
+  });
+
+  it("enforces BigQuery bare-component and dash rules", () => {
+    const decode =
+      BIGQUERY_SQL_RELATION_DIALECT.querySite.decodeRelationPath;
+    for (const path of [
+      "-project.dataset.users",
+      "project-.dataset.users",
+      "project--x.dataset.users",
+      "select.dataset.users",
+      `${"x".repeat(257)}.dataset.users`,
+      "\ud800.dataset.users",
+    ]) {
+      expect(decode(path, path.length)).toEqual(INVALID_IDENTIFIER);
+    }
+    expect(decode("project-123.dataset.us", 22)).toMatchObject({
+      prefix: { value: "us" },
+      qualifier: [
+        { value: "project-123" },
+        { value: "dataset" },
+      ],
+      status: "decoded",
+    });
+  });
+
+  it("decodes every whole-backtick escape class in path components", () => {
+    const decode =
+      BIGQUERY_SQL_RELATION_DIALECT.querySite.decodeRelationPath;
+    for (const [path, values] of [
+      ["`\\141.\\x62.\\u0063`", ["a", "b", "c"]],
+      ["`\\X61.\\U00000062.c`", ["a", "b", "c"]],
+      ["`a\\?.b.c`", ["a?", "b", "c"]],
+    ] as const) {
+      const result = decode(path, path.length);
+      expect(result.status).toBe("decoded");
+      if (result.status === "decoded") {
+        expect([
+          ...result.qualifier.map((item) => item.value),
+          result.prefix.value,
+        ]).toEqual(values);
+      }
+    }
+  });
+
+  it("rejects malformed whole-backtick paths and invalid cursor regions", () => {
+    const decode =
+      BIGQUERY_SQL_RELATION_DIALECT.querySite.decodeRelationPath;
+    for (const [path, cursor] of [
+      ["`a..b`", 6],
+      ["`a.b.`", 6],
+      ["`a.b.c.d`", 9],
+      ["`a.b.c`", 0],
+      ["`a.b.c`", 2],
+      ["`\\xGG.b.c`", 11],
+      ["`a.b.\\xGG`", 11],
+      ["`a`junk", 7],
+    ] as const) {
+      expect(decode(path, cursor)).toEqual(INVALID_IDENTIFIER);
+    }
+    expect(decode("`a.b\\`", 6)).toMatchObject({
+      prefix: { quoted: true, value: "b`" },
+      qualifier: [{ quoted: true, value: "a" }],
+      quality: "recovered",
+      status: "decoded",
+    });
+  });
+
+  it("fails closed for non-string and hostile path inputs", () => {
+    const decode =
+      DREMIO_SQL_RELATION_DIALECT.querySite.decodeRelationPath;
+    expect(
+      Reflect.apply(decode, undefined, [null, 0]),
+    ).toEqual(INVALID_IDENTIFIER);
+    expect(
+      Reflect.apply(decode, undefined, ["users", "5"]),
+    ).toEqual(INVALID_IDENTIFIER);
+    expect(
+      decode("x".repeat(100_000), 100_000),
+    ).toEqual(INVALID_IDENTIFIER);
+  });
+});
+
+describe("comparison and prefix boundaries", () => {
+  it("covers exact, short-prefix, and mixed quoting decisions", () => {
+    const postgres = POSTGRESQL_SQL_RELATION_DIALECT.completion;
+    expect(
+      postgres.compareCteIdentifiers(
+        identifier("Users", true),
+        identifier("Users", true),
+      ),
+    ).toBe("equal");
+    expect(
+      postgres.cteIdentifierMatchesPrefix(
+        identifier("Users"),
+        identifier(""),
+      ),
+    ).toBe("match");
+    expect(
+      postgres.cteIdentifierMatchesPrefix(
+        identifier("Users", true),
+        identifier("Use", true),
+      ),
+    ).toBe("match");
+    expect(
+      postgres.cteIdentifierMatchesPrefix(
+        identifier("us"),
+        identifier("users"),
+      ),
+    ).toBe("no-match");
+    expect(
+      postgres.cteIdentifierMatchesPrefix(
+        identifier("É", true),
+        identifier("Éclair", true),
+      ),
+    ).toBe("no-match");
+
+    const duckdb = DUCKDB_SQL_RELATION_DIALECT.completion;
+    expect(
+      duckdb.cteIdentifierMatchesPrefix(
+        identifier("Users"),
+        identifier(""),
+      ),
+    ).toBe("match");
+    expect(
+      duckdb.cteIdentifierMatchesPrefix(
+        identifier("Users"),
+        identifier("Use"),
+      ),
+    ).toBe("match");
+    expect(
+      duckdb.cteIdentifierMatchesPrefix(
+        identifier("us"),
+        identifier("users"),
+      ),
+    ).toBe("no-match");
+  });
+
+  it("rejects every malformed comparison component shape", () => {
+    const runtime = DUCKDB_SQL_RELATION_DIALECT.completion;
+    for (const malformed of [
+      null,
+      "users",
+      {},
+      { quoted: "false", value: "users" },
+      { quoted: false, value: 1 },
+      { quoted: false, value: "" },
+      { quoted: false, value: "x".repeat(257) },
+      { quoted: false, value: "nul\0name" },
+      { quoted: false, value: "\udc00" },
+    ]) {
+      expect(
+        Reflect.apply(runtime.compareCteIdentifiers, undefined, [
+          malformed,
+          identifier("users"),
+        ]),
+      ).toBe("unknown");
+    }
+    expect(
+      Reflect.apply(runtime.cteIdentifierMatchesPrefix, undefined, [
+        identifier("users"),
+        { quoted: false, value: 1 },
+      ]),
+    ).toBe("unknown");
+  });
+
+  it("snapshots comparison getters once", () => {
+    let reads = 0;
+    const stateful = {
+      get quoted() {
+        return false;
+      },
+      get value() {
+        reads += 1;
+        if (reads > 1) {
+          throw new Error("value was read twice");
+        }
+        return "Users";
+      },
+    };
+    expect(
+      Reflect.apply(
+        DUCKDB_SQL_RELATION_DIALECT.completion
+          .compareCteIdentifiers,
+        undefined,
+        [stateful, identifier("users")],
+      ),
+    ).toBe("equal");
+    expect(reads).toBe(1);
+  });
+});
+
+describe("relation rendering boundaries", () => {
+  it("escapes every BigQuery control and delimiter class", () => {
+    const rendered =
+      BIGQUERY_SQL_RELATION_DIALECT.completion.renderRelationPath([
+        {
+          quoted: true,
+          role: "relation",
+          value: "`\\\u0007\b\t\n\v\f\r\u0001\u007f",
+        },
+      ]);
+    expect(rendered).toEqual({
+      status: "rendered",
+      text: "`\\`\\\\\\a\\b\\t\\n\\v\\f\\r\\x01\\x7f`",
+    });
+  });
+
+  it("accepts only dialect-legal role sequences", () => {
+    expect(
+      BIGQUERY_SQL_RELATION_DIALECT.completion.renderRelationPath([
+        { quoted: false, role: "dataset", value: "analytics" },
+        { quoted: false, role: "relation", value: "events" },
+      ]).status,
+    ).toBe("rendered");
+    expect(
+      BIGQUERY_SQL_RELATION_DIALECT.completion.renderRelationPath([
+        { quoted: false, role: "relation", value: "events-2026" },
+      ]),
+    ).toEqual({ status: "rendered", text: "events-2026" });
+    expect(
+      DREMIO_SQL_RELATION_DIALECT.completion.renderRelationPath([
+        { quoted: false, role: "schema", value: "folder" },
+        { quoted: false, role: "schema", value: "nested" },
+        { quoted: false, role: "relation", value: "events" },
+      ]).status,
+    ).toBe("rendered");
+
+    for (const [render, path] of [
+      [
+        POSTGRESQL_SQL_RELATION_DIALECT.completion.renderRelationPath,
+        [{ quoted: false, role: "schema", value: "public" }],
+      ],
+      [
+        DUCKDB_SQL_RELATION_DIALECT.completion.renderRelationPath,
+        [
+          { quoted: false, role: "schema", value: "main" },
+          { quoted: false, role: "catalog", value: "memory" },
+          { quoted: false, role: "relation", value: "events" },
+        ],
+      ],
+      [
+        DREMIO_SQL_RELATION_DIALECT.completion.renderRelationPath,
+        [
+          { quoted: false, role: "catalog", value: "source" },
+          { quoted: false, role: "project", value: "bad" },
+          { quoted: false, role: "relation", value: "events" },
+        ],
+      ],
+    ] as const) {
+      expect(Reflect.apply(render, undefined, [path])).toEqual(
+        UNSUPPORTED_PATH,
+      );
+    }
+  });
+
+  it("fails closed for malformed and hostile rendering inputs", () => {
+    const render =
+      POSTGRESQL_SQL_RELATION_DIALECT.completion.renderRelationPath;
+    for (const path of [
+      null,
+      "users",
+      [null],
+      ["users"],
+      [{ quoted: false, role: 1, value: "users" }],
+      [{ quoted: "false", role: "relation", value: "users" }],
+      [{ quoted: false, role: "relation", value: 1 }],
+      [{ quoted: false, role: "relation", value: "" }],
+      [{ quoted: false, role: "relation", value: "x".repeat(257) }],
+      [{ quoted: false, role: "relation", value: "nul\0name" }],
+      [{ quoted: false, role: "relation", value: "\ud800" }],
+    ]) {
+      expect(Reflect.apply(render, undefined, [path])).toEqual(
+        UNSUPPORTED_PATH,
+      );
+    }
+
+    const hostile = new Proxy([], {
+      get() {
+        throw new Error("hostile path");
+      },
+    });
+    expect(
+      Reflect.apply(render, undefined, [hostile]),
+    ).toEqual(UNSUPPORTED_PATH);
+  });
+
+  it("uses bounded indexing and snapshots rendered component getters", () => {
+    const path: [
+      {
+        readonly quoted: false;
+        readonly role: "relation";
+        readonly value: "users";
+      },
+    ] = [
+      {
+        quoted: false,
+        role: "relation",
+        value: "users",
+      },
+    ];
+    Object.defineProperty(path, Symbol.iterator, {
+      value: function* () {
+        while (true) {
+          yield path[0];
+        }
+      },
+    });
+    expect(
+      POSTGRESQL_SQL_RELATION_DIALECT.completion
+        .renderRelationPath(path),
+    ).toEqual({ status: "rendered", text: "users" });
+
+    let reads = 0;
+    const stateful = {
+      get quoted() {
+        return false;
+      },
+      get role() {
+        return "relation";
+      },
+      get value() {
+        reads += 1;
+        if (reads > 1) {
+          throw new Error("value was read twice");
+        }
+        return "users";
+      },
+    };
+    expect(
+      Reflect.apply(
+        POSTGRESQL_SQL_RELATION_DIALECT.completion
+          .renderRelationPath,
+        undefined,
+        [[stateful]],
+      ),
+    ).toEqual({ status: "rendered", text: "users" });
+    expect(reads).toBe(1);
+  });
+});

--- a/src/vnext/__tests__/relation-dialect.test.ts
+++ b/src/vnext/__tests__/relation-dialect.test.ts
@@ -1,0 +1,1038 @@
+import { describe, expect, it } from "vitest";
+import {
+  analyzeSqlCteLayout,
+  type SqlCteLayout,
+} from "../cte-layout.js";
+import {
+  BIGQUERY_SQL_RELATION_DIALECT,
+  DREMIO_SQL_RELATION_DIALECT,
+  DUCKDB_SQL_RELATION_DIALECT,
+  POSTGRESQL_SQL_RELATION_DIALECT,
+  type SqlRelationDialectRuntime,
+} from "../relation-dialect.js";
+import type {
+  SqlCanonicalRelationPath,
+  SqlIdentifierDecodeResult,
+} from "../relation-completion-types.js";
+import {
+  createIdentitySqlSource,
+} from "../source.js";
+import {
+  buildSqlStatementIndex,
+} from "../statement-index.js";
+import type { SqlIdentifierComponent } from "../types.js";
+
+const RUNTIMES = Object.freeze({
+  bigquery: BIGQUERY_SQL_RELATION_DIALECT,
+  dremio: DREMIO_SQL_RELATION_DIALECT,
+  duckdb: DUCKDB_SQL_RELATION_DIALECT,
+  postgresql: POSTGRESQL_SQL_RELATION_DIALECT,
+});
+
+function decoded(
+  result: SqlIdentifierDecodeResult,
+): Extract<SqlIdentifierDecodeResult, { readonly status: "decoded" }> {
+  expect(result.status).toBe("decoded");
+  if (result.status !== "decoded") {
+    throw new Error("Expected a decoded identifier");
+  }
+  return result;
+}
+
+function readyPath(
+  runtime: SqlRelationDialectRuntime,
+  text: string,
+  position = text.length,
+) {
+  const result = runtime.querySite.decodeRelationPath(text, position);
+  expect(result.status).toBe("decoded");
+  if (result.status !== "decoded") {
+    throw new Error("Expected a decoded relation path");
+  }
+  return result;
+}
+
+function component(
+  value: string,
+  quoted = false,
+): SqlIdentifierComponent {
+  return { quoted, value };
+}
+
+function analyze(
+  runtime: SqlRelationDialectRuntime,
+  text: string,
+): SqlCteLayout {
+  const source = createIdentitySqlSource(text);
+  const slot = buildSqlStatementIndex(
+    source.analysisText,
+    runtime.querySite.lexicalProfile,
+  ).slots[0];
+  expect(slot?.boundaryQuality).toBe("exact");
+  if (!slot || slot.boundaryQuality !== "exact") {
+    throw new Error("Expected one exact SQL statement");
+  }
+  return analyzeSqlCteLayout(source, slot, runtime.cteLayout);
+}
+
+function expectDeepFrozenRuntime(
+  runtime: SqlRelationDialectRuntime,
+): void {
+  expect(Object.isFrozen(runtime)).toBe(true);
+  expect(Object.isFrozen(runtime.completion)).toBe(true);
+  expect(Object.isFrozen(runtime.cteLayout)).toBe(true);
+  expect(Object.isFrozen(runtime.cteLayout.grammar)).toBe(true);
+  expect(Object.isFrozen(runtime.querySite)).toBe(true);
+}
+
+describe("built-in relation dialect runtime", () => {
+  it("owns stable, deeply frozen, coherent views", () => {
+    for (const runtime of Object.values(RUNTIMES)) {
+      expectDeepFrozenRuntime(runtime);
+      expect(runtime.cteLayout.lexicalProfile).toBe(
+        runtime.querySite.lexicalProfile,
+      );
+      expect(runtime.cteLayout.compareCteIdentifiers).toBe(
+        runtime.completion.compareCteIdentifiers,
+      );
+    }
+    expect(POSTGRESQL_SQL_RELATION_DIALECT).toBe(
+      POSTGRESQL_SQL_RELATION_DIALECT,
+    );
+  });
+
+  it("records the closed dialect capability matrix", () => {
+    expect(POSTGRESQL_SQL_RELATION_DIALECT.querySite).toMatchObject({
+      maximumPathDepth: 2,
+      supportsNaturalJoin: true,
+    });
+    expect(POSTGRESQL_SQL_RELATION_DIALECT.cteLayout.grammar).toEqual({
+      declaredColumns: true,
+      materialization: true,
+      maximumDeclarationsPerFrame: 256,
+      recursive: true,
+    });
+    expect(DUCKDB_SQL_RELATION_DIALECT.querySite).toMatchObject({
+      maximumPathDepth: 3,
+      supportsNaturalJoin: true,
+    });
+    expect(DUCKDB_SQL_RELATION_DIALECT.cteLayout.grammar).toEqual({
+      declaredColumns: true,
+      materialization: true,
+      maximumDeclarationsPerFrame: 256,
+      recursive: true,
+    });
+    expect(BIGQUERY_SQL_RELATION_DIALECT.querySite).toMatchObject({
+      maximumPathDepth: 3,
+      supportsNaturalJoin: false,
+    });
+    expect(BIGQUERY_SQL_RELATION_DIALECT.cteLayout.grammar).toEqual({
+      declaredColumns: false,
+      materialization: false,
+      maximumDeclarationsPerFrame: 256,
+      recursive: true,
+    });
+    expect(DREMIO_SQL_RELATION_DIALECT.querySite).toMatchObject({
+      maximumPathDepth: 32,
+      supportsNaturalJoin: false,
+    });
+    expect(DREMIO_SQL_RELATION_DIALECT.cteLayout.grammar).toEqual({
+      declaredColumns: true,
+      materialization: false,
+      maximumDeclarationsPerFrame: 1,
+      recursive: false,
+    });
+  });
+});
+
+describe("identifier decoding and classification", () => {
+  it.each([
+    ["postgresql", POSTGRESQL_SQL_RELATION_DIALECT],
+    ["duckdb", DUCKDB_SQL_RELATION_DIALECT],
+    ["dremio", DREMIO_SQL_RELATION_DIALECT],
+  ] as const)("decodes standard identifiers for %s", (_name, runtime) => {
+    expect(
+      decoded(
+        runtime.completion.decodeIdentifier("Users", "complete"),
+      ),
+    ).toMatchObject({
+      component: { quoted: false, value: "Users" },
+      quality: "exact",
+    });
+    expect(
+      decoded(
+        runtime.completion.decodeIdentifier(
+          "\"User \"\"Events\"\"\"",
+          "complete",
+        ),
+      ),
+    ).toMatchObject({
+      component: { quoted: true, value: "User \"Events\"" },
+      quality: "exact",
+    });
+    expect(
+      decoded(
+        runtime.completion.decodeIdentifier(
+          "\"line\nname\"",
+          "complete",
+        ),
+      ).component,
+    ).toEqual({ quoted: true, value: "line\nname" });
+    expect(
+      decoded(
+        runtime.completion.decodeIdentifier(
+          "\"User",
+          "completion-prefix",
+        ),
+      ),
+    ).toMatchObject({
+      component: { quoted: true, value: "User" },
+      quality: "recovered",
+    });
+    expect(
+      decoded(
+        runtime.completion.decodeIdentifier(
+          "\"",
+          "completion-prefix",
+        ),
+      ),
+    ).toMatchObject({
+      component: { quoted: true, value: "" },
+      quality: "recovered",
+    });
+    expect(
+      runtime.completion.decodeIdentifier("\"User", "complete"),
+    ).toEqual({
+      reason: "invalid-identifier",
+      status: "unavailable",
+    });
+  });
+
+  it("keeps PostgreSQL dollar identifiers dialect-specific", () => {
+    expect(
+      POSTGRESQL_SQL_RELATION_DIALECT.completion.decodeIdentifier(
+        "user$id",
+        "complete",
+      ).status,
+    ).toBe("decoded");
+    expect(
+      DUCKDB_SQL_RELATION_DIALECT.completion.decodeIdentifier(
+        "user$id",
+        "complete",
+      ).status,
+    ).toBe("unavailable");
+  });
+
+  it("keeps BigQuery bare identifiers ASCII-only", () => {
+    for (const token of ["Éclair", "😀", "\u00a0name"]) {
+      expect(
+        BIGQUERY_SQL_RELATION_DIALECT.completion.decodeIdentifier(
+          token,
+          "complete",
+        ),
+      ).toEqual({
+        reason: "invalid-identifier",
+        status: "unavailable",
+      });
+    }
+    expect(
+      POSTGRESQL_SQL_RELATION_DIALECT.completion.decodeIdentifier(
+        "Éclair",
+        "complete",
+      ).status,
+    ).toBe("decoded");
+    expect(
+      BIGQUERY_SQL_RELATION_DIALECT.completion.renderRelationPath([
+        {
+          quoted: false,
+          role: "relation",
+          value: "Éclair",
+        },
+      ]),
+    ).toEqual({ status: "rendered", text: "`Éclair`" });
+  });
+
+  it("preserves DuckDB's high-bit bare identifier behavior", () => {
+    for (const token of ["Éclair", "🦆", "\u00a0name", "名字"]) {
+      expect(
+        DUCKDB_SQL_RELATION_DIALECT.completion.decodeIdentifier(
+          token,
+          "complete",
+        ).status,
+      ).toBe("decoded");
+      expect(
+        DUCKDB_SQL_RELATION_DIALECT.completion.renderRelationPath([
+          {
+            quoted: false,
+            role: "relation",
+            value: token,
+          },
+        ]),
+      ).toEqual({ status: "rendered", text: token });
+    }
+  });
+
+  it("uses Dremio's Unicode letter and number rules for bare names", () => {
+    for (const token of ["Éclair", "名字", "_é2"]) {
+      expect(
+        DREMIO_SQL_RELATION_DIALECT.completion.decodeIdentifier(
+          token,
+          "complete",
+        ).status,
+      ).toBe("decoded");
+    }
+    for (const token of ["🦆", "\u00a0name"]) {
+      expect(
+        DREMIO_SQL_RELATION_DIALECT.completion.decodeIdentifier(
+          token,
+          "complete",
+        ).status,
+      ).toBe("unavailable");
+      expect(
+        DREMIO_SQL_RELATION_DIALECT.completion.renderRelationPath([
+          {
+            quoted: false,
+            role: "relation",
+            value: token,
+          },
+        ]),
+      ).toEqual({
+        status: "rendered",
+        text: `"${token}"`,
+      });
+    }
+  });
+
+  it("decodes the documented BigQuery identifier escapes", () => {
+    expect(
+      decoded(
+        BIGQUERY_SQL_RELATION_DIALECT.completion.decodeIdentifier(
+          "`line\\nquote\\`slash\\\\A\\x42\\u0043\\U00000044`",
+          "complete",
+        ),
+      ),
+    ).toMatchObject({
+      component: {
+        quoted: true,
+        value: "line\nquote`slash\\ABCD",
+      },
+      quality: "exact",
+    });
+    expect(
+      decoded(
+        BIGQUERY_SQL_RELATION_DIALECT.completion.decodeIdentifier(
+          "`partial",
+          "completion-prefix",
+        ),
+      ),
+    ).toMatchObject({
+      component: { quoted: true, value: "partial" },
+      quality: "recovered",
+    });
+    expect(
+      readyPath(BIGQUERY_SQL_RELATION_DIALECT, "`"),
+    ).toMatchObject({
+      prefix: { quoted: true, value: "" },
+      quality: "recovered",
+    });
+    for (const token of [
+      "`bad\\q`",
+      "`bad\\x4`",
+      "`bad\\uD800`",
+      "`bad\\U00110000`",
+      "`\\000`",
+    ]) {
+      expect(
+        BIGQUERY_SQL_RELATION_DIALECT.completion.decodeIdentifier(
+          token,
+          "complete",
+        ).status,
+      ).toBe("unavailable");
+    }
+  });
+
+  it("rejects reserved, malformed, oversized, and ill-formed names", () => {
+    for (const [name, runtime] of Object.entries(RUNTIMES)) {
+      for (const token of [
+        "",
+        "select",
+        "1table",
+        "has space",
+        "\ud800",
+        "a".repeat(257),
+      ]) {
+        expect(
+          runtime.completion.decodeIdentifier(token, "complete")
+            .status,
+          `${name}: ${JSON.stringify(token)}`,
+        ).toBe("unavailable");
+      }
+      expect(
+        decoded(
+          runtime.completion.decodeIdentifier(
+            "",
+            "completion-prefix",
+          ),
+        ).component,
+      ).toEqual({ quoted: false, value: "" });
+    }
+  });
+
+  it("uses the same decoder for query and CTE token classification", () => {
+    for (const runtime of Object.values(RUNTIMES)) {
+      expect(
+        runtime.querySite.classifyIdentifierToken(
+          "select",
+          false,
+          "implicit-alias",
+        ),
+      ).toEqual({ status: "unsupported" });
+      expect(
+        runtime.cteLayout.classifyIdentifierToken(
+          "select",
+          false,
+          "cte-name",
+        ),
+      ).toEqual({ status: "unsupported" });
+      expect(
+        runtime.querySite.classifyIdentifierToken(
+          runtime === BIGQUERY_SQL_RELATION_DIALECT
+            ? "`select`"
+            : "\"select\"",
+          true,
+          "using-column",
+        ),
+      ).toMatchObject({
+        status: "identifier",
+        value: "select",
+      });
+    }
+  });
+
+  it("rejects control words only where they are structurally ambiguous", () => {
+    const query =
+      BIGQUERY_SQL_RELATION_DIALECT.querySite
+        .classifyIdentifierToken;
+    expect(query("pivot", false, "implicit-alias")).toEqual({
+      status: "unsupported",
+    });
+    expect(query("pivot", false, "explicit-alias")).toEqual({
+      status: "identifier",
+      value: "pivot",
+    });
+    expect(query("pivot", false, "using-column")).toEqual({
+      status: "identifier",
+      value: "pivot",
+    });
+    expect(
+      POSTGRESQL_SQL_RELATION_DIALECT.querySite
+        .classifyIdentifierToken(
+          "pivot",
+          false,
+          "implicit-alias",
+        ),
+    ).toEqual({
+      status: "identifier",
+      value: "pivot",
+    });
+
+    const cte =
+      POSTGRESQL_SQL_RELATION_DIALECT.cteLayout
+        .classifyIdentifierToken;
+    expect(cte("materialized", false, "cte-name").status).toBe(
+      "identifier",
+    );
+    expect(cte("materialized", false, "cte-column").status).toBe(
+      "identifier",
+    );
+  });
+
+  it("uses dialect-specific reserved-word tables", () => {
+    expect(
+      POSTGRESQL_SQL_RELATION_DIALECT.completion.decodeIdentifier(
+        "abs",
+        "complete",
+      ).status,
+    ).toBe("decoded");
+    for (const [runtime, word, renderedText] of [
+      [
+        POSTGRESQL_SQL_RELATION_DIALECT,
+        "authorization",
+        "\"authorization\"",
+      ],
+      [DUCKDB_SQL_RELATION_DIALECT, "describe", "\"describe\""],
+      [BIGQUERY_SQL_RELATION_DIALECT, "graph_table", "`graph_table`"],
+      [DREMIO_SQL_RELATION_DIALECT, "abs", "\"abs\""],
+    ] as const) {
+      expect(
+        runtime.completion.decodeIdentifier(word, "complete").status,
+      ).toBe("unavailable");
+      expect(
+        runtime.completion.renderRelationPath([
+          {
+            quoted: false,
+            role: "relation",
+            value: word,
+          },
+        ]),
+      ).toEqual({
+        status: "rendered",
+        text: renderedText,
+      });
+    }
+  });
+
+  it("keeps the CTE raw bound coherent with BigQuery escapes", () => {
+    const escaped = "\\U00000041".repeat(256);
+    const layout = analyze(
+      BIGQUERY_SQL_RELATION_DIALECT,
+      `WITH \`${escaped}\` AS (SELECT 1) SELECT 1`,
+    );
+    expect(layout.status).toBe("ready");
+    if (layout.status !== "unavailable") {
+      expect(layout.declarations[0]?.name.value).toBe("A".repeat(256));
+    }
+  });
+});
+
+describe("relation path decoding", () => {
+  it.each([
+    ["postgresql", POSTGRESQL_SQL_RELATION_DIALECT],
+    ["duckdb", DUCKDB_SQL_RELATION_DIALECT],
+    ["dremio", DREMIO_SQL_RELATION_DIALECT],
+  ] as const)("preserves quoted dots for %s", (_name, runtime) => {
+    expect(readyPath(runtime, "\"my.schema\".us")).toMatchObject({
+      finalSegment: { from: 12, to: 14 },
+      prefix: { quoted: false, value: "us" },
+      qualifier: [{ quoted: true, value: "my.schema" }],
+      quality: "exact",
+    });
+  });
+
+  it("decodes a cursor inside the final quoted token", () => {
+    const text = "public.\"Users\"";
+    const cursor = text.indexOf("ers");
+    expect(
+      readyPath(POSTGRESQL_SQL_RELATION_DIALECT, text, cursor),
+    ).toMatchObject({
+      finalSegment: { from: 7, to: text.length },
+      prefix: { quoted: true, value: "Us" },
+      qualifier: [{ quoted: false, value: "public" }],
+      quality: "exact",
+    });
+  });
+
+  it("recovers only the final incomplete quoted component", () => {
+    expect(
+      readyPath(POSTGRESQL_SQL_RELATION_DIALECT, "public.\"Us"),
+    ).toMatchObject({
+      prefix: { quoted: true, value: "Us" },
+      qualifier: [{ quoted: false, value: "public" }],
+      quality: "recovered",
+    });
+  });
+
+  it("supports a trailing empty final segment", () => {
+    expect(
+      readyPath(POSTGRESQL_SQL_RELATION_DIALECT, "public."),
+    ).toMatchObject({
+      finalSegment: { from: 7, to: 7 },
+      prefix: { quoted: false, value: "" },
+      qualifier: [{ quoted: false, value: "public" }],
+    });
+  });
+
+  it("rejects invalid offsets, malformed paths, and excess depth", () => {
+    const decoder =
+      POSTGRESQL_SQL_RELATION_DIALECT.querySite.decodeRelationPath;
+    for (const [text, position] of [
+      ["public.users", -1],
+      ["public.users", 0.5],
+      ["public.users", Number.NaN],
+      ["public.users", 13],
+      ["a..b", 4],
+      ["a.b.c", 5],
+      ["\"a\"x.b", 6],
+      [".users", 6],
+    ] as const) {
+      expect(decoder(text, position).status).toBe("unavailable");
+    }
+  });
+
+  it("supports BigQuery dashed-first and whole-backtick paths", () => {
+    expect(
+      readyPath(
+        BIGQUERY_SQL_RELATION_DIALECT,
+        "my-project.dataset.ta",
+      ),
+    ).toMatchObject({
+      prefix: { quoted: false, value: "ta" },
+      qualifier: [
+        { quoted: false, value: "my-project" },
+        { quoted: false, value: "dataset" },
+      ],
+    });
+    expect(
+      readyPath(
+        BIGQUERY_SQL_RELATION_DIALECT,
+        "`my-project.dataset.ta`",
+        "`my-project.dataset.ta".length,
+      ),
+    ).toMatchObject({
+      finalSegment: { from: 20, to: 23 },
+      prefix: { quoted: true, value: "ta" },
+      qualifier: [
+        { quoted: true, value: "my-project" },
+        { quoted: true, value: "dataset" },
+      ],
+      quality: "exact",
+    });
+    expect(
+      readyPath(
+        BIGQUERY_SQL_RELATION_DIALECT,
+        "`project.with.dot`.ta",
+      ),
+    ).toMatchObject({
+      prefix: { quoted: false, value: "ta" },
+      qualifier: [{ quoted: true, value: "project.with.dot" }],
+    });
+    expect(
+      readyPath(
+        BIGQUERY_SQL_RELATION_DIALECT,
+        "abc5.GROUP",
+      ),
+    ).toMatchObject({
+      prefix: { quoted: false, value: "GROUP" },
+      qualifier: [{ quoted: false, value: "abc5" }],
+    });
+    expect(
+      BIGQUERY_SQL_RELATION_DIALECT.querySite.decodeRelationPath(
+        "GROUP",
+        5,
+      ).status,
+    ).toBe("unavailable");
+  });
+
+  it("rejects a BigQuery dash outside the first path component", () => {
+    for (const text of [
+      "project.my-dataset.table",
+      "project.dataset.my-table",
+      "table-287a",
+      "table-",
+    ]) {
+      expect(
+        BIGQUERY_SQL_RELATION_DIALECT.querySite.decodeRelationPath(
+          text,
+          text.length,
+        ).status,
+      ).toBe("unavailable");
+    }
+  });
+
+  it("recovers an incomplete BigQuery whole-backtick path", () => {
+    expect(
+      readyPath(
+        BIGQUERY_SQL_RELATION_DIALECT,
+        "`project.dataset.ta",
+      ),
+    ).toMatchObject({
+      prefix: { quoted: true, value: "ta" },
+      qualifier: [
+        { quoted: true, value: "project" },
+        { quoted: true, value: "dataset" },
+      ],
+      quality: "recovered",
+    });
+  });
+});
+
+describe("CTE equality and prefix policy", () => {
+  it("implements PostgreSQL quoted and unquoted resolution", () => {
+    const runtime = POSTGRESQL_SQL_RELATION_DIALECT.completion;
+    expect(
+      runtime.compareCteIdentifiers(
+        component("Users"),
+        component("users"),
+      ),
+    ).toBe("equal");
+    expect(
+      runtime.compareCteIdentifiers(
+        component("users", true),
+        component("USERS"),
+      ),
+    ).toBe("equal");
+    expect(
+      runtime.compareCteIdentifiers(
+        component("Users", true),
+        component("users"),
+      ),
+    ).toBe("distinct");
+    expect(
+      runtime.compareCteIdentifiers(
+        component("É"),
+        component("é"),
+      ),
+    ).toBe("unknown");
+    expect(
+      runtime.cteIdentifierMatchesPrefix(
+        component("Users"),
+        component("us"),
+      ),
+    ).toBe("match");
+    expect(
+      runtime.cteIdentifierMatchesPrefix(
+        component("Users", true),
+        component("us"),
+      ),
+    ).toBe("no-match");
+    expect(
+      runtime.cteIdentifierMatchesPrefix(
+        component("Éclair"),
+        component("é"),
+      ),
+    ).toBe("unknown");
+  });
+
+  it("keeps DuckDB ASCII comparison fully decidable", () => {
+    const runtime = DUCKDB_SQL_RELATION_DIALECT.completion;
+    expect(
+      runtime.compareCteIdentifiers(
+        component("Users", true),
+        component("users"),
+      ),
+    ).toBe("equal");
+    expect(
+      runtime.compareCteIdentifiers(
+        component("É"),
+        component("é"),
+      ),
+    ).toBe("distinct");
+    expect(
+      runtime.cteIdentifierMatchesPrefix(
+        component("Éclair", true),
+        component("é"),
+      ),
+    ).toBe("no-match");
+  });
+
+  it.each([
+    ["bigquery", BIGQUERY_SQL_RELATION_DIALECT],
+    ["dremio", DREMIO_SQL_RELATION_DIALECT],
+  ] as const)(
+    "uses conservative non-ASCII comparison for %s",
+    (_name, dialect) => {
+      const runtime = dialect.completion;
+      expect(
+        runtime.compareCteIdentifiers(
+          component("Users", true),
+          component("users"),
+        ),
+      ).toBe("equal");
+      expect(
+        runtime.compareCteIdentifiers(
+          component("É"),
+          component("É", true),
+        ),
+      ).toBe("equal");
+      expect(
+        runtime.compareCteIdentifiers(
+          component("É"),
+          component("é"),
+        ),
+      ).toBe("unknown");
+      expect(
+        runtime.cteIdentifierMatchesPrefix(
+          component("Éclair"),
+          component("é"),
+        ),
+      ).toBe("unknown");
+    },
+  );
+
+  it("fails closed for malformed comparison inputs", () => {
+    expect(
+      Reflect.apply(
+        POSTGRESQL_SQL_RELATION_DIALECT.completion
+          .compareCteIdentifiers,
+        undefined,
+        [null, component("users")],
+      ),
+    ).toBe("unknown");
+    expect(
+      POSTGRESQL_SQL_RELATION_DIALECT.completion
+        .compareCteIdentifiers(component(""), component("")),
+    ).toBe("unknown");
+    expect(
+      DUCKDB_SQL_RELATION_DIALECT.completion
+        .cteIdentifierMatchesPrefix(
+          component("\ud800"),
+          component("u"),
+        ),
+    ).toBe("unknown");
+    const hostile = new Proxy(component("users"), {
+      get() {
+        throw new Error("hostile");
+      },
+    });
+    expect(
+      POSTGRESQL_SQL_RELATION_DIALECT.completion
+        .compareCteIdentifiers(hostile, component("users")),
+    ).toBe("unknown");
+    expect(
+      POSTGRESQL_SQL_RELATION_DIALECT.completion
+        .cteIdentifierMatchesPrefix(hostile, component("u")),
+    ).toBe("unknown");
+    const malformedDecode = Reflect.apply(
+      POSTGRESQL_SQL_RELATION_DIALECT.completion.decodeIdentifier,
+      undefined,
+      [null, "complete"],
+    );
+    expect(malformedDecode).toEqual({
+      reason: "invalid-identifier",
+      status: "unavailable",
+    });
+  });
+});
+
+describe("safe role-aware rendering", () => {
+  it("renders PostgreSQL relation suffixes and rejects catalog roles", () => {
+    const relation = [
+      { quoted: false, role: "relation", value: "users" },
+    ] satisfies SqlCanonicalRelationPath;
+    const schemaRelation = [
+      { quoted: false, role: "schema", value: "public" },
+      { quoted: true, role: "relation", value: "User Events" },
+    ] satisfies SqlCanonicalRelationPath;
+    const catalogRelation = [
+      { quoted: false, role: "catalog", value: "warehouse" },
+      { quoted: false, role: "relation", value: "users" },
+    ] satisfies SqlCanonicalRelationPath;
+    expect(
+      POSTGRESQL_SQL_RELATION_DIALECT.completion
+        .renderRelationPath(relation),
+    ).toEqual({ status: "rendered", text: "users" });
+    expect(
+      POSTGRESQL_SQL_RELATION_DIALECT.completion
+        .renderRelationPath(schemaRelation),
+    ).toEqual({
+      status: "rendered",
+      text: "public.\"User Events\"",
+    });
+    expect(
+      POSTGRESQL_SQL_RELATION_DIALECT.completion
+        .renderRelationPath(catalogRelation),
+    ).toEqual({
+      reason: "illegal-role-sequence",
+      status: "unsupported",
+    });
+  });
+
+  it("renders every closed DuckDB qualification shape", () => {
+    const paths = [
+      [
+        { quoted: false, role: "relation", value: "users" },
+      ],
+      [
+        { quoted: false, role: "schema", value: "main" },
+        { quoted: false, role: "relation", value: "users" },
+      ],
+      [
+        { quoted: false, role: "catalog", value: "memory" },
+        { quoted: false, role: "relation", value: "users" },
+      ],
+      [
+        { quoted: false, role: "catalog", value: "memory" },
+        { quoted: false, role: "schema", value: "main" },
+        { quoted: false, role: "relation", value: "users" },
+      ],
+    ] as const;
+    expect(
+      paths.map((path) =>
+        DUCKDB_SQL_RELATION_DIALECT.completion
+          .renderRelationPath(path).status,
+      ),
+    ).toEqual(["rendered", "rendered", "rendered", "rendered"]);
+  });
+
+  it("renders BigQuery roles with role-specific dash handling", () => {
+    const path = [
+      { quoted: false, role: "project", value: "my-project" },
+      { quoted: false, role: "dataset", value: "analytics" },
+      { quoted: true, role: "relation", value: "select`events" },
+    ] satisfies SqlCanonicalRelationPath;
+    expect(
+      BIGQUERY_SQL_RELATION_DIALECT.completion
+        .renderRelationPath(path),
+    ).toEqual({
+      status: "rendered",
+      text: "my-project.analytics.`select\\`events`",
+    });
+    const illegal = [
+      { quoted: false, role: "project", value: "my-project" },
+      { quoted: false, role: "relation", value: "events" },
+    ] satisfies SqlCanonicalRelationPath;
+    expect(
+      BIGQUERY_SQL_RELATION_DIALECT.completion
+        .renderRelationPath(illegal).status,
+    ).toBe("unsupported");
+  });
+
+  it("renders a bounded Dremio source and folder hierarchy", () => {
+    const path = [
+      { quoted: false, role: "catalog", value: "Samples" },
+      {
+        quoted: true,
+        role: "schema",
+        value: "samples.dremio.com",
+      },
+      { quoted: false, role: "schema", value: "folder" },
+      {
+        quoted: true,
+        role: "relation",
+        value: "NYC \"trips\"",
+      },
+    ] satisfies SqlCanonicalRelationPath;
+    expect(
+      DREMIO_SQL_RELATION_DIALECT.completion
+        .renderRelationPath(path),
+    ).toEqual({
+      status: "rendered",
+      text:
+        "Samples.\"samples.dremio.com\".\"folder\"." +
+        "\"NYC \"\"trips\"\"\"",
+    });
+  });
+
+  it("quotes reserved words even when provider spelling is bare", () => {
+    const path = [
+      { quoted: false, role: "relation", value: "select" },
+    ] satisfies SqlCanonicalRelationPath;
+    expect(
+      POSTGRESQL_SQL_RELATION_DIALECT.completion
+        .renderRelationPath(path),
+    ).toEqual({ status: "rendered", text: "\"select\"" });
+    expect(
+      BIGQUERY_SQL_RELATION_DIALECT.completion
+        .renderRelationPath(path),
+    ).toEqual({ status: "rendered", text: "`select`" });
+  });
+
+  it("round-trips rendered paths through the query decoder", () => {
+    const cases = [
+      {
+        path: [
+          { quoted: false, role: "schema", value: "public" },
+          {
+            quoted: true,
+            role: "relation",
+            value: "User.Events",
+          },
+        ] satisfies SqlCanonicalRelationPath,
+        runtime: POSTGRESQL_SQL_RELATION_DIALECT,
+      },
+      {
+        path: [
+          { quoted: false, role: "catalog", value: "memory" },
+          { quoted: false, role: "schema", value: "main" },
+          { quoted: false, role: "relation", value: "users" },
+        ] satisfies SqlCanonicalRelationPath,
+        runtime: DUCKDB_SQL_RELATION_DIALECT,
+      },
+      {
+        path: [
+          { quoted: false, role: "project", value: "my-project" },
+          { quoted: false, role: "dataset", value: "analytics" },
+          {
+            quoted: true,
+            role: "relation",
+            value: "event`stream",
+          },
+        ] satisfies SqlCanonicalRelationPath,
+        runtime: BIGQUERY_SQL_RELATION_DIALECT,
+      },
+      {
+        path: [
+          { quoted: false, role: "catalog", value: "Samples" },
+          {
+            quoted: true,
+            role: "schema",
+            value: "samples.dremio.com",
+          },
+          { quoted: false, role: "relation", value: "trips" },
+        ] satisfies SqlCanonicalRelationPath,
+        runtime: DREMIO_SQL_RELATION_DIALECT,
+      },
+    ];
+    for (const { path, runtime } of cases) {
+      const rendered = runtime.completion.renderRelationPath(path);
+      expect(rendered.status).toBe("rendered");
+      if (rendered.status !== "rendered") {
+        throw new Error("Expected a rendered path");
+      }
+      const decodedPath = readyPath(runtime, rendered.text);
+      expect([
+        ...decodedPath.qualifier.map((item) => item.value),
+        decodedPath.prefix.value,
+      ]).toEqual(path.map((item) => item.value));
+    }
+  });
+
+  it("returns frozen results and fails closed on malformed paths", () => {
+    const valid = [
+      { quoted: false, role: "relation", value: "users" },
+    ] satisfies SqlCanonicalRelationPath;
+    const rendered =
+      POSTGRESQL_SQL_RELATION_DIALECT.completion
+        .renderRelationPath(valid);
+    expect(Object.isFrozen(rendered)).toBe(true);
+    expect(
+      Reflect.apply(
+        POSTGRESQL_SQL_RELATION_DIALECT.completion
+          .renderRelationPath,
+        undefined,
+        [[]],
+      ),
+    ).toEqual({
+      reason: "illegal-role-sequence",
+      status: "unsupported",
+    });
+  });
+});
+
+describe("recognizer integration", () => {
+  it.each([
+    ["postgresql", POSTGRESQL_SQL_RELATION_DIALECT, "\"Recent\""],
+    ["duckdb", DUCKDB_SQL_RELATION_DIALECT, "\"Recent\""],
+    ["bigquery", BIGQUERY_SQL_RELATION_DIALECT, "`Recent`"],
+    ["dremio", DREMIO_SQL_RELATION_DIALECT, "\"Recent\""],
+  ] as const)(
+    "feeds one coherent runtime into CTE analysis for %s",
+    (_name, runtime, cteName) => {
+      const text =
+        `WITH ${cteName} AS (SELECT 1) ` +
+        `SELECT * FROM ${cteName}`;
+      const layout = analyze(runtime, text);
+      expect(layout.status).not.toBe("unavailable");
+      if (layout.status === "unavailable") {
+        throw new Error("Expected CTE layout evidence");
+      }
+      expect(layout.declarations).toHaveLength(1);
+      expect(layout.declarations[0]?.name.value).toBe("Recent");
+    },
+  );
+
+  it("accepts contextual materialized CTE and column names", () => {
+    const layout = analyze(
+      POSTGRESQL_SQL_RELATION_DIALECT,
+      "WITH materialized(materialized) AS (SELECT 1) " +
+        "SELECT * FROM materialized",
+    );
+    expect(layout.status).not.toBe("unavailable");
+    if (layout.status === "unavailable") {
+      throw new Error("Expected CTE layout evidence");
+    }
+    expect(layout.declarations[0]).toMatchObject({
+      name: { value: "materialized" },
+    });
+  });
+});

--- a/src/vnext/__tests__/session.test.ts
+++ b/src/vnext/__tests__/session.test.ts
@@ -7,7 +7,16 @@ import {
   postgresDialect,
   SqlSessionError,
 } from "../index.js";
-import { DefaultSqlLanguageService } from "../session.js";
+import {
+  DefaultSqlLanguageService,
+  getSqlRelationDialectRuntime,
+} from "../session.js";
+import {
+  BIGQUERY_SQL_RELATION_DIALECT,
+  DREMIO_SQL_RELATION_DIALECT,
+  DUCKDB_SQL_RELATION_DIALECT,
+  POSTGRESQL_SQL_RELATION_DIALECT,
+} from "../relation-dialect.js";
 import {
   BIGQUERY_SQL_LEXICAL_PROFILE,
   buildSqlStatementIndex,
@@ -67,6 +76,28 @@ describe("dialect definitions", () => {
     expect(postgresDialect()).toBe(postgres);
     expect(bigQueryDialect()).toBe(bigQueryDialect());
     expect(dremioDialect()).toBe(dremioDialect());
+  });
+
+  it("authenticates one coherent relation runtime per built-in handle", () => {
+    for (const [dialect, relationDialect] of [
+      [bigQueryDialect(), BIGQUERY_SQL_RELATION_DIALECT],
+      [dremioDialect(), DREMIO_SQL_RELATION_DIALECT],
+      [duckdbDialect(), DUCKDB_SQL_RELATION_DIALECT],
+      [postgresDialect(), POSTGRESQL_SQL_RELATION_DIALECT],
+    ] as const) {
+      expect(getSqlRelationDialectRuntime(dialect)).toBe(
+        relationDialect,
+      );
+      expect(relationDialect.querySite.lexicalProfile).toBe(
+        relationDialect.cteLayout.lexicalProfile,
+      );
+    }
+    expect(
+      getSqlRelationDialectRuntime({
+        displayName: "DuckDB",
+        id: "duckdb",
+      }),
+    ).toBeNull();
   });
 
   it("rejects duplicate IDs", () => {

--- a/src/vnext/cte-layout.ts
+++ b/src/vnext/cte-layout.ts
@@ -15,6 +15,8 @@ export const MAX_CTE_DEPTH = 128;
 export const MAX_CTE_DECLARATIONS = 256;
 export const MAX_CTE_FRAMES = 256;
 export const MAX_CTE_IDENTIFIER_LENGTH = 256;
+export const MAX_CTE_QUOTED_IDENTIFIER_LENGTH =
+  MAX_CTE_IDENTIFIER_LENGTH * 10 + 2;
 
 export interface SqlCteRange {
   readonly [cteRangeBrand]: "SqlCteRange";
@@ -330,7 +332,7 @@ function normalizeIdentifier(
   const raw = text.slice(token.from, token.to);
   const maximumRawLength =
     token.kind === "quoted-identifier"
-      ? MAX_CTE_IDENTIFIER_LENGTH * 2 + 2
+      ? MAX_CTE_QUOTED_IDENTIFIER_LENGTH
       : MAX_CTE_IDENTIFIER_LENGTH;
   if (raw.length > maximumRawLength) {
     return null;

--- a/src/vnext/relation-dialect.ts
+++ b/src/vnext/relation-dialect.ts
@@ -1,0 +1,1482 @@
+import {
+  MAX_CTE_DECLARATIONS,
+  MAX_CTE_QUOTED_IDENTIFIER_LENGTH,
+  type SqlCteIdentifierResult,
+  type SqlCteLayoutDialect,
+} from "./cte-layout.js";
+import {
+  BIGQUERY_SQL_LEXICAL_PROFILE,
+  DREMIO_SQL_LEXICAL_PROFILE,
+  DUCKDB_SQL_LEXICAL_PROFILE,
+  POSTGRESQL_SQL_LEXICAL_PROFILE,
+  sqlIdentifierContinueLengthAt,
+  sqlIdentifierStartLengthAt,
+  type SqlLexicalProfile,
+} from "./lexical.js";
+import {
+  MAX_QUERY_SITE_IDENTIFIER_LENGTH,
+  MAX_QUERY_SITE_PATH_COMPONENTS,
+  type SqlDecodedQueryPath,
+  type SqlQuerySiteDialect,
+} from "./query-site.js";
+import { isSqlRelationReservedWord } from "./relation-reserved-words.js";
+import type {
+  SqlCteIdentifierComparison,
+  SqlCteIdentifierPrefixMatch,
+  SqlIdentifierDecodeResult,
+  SqlRelationCompletionDialectRuntime,
+  SqlRenderedRelationPath,
+} from "./relation-completion-types.js";
+import type { SqlIdentifierComponent } from "./types.js";
+
+export interface SqlRelationDialectRuntime {
+  readonly completion: SqlRelationCompletionDialectRuntime;
+  readonly cteLayout: SqlCteLayoutDialect;
+  readonly querySite: SqlQuerySiteDialect;
+}
+
+type DialectKind =
+  | "bigquery"
+  | "dremio"
+  | "duckdb"
+  | "postgresql";
+
+interface RelationDialectSpec {
+  readonly cteGrammar: SqlCteLayoutDialect["grammar"];
+  readonly kind: DialectKind;
+  readonly lexicalProfile: SqlLexicalProfile;
+  readonly maximumPathDepth: number;
+  readonly supportsNaturalJoin: boolean;
+}
+
+interface RawSegment {
+  readonly closed: boolean;
+  readonly from: number;
+  readonly quoted: boolean;
+  readonly to: number;
+}
+
+const MAX_IDENTIFIER_LENGTH = MAX_QUERY_SITE_IDENTIFIER_LENGTH;
+const MAX_BIGQUERY_QUOTED_IDENTIFIER_RAW_LENGTH =
+  MAX_CTE_QUOTED_IDENTIFIER_LENGTH;
+const MAX_STANDARD_QUOTED_IDENTIFIER_RAW_LENGTH =
+  MAX_IDENTIFIER_LENGTH * 2 + 2;
+const DREMIO_BARE_IDENTIFIER = /^[\p{L}_][\p{L}\p{N}_]*$/u;
+const INVALID_IDENTIFIER = Object.freeze({
+  reason: "invalid-identifier" as const,
+  status: "unavailable" as const,
+});
+const UNSUPPORTED_IDENTIFIER = Object.freeze({
+  status: "unsupported" as const,
+});
+const BIGQUERY_IMPLICIT_ALIAS_CONTROL_WORDS = Object.freeze([
+  "match_recognize",
+  "pivot",
+  "unpivot",
+]);
+
+function asciiFoldCode(code: number): number {
+  return code >= 65 && code <= 90 ? code + 32 : code;
+}
+
+function identifierCodeEquals(
+  left: string,
+  right: string,
+  foldLeft: boolean,
+  foldRight: boolean,
+): boolean {
+  if (left.length !== right.length) {
+    return false;
+  }
+  for (let index = 0; index < left.length; index += 1) {
+    const leftCode = left.charCodeAt(index);
+    const rightCode = right.charCodeAt(index);
+    if (
+      (foldLeft ? asciiFoldCode(leftCode) : leftCode) !==
+      (foldRight ? asciiFoldCode(rightCode) : rightCode)
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function identifierPrefixMatches(
+  candidate: string,
+  prefix: string,
+  foldCandidate: boolean,
+  foldPrefix: boolean,
+): boolean {
+  if (prefix.length > candidate.length) {
+    return false;
+  }
+  for (let index = 0; index < prefix.length; index += 1) {
+    const candidateCode = candidate.charCodeAt(index);
+    const prefixCode = prefix.charCodeAt(index);
+    if (
+      (foldCandidate ? asciiFoldCode(candidateCode) : candidateCode) !==
+      (foldPrefix ? asciiFoldCode(prefixCode) : prefixCode)
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function isAscii(value: string): boolean {
+  for (let index = 0; index < value.length; index += 1) {
+    if (value.charCodeAt(index) > 0x7f) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function isControlWord(
+  value: string,
+  words: readonly string[],
+): boolean {
+  if (!isAscii(value)) {
+    return false;
+  }
+  for (const word of words) {
+    if (identifierCodeEquals(value, word, true, false)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function isWellFormed(value: string): boolean {
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      const trailing = value.charCodeAt(index + 1);
+      if (!(trailing >= 0xdc00 && trailing <= 0xdfff)) {
+        return false;
+      }
+      index += 1;
+    } else if (code >= 0xdc00 && code <= 0xdfff) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function isBareIdentifier(
+  value: string,
+  allowDollar: boolean,
+): boolean {
+  if (
+    value.length === 0 ||
+    value.length > MAX_IDENTIFIER_LENGTH ||
+    !isWellFormed(value)
+  ) {
+    return false;
+  }
+  let cursor = sqlIdentifierStartLengthAt(value, 0);
+  if (cursor === 0) {
+    return false;
+  }
+  while (cursor < value.length) {
+    if (allowDollar && value.charCodeAt(cursor) === 36) {
+      cursor += 1;
+      continue;
+    }
+    const length = sqlIdentifierContinueLengthAt(value, cursor);
+    if (length === 0) {
+      return false;
+    }
+    cursor += length;
+  }
+  return true;
+}
+
+function isBigQueryDashedIdentifier(value: string): boolean {
+  if (!isAscii(value)) {
+    return false;
+  }
+  const parts = value.split("-");
+  const first = parts[0];
+  if (!first || !isBareIdentifier(first, false)) {
+    return false;
+  }
+  for (let index = 1; index < parts.length; index += 1) {
+    const part = parts[index];
+    if (
+      !part ||
+      (!/^\d+$/.test(part) && !isBareIdentifier(part, false))
+    ) {
+      return false;
+    }
+  }
+  return parts.length > 1;
+}
+
+function isDremioBareIdentifier(value: string): boolean {
+  return (
+    isBareIdentifier(value, false) &&
+    DREMIO_BARE_IDENTIFIER.test(value)
+  );
+}
+
+function freezeComponent(
+  value: string,
+  quoted: boolean,
+): SqlIdentifierComponent {
+  return Object.freeze({ quoted, value });
+}
+
+function decodedIdentifier(
+  value: string,
+  quoted: boolean,
+  quality: "exact" | "recovered",
+): SqlIdentifierDecodeResult {
+  return Object.freeze({
+    component: freezeComponent(value, quoted),
+    quality,
+    status: "decoded",
+  });
+}
+
+function decodeDoubleQuoted(
+  token: string,
+  mode: "complete" | "completion-prefix",
+  kind: Exclude<DialectKind, "bigquery">,
+): SqlIdentifierDecodeResult {
+  if (token.length > MAX_STANDARD_QUOTED_IDENTIFIER_RAW_LENGTH) {
+    return INVALID_IDENTIFIER;
+  }
+  if (token.length === 0 && mode === "completion-prefix") {
+    return decodedIdentifier("", false, "exact");
+  }
+  if (!token.startsWith("\"")) {
+    if (
+      !(kind === "dremio"
+        ? isDremioBareIdentifier(token)
+        : isBareIdentifier(token, kind === "postgresql")) ||
+      isSqlRelationReservedWord(kind, token)
+    ) {
+      return INVALID_IDENTIFIER;
+    }
+    return decodedIdentifier(token, false, "exact");
+  }
+
+  const closed = token.length > 1 && token.endsWith("\"");
+  if (!closed && mode === "complete") {
+    return INVALID_IDENTIFIER;
+  }
+  const contentTo = closed ? token.length - 1 : token.length;
+  let output = "";
+  for (let cursor = 1; cursor < contentTo; cursor += 1) {
+    const code = token.charCodeAt(cursor);
+    if (code === 0) {
+      return INVALID_IDENTIFIER;
+    }
+    if (code !== 34) {
+      output += token[cursor];
+      if (output.length > MAX_IDENTIFIER_LENGTH) {
+        return INVALID_IDENTIFIER;
+      }
+      continue;
+    }
+    if (
+      cursor + 1 >= contentTo ||
+      token.charCodeAt(cursor + 1) !== 34
+    ) {
+      return INVALID_IDENTIFIER;
+    }
+    output += "\"";
+    if (output.length > MAX_IDENTIFIER_LENGTH) {
+      return INVALID_IDENTIFIER;
+    }
+    cursor += 1;
+  }
+  if (
+    (output.length === 0 &&
+      !(mode === "completion-prefix" && !closed)) ||
+    output.length > MAX_IDENTIFIER_LENGTH ||
+    !isWellFormed(output)
+  ) {
+    return INVALID_IDENTIFIER;
+  }
+  return decodedIdentifier(
+    output,
+    true,
+    closed ? "exact" : "recovered",
+  );
+}
+
+function digitValue(code: number, radix: number): number {
+  if (code >= 48 && code <= 57) {
+    const value = code - 48;
+    return value < radix ? value : -1;
+  }
+  if (radix === 16 && code >= 65 && code <= 70) {
+    return code - 55;
+  }
+  if (radix === 16 && code >= 97 && code <= 102) {
+    return code - 87;
+  }
+  return -1;
+}
+
+function decodeDigits(
+  text: string,
+  from: number,
+  length: number,
+  radix: number,
+): number | null {
+  if (from + length > text.length) {
+    return null;
+  }
+  let value = 0;
+  for (let index = 0; index < length; index += 1) {
+    const digit = digitValue(text.charCodeAt(from + index), radix);
+    if (digit < 0) {
+      return null;
+    }
+    value = value * radix + digit;
+  }
+  return value;
+}
+
+const BIGQUERY_SIMPLE_ESCAPES: Readonly<Record<string, string>> =
+  Object.freeze({
+    "\"": "\"",
+    "'": "'",
+    "?": "?",
+    "\\": "\\",
+    "`": "`",
+    a: "\u0007",
+    b: "\b",
+    f: "\f",
+    n: "\n",
+    r: "\r",
+    t: "\t",
+    v: "\v",
+  });
+
+function decodeBigQueryContent(content: string): string | null {
+  let output = "";
+  for (let cursor = 0; cursor < content.length; cursor += 1) {
+    const code = content.charCodeAt(cursor);
+    if (code === 0 || code === 10 || code === 13) {
+      return null;
+    }
+    if (code !== 92) {
+      output += content[cursor];
+      if (output.length > MAX_IDENTIFIER_LENGTH) {
+        return null;
+      }
+      continue;
+    }
+    const escape = content[cursor + 1];
+    if (escape === undefined) {
+      return null;
+    }
+    const simple = BIGQUERY_SIMPLE_ESCAPES[escape];
+    if (simple !== undefined) {
+      output += simple;
+      if (output.length > MAX_IDENTIFIER_LENGTH) {
+        return null;
+      }
+      cursor += 1;
+      continue;
+    }
+    let digitsFrom = cursor + 1;
+    let digitsLength = 0;
+    let radix = 16;
+    if (escape >= "0" && escape <= "7") {
+      digitsLength = 3;
+      radix = 8;
+    } else if (escape === "x" || escape === "X") {
+      digitsFrom += 1;
+      digitsLength = 2;
+    } else if (escape === "u") {
+      digitsFrom += 1;
+      digitsLength = 4;
+    } else if (escape === "U") {
+      digitsFrom += 1;
+      digitsLength = 8;
+    } else {
+      return null;
+    }
+    const value = decodeDigits(
+      content,
+      digitsFrom,
+      digitsLength,
+      radix,
+    );
+    if (
+      value === null ||
+      value === 0 ||
+      value > 0x10ffff ||
+      (value >= 0xd800 && value <= 0xdfff)
+    ) {
+      return null;
+    }
+    output += String.fromCodePoint(value);
+    if (output.length > MAX_IDENTIFIER_LENGTH) {
+      return null;
+    }
+    cursor = digitsFrom + digitsLength - 1;
+  }
+  return output.length <= MAX_IDENTIFIER_LENGTH &&
+    isWellFormed(output)
+    ? output
+    : null;
+}
+
+function decodeBigQueryIdentifier(
+  token: string,
+  mode: "complete" | "completion-prefix",
+): SqlIdentifierDecodeResult {
+  if (token.length > MAX_BIGQUERY_QUOTED_IDENTIFIER_RAW_LENGTH) {
+    return INVALID_IDENTIFIER;
+  }
+  if (token.length === 0 && mode === "completion-prefix") {
+    return decodedIdentifier("", false, "exact");
+  }
+  if (!token.startsWith("`")) {
+    if (
+      !isAscii(token) ||
+      !isBareIdentifier(token, false) ||
+      isSqlRelationReservedWord("bigquery", token)
+    ) {
+      return INVALID_IDENTIFIER;
+    }
+    return decodedIdentifier(token, false, "exact");
+  }
+  const closed =
+    token.length > 1 &&
+    token.endsWith("`") &&
+    !isEscapedAt(token, token.length - 1);
+  if (!closed && mode === "complete") {
+    return INVALID_IDENTIFIER;
+  }
+  const value = decodeBigQueryContent(
+    token.slice(1, closed ? -1 : undefined),
+  );
+  if (
+    value === null ||
+    (value.length === 0 &&
+      !(mode === "completion-prefix" && !closed))
+  ) {
+    return INVALID_IDENTIFIER;
+  }
+  return decodedIdentifier(
+    value,
+    true,
+    closed ? "exact" : "recovered",
+  );
+}
+
+function isEscapedAt(text: string, index: number): boolean {
+  let slashes = 0;
+  for (
+    let cursor = index - 1;
+    cursor >= 0 && text.charCodeAt(cursor) === 92;
+    cursor -= 1
+  ) {
+    slashes += 1;
+  }
+  return slashes % 2 === 1;
+}
+
+function splitQuotedPath(
+  rawPath: string,
+  quote: "\"" | "`",
+): readonly RawSegment[] | null {
+  const output: RawSegment[] = [];
+  let segmentFrom = 0;
+  let cursor = 0;
+  while (cursor <= rawPath.length) {
+    if (cursor === rawPath.length) {
+      output.push({
+        closed: true,
+        from: segmentFrom,
+        quoted: false,
+        to: cursor,
+      });
+      break;
+    }
+    if (rawPath[cursor] === quote && cursor === segmentFrom) {
+      const quotedFrom = cursor;
+      cursor += 1;
+      let closed = false;
+      while (cursor < rawPath.length) {
+        if (rawPath[cursor] !== quote) {
+          if (quote === "`" && rawPath[cursor] === "\\") {
+            cursor += Math.min(2, rawPath.length - cursor);
+          } else {
+            cursor += 1;
+          }
+          continue;
+        }
+        if (
+          quote === "\"" &&
+          rawPath[cursor + 1] === "\""
+        ) {
+          cursor += 2;
+          continue;
+        }
+        closed = true;
+        cursor += 1;
+        break;
+      }
+      if (cursor < rawPath.length && rawPath[cursor] !== ".") {
+        return null;
+      }
+      output.push({
+        closed,
+        from: quotedFrom,
+        quoted: true,
+        to: cursor,
+      });
+      if (cursor === rawPath.length) {
+        break;
+      }
+      segmentFrom = cursor + 1;
+      cursor = segmentFrom;
+      continue;
+    }
+    if (rawPath[cursor] === quote) {
+      return null;
+    }
+    if (rawPath[cursor] === ".") {
+      output.push({
+        closed: true,
+        from: segmentFrom,
+        quoted: false,
+        to: cursor,
+      });
+      segmentFrom = cursor + 1;
+    }
+    cursor += 1;
+  }
+  return output;
+}
+
+function decodePathSegment(
+  rawPath: string,
+  segment: RawSegment,
+  decodeIdentifier: SqlRelationCompletionDialectRuntime["decodeIdentifier"],
+): SqlIdentifierComponent | null {
+  if (!segment.closed || segment.from === segment.to) {
+    return null;
+  }
+  const result = decodeIdentifier(
+    rawPath.slice(segment.from, segment.to),
+    "complete",
+  );
+  return result.status === "decoded" ? result.component : null;
+}
+
+function freezeDecodedPath(
+  qualifier: SqlIdentifierComponent[],
+  prefix: SqlIdentifierComponent,
+  finalFrom: number,
+  finalTo: number,
+  quality: "exact" | "recovered",
+): SqlDecodedQueryPath {
+  return Object.freeze({
+    finalSegment: Object.freeze({ from: finalFrom, to: finalTo }),
+    prefix,
+    qualifier: Object.freeze(qualifier),
+    quality,
+    status: "decoded",
+  });
+}
+
+function decodeSegmentedPath(
+  rawPath: string,
+  cursorOffset: number,
+  maximumPathDepth: number,
+  quote: "\"" | "`",
+  decodeIdentifier: SqlRelationCompletionDialectRuntime["decodeIdentifier"],
+  kind: DialectKind,
+): SqlDecodedQueryPath {
+  if (
+    typeof rawPath !== "string" ||
+    !Number.isSafeInteger(cursorOffset) ||
+    cursorOffset < 0 ||
+    cursorOffset > rawPath.length
+  ) {
+    return INVALID_IDENTIFIER;
+  }
+  const segments = splitQuotedPath(rawPath, quote);
+  if (
+    !segments ||
+    segments.length === 0 ||
+    segments.length > maximumPathDepth
+  ) {
+    return INVALID_IDENTIFIER;
+  }
+  const final = segments[segments.length - 1];
+  if (
+    !final ||
+    cursorOffset < final.from ||
+    cursorOffset > final.to
+  ) {
+    return INVALID_IDENTIFIER;
+  }
+  const qualifier: SqlIdentifierComponent[] = [];
+  for (let index = 0; index < segments.length - 1; index += 1) {
+    const segment = segments[index];
+    if (!segment) {
+      return INVALID_IDENTIFIER;
+    }
+    const component =
+      kind === "bigquery" && !segment.quoted
+        ? decodeBigQueryBarePathSegment(
+            rawPath.slice(segment.from, segment.to),
+            index,
+          )
+        : decodePathSegment(rawPath, segment, decodeIdentifier);
+    if (!component) {
+      return INVALID_IDENTIFIER;
+    }
+    qualifier.push(component);
+  }
+
+  let prefixToken = rawPath.slice(final.from, cursorOffset);
+  if (final.quoted) {
+    if (prefixToken.length === 0) {
+      return freezeDecodedPath(
+        qualifier,
+        freezeComponent("", true),
+        final.from,
+        final.to,
+        "exact",
+      );
+    }
+    if (final.closed && !prefixToken.endsWith(quote)) {
+      prefixToken += quote;
+    }
+  }
+  let prefix: SqlIdentifierComponent | null = null;
+  let quality: "exact" | "recovered" =
+    final.quoted && !final.closed ? "recovered" : "exact";
+  if (
+    kind === "bigquery" &&
+    !final.quoted &&
+    prefixToken.length > 0
+  ) {
+    prefix = decodeBigQueryBarePathSegment(
+      prefixToken,
+      segments.length - 1,
+    );
+  } else {
+    const decoded = decodeIdentifier(
+      prefixToken,
+      "completion-prefix",
+    );
+    if (decoded.status === "decoded") {
+      prefix = decoded.component;
+      if (decoded.quality === "recovered") {
+        quality = "recovered";
+      }
+    }
+  }
+  return prefix
+    ? freezeDecodedPath(
+        qualifier,
+        prefix,
+        final.from,
+        final.to,
+        quality,
+      )
+    : INVALID_IDENTIFIER;
+}
+
+function decodeBigQueryBarePathSegment(
+  value: string,
+  index: number,
+): SqlIdentifierComponent | null {
+  if (
+    value.length === 0 ||
+    value.length > MAX_IDENTIFIER_LENGTH ||
+    !isAscii(value) ||
+    !isWellFormed(value)
+  ) {
+    return null;
+  }
+  if (value.includes("-")) {
+    return index === 0 && isBigQueryDashedIdentifier(value)
+      ? freezeComponent(value, false)
+      : null;
+  }
+  if (
+    !isBareIdentifier(value, false) ||
+    (index === 0 &&
+      isSqlRelationReservedWord("bigquery", value))
+  ) {
+    return null;
+  }
+  return freezeComponent(value, false);
+}
+
+function splitBigQueryWholePath(
+  content: string,
+): readonly { readonly from: number; readonly to: number }[] | null {
+  const output: { from: number; to: number }[] = [];
+  let from = 0;
+  for (let cursor = 0; cursor < content.length; cursor += 1) {
+    if (content[cursor] === "\\") {
+      const escape = content[cursor + 1];
+      if (escape === undefined) {
+        return null;
+      }
+      if (escape >= "0" && escape <= "7") {
+        cursor += 3;
+      } else if (escape === "x" || escape === "X") {
+        cursor += 3;
+      } else if (escape === "u") {
+        cursor += 5;
+      } else if (escape === "U") {
+        cursor += 9;
+      } else {
+        cursor += 1;
+      }
+      if (cursor >= content.length) {
+        return null;
+      }
+      continue;
+    }
+    if (content[cursor] === ".") {
+      if (cursor === from) {
+        return null;
+      }
+      output.push({ from, to: cursor });
+      from = cursor + 1;
+    }
+  }
+  if (from === content.length) {
+    return null;
+  }
+  output.push({ from, to: content.length });
+  return output;
+}
+
+function decodeBigQueryWholePath(
+  rawPath: string,
+  cursorOffset: number,
+): SqlDecodedQueryPath | null {
+  if (!rawPath.startsWith("`")) {
+    return null;
+  }
+  let closingAt = -1;
+  for (let cursor = 1; cursor < rawPath.length; cursor += 1) {
+    if (rawPath[cursor] === "\\") {
+      cursor += 1;
+    } else if (rawPath[cursor] === "`") {
+      closingAt = cursor;
+      break;
+    }
+  }
+  if (closingAt >= 0 && closingAt !== rawPath.length - 1) {
+    return null;
+  }
+  const closed = closingAt === rawPath.length - 1;
+  const contentTo = closed ? rawPath.length - 1 : rawPath.length;
+  const content = rawPath.slice(1, contentTo);
+  if (content.length === 0 && !closed) {
+    return freezeDecodedPath(
+      [],
+      freezeComponent("", true),
+      1,
+      rawPath.length,
+      "recovered",
+    );
+  }
+  const parts = splitBigQueryWholePath(content);
+  if (
+    !parts ||
+    parts.length > 3 ||
+    !Number.isSafeInteger(cursorOffset) ||
+    cursorOffset < 1 ||
+    cursorOffset > rawPath.length
+  ) {
+    return INVALID_IDENTIFIER;
+  }
+  const final = parts[parts.length - 1];
+  if (!final) {
+    return INVALID_IDENTIFIER;
+  }
+  const finalFrom = final.from + 1;
+  const finalContentTo = final.to + 1;
+  const maximumCursor = closed ? rawPath.length - 1 : rawPath.length;
+  const contentCursor = Math.min(cursorOffset, maximumCursor);
+  if (contentCursor < finalFrom || contentCursor > finalContentTo) {
+    return INVALID_IDENTIFIER;
+  }
+  const qualifier: SqlIdentifierComponent[] = [];
+  for (let index = 0; index < parts.length - 1; index += 1) {
+    const part = parts[index];
+    if (!part) {
+      return INVALID_IDENTIFIER;
+    }
+    const value = decodeBigQueryContent(
+      content.slice(part.from, part.to),
+    );
+    if (!value) {
+      return INVALID_IDENTIFIER;
+    }
+    qualifier.push(freezeComponent(value, true));
+  }
+  const prefixValue = decodeBigQueryContent(
+    rawPath.slice(finalFrom, contentCursor),
+  );
+  if (prefixValue === null) {
+    return INVALID_IDENTIFIER;
+  }
+  return freezeDecodedPath(
+    qualifier,
+    freezeComponent(prefixValue, true),
+    finalFrom,
+    rawPath.length,
+    closed ? "exact" : "recovered",
+  );
+}
+
+function createPathDecoder(
+  spec: RelationDialectSpec,
+  decodeIdentifier: SqlRelationCompletionDialectRuntime["decodeIdentifier"],
+): SqlQuerySiteDialect["decodeRelationPath"] {
+  const maximumRawIdentifierLength =
+    spec.kind === "bigquery"
+      ? MAX_BIGQUERY_QUOTED_IDENTIFIER_RAW_LENGTH
+      : MAX_STANDARD_QUOTED_IDENTIFIER_RAW_LENGTH;
+  const maximumRawPathLength =
+    spec.maximumPathDepth * (maximumRawIdentifierLength + 1);
+  return (rawPath, cursorOffset) => {
+    try {
+      if (
+        typeof rawPath !== "string" ||
+        rawPath.length > maximumRawPathLength ||
+        !Number.isSafeInteger(cursorOffset)
+      ) {
+        return INVALID_IDENTIFIER;
+      }
+      if (spec.kind === "bigquery") {
+        const whole = decodeBigQueryWholePath(rawPath, cursorOffset);
+        if (whole) {
+          return whole;
+        }
+      }
+      return decodeSegmentedPath(
+        rawPath,
+        cursorOffset,
+        spec.maximumPathDepth,
+        spec.kind === "bigquery" ? "`" : "\"",
+        decodeIdentifier,
+        spec.kind,
+      );
+    } catch {
+      return INVALID_IDENTIFIER;
+    }
+  };
+}
+
+function createQueryClassifier(
+  kind: DialectKind,
+  decodeIdentifier: SqlRelationCompletionDialectRuntime["decodeIdentifier"],
+): SqlQuerySiteDialect["classifyIdentifierToken"] {
+  return (rawIdentifier, quoted, role) => {
+    if (
+      typeof rawIdentifier !== "string" ||
+      typeof quoted !== "boolean" ||
+      (role !== "explicit-alias" &&
+        role !== "implicit-alias" &&
+        role !== "using-column") ||
+      (kind === "bigquery" &&
+        role === "implicit-alias" &&
+        !quoted &&
+        isControlWord(
+          rawIdentifier,
+          BIGQUERY_IMPLICIT_ALIAS_CONTROL_WORDS,
+        ))
+    ) {
+      return UNSUPPORTED_IDENTIFIER;
+    }
+    const result = decodeIdentifier(rawIdentifier, "complete");
+    if (
+      result.status !== "decoded" ||
+      result.component.quoted !== quoted ||
+      result.component.value.length === 0
+    ) {
+      return UNSUPPORTED_IDENTIFIER;
+    }
+    return Object.freeze({
+      status: "identifier" as const,
+      value: result.component.value,
+    });
+  };
+}
+
+function createCteClassifier(
+  decodeIdentifier: SqlRelationCompletionDialectRuntime["decodeIdentifier"],
+): SqlCteLayoutDialect["classifyIdentifierToken"] {
+  return (rawIdentifier, quoted, role): SqlCteIdentifierResult => {
+    if (
+      typeof rawIdentifier !== "string" ||
+      typeof quoted !== "boolean" ||
+      (role !== "cte-column" && role !== "cte-name")
+    ) {
+      return UNSUPPORTED_IDENTIFIER;
+    }
+    const result = decodeIdentifier(rawIdentifier, "complete");
+    if (
+      result.status !== "decoded" ||
+      result.component.quoted !== quoted ||
+      result.component.value.length === 0
+    ) {
+      return UNSUPPORTED_IDENTIFIER;
+    }
+    return Object.freeze({
+      status: "identifier" as const,
+      value: Object.freeze({ component: result.component }),
+    });
+  };
+}
+
+function postgresComparison(
+  left: SqlIdentifierComponent,
+  right: SqlIdentifierComponent,
+): SqlCteIdentifierComparison {
+  if (
+    left === null ||
+    typeof left !== "object" ||
+    right === null ||
+    typeof right !== "object"
+  ) {
+    return "unknown";
+  }
+  const leftQuoted = left.quoted;
+  const leftValue = left.value;
+  const rightQuoted = right.quoted;
+  const rightValue = right.value;
+  if (
+    !validComparisonValue(leftValue, leftQuoted) ||
+    !validComparisonValue(rightValue, rightQuoted)
+  ) {
+    return "unknown";
+  }
+  if (leftQuoted === rightQuoted && leftValue === rightValue) {
+    return "equal";
+  }
+  if (isAscii(leftValue) && isAscii(rightValue)) {
+    return identifierCodeEquals(
+      leftValue,
+      rightValue,
+      !leftQuoted,
+      !rightQuoted,
+    )
+      ? "equal"
+      : "distinct";
+  }
+  return "unknown";
+}
+
+function asciiInsensitiveComparison(
+  left: SqlIdentifierComponent,
+  right: SqlIdentifierComponent,
+  fullyDecidable: boolean,
+): SqlCteIdentifierComparison {
+  if (
+    left === null ||
+    typeof left !== "object" ||
+    right === null ||
+    typeof right !== "object"
+  ) {
+    return "unknown";
+  }
+  const leftQuoted = left.quoted;
+  const leftValue = left.value;
+  const rightQuoted = right.quoted;
+  const rightValue = right.value;
+  if (
+    !validComparisonValue(leftValue, leftQuoted) ||
+    !validComparisonValue(rightValue, rightQuoted)
+  ) {
+    return "unknown";
+  }
+  if (leftValue === rightValue) {
+    return "equal";
+  }
+  if (
+    fullyDecidable ||
+    (isAscii(leftValue) && isAscii(rightValue))
+  ) {
+    return identifierCodeEquals(
+      leftValue,
+      rightValue,
+      true,
+      true,
+    )
+      ? "equal"
+      : "distinct";
+  }
+  return "unknown";
+}
+
+function postgresPrefixMatch(
+  candidate: SqlIdentifierComponent,
+  prefix: SqlIdentifierComponent,
+): SqlCteIdentifierPrefixMatch {
+  if (
+    candidate === null ||
+    typeof candidate !== "object" ||
+    prefix === null ||
+    typeof prefix !== "object"
+  ) {
+    return "unknown";
+  }
+  const candidateQuoted = candidate.quoted;
+  const candidateValue = candidate.value;
+  const prefixQuoted = prefix.quoted;
+  const prefixValue = prefix.value;
+  if (
+    !validComparisonValue(candidateValue, candidateQuoted) ||
+    !validComparisonValue(prefixValue, prefixQuoted, true)
+  ) {
+    return "unknown";
+  }
+  if (prefixValue.length === 0) {
+    return "match";
+  }
+  if (
+    candidateQuoted === prefixQuoted &&
+    candidateValue.startsWith(prefixValue)
+  ) {
+    return "match";
+  }
+  if (isAscii(candidateValue) && isAscii(prefixValue)) {
+    return identifierPrefixMatches(
+      candidateValue,
+      prefixValue,
+      !candidateQuoted,
+      !prefixQuoted,
+    )
+      ? "match"
+      : "no-match";
+  }
+  return candidateQuoted === prefixQuoted &&
+    candidateValue.length < prefixValue.length
+    ? "no-match"
+    : "unknown";
+}
+
+function asciiInsensitivePrefixMatch(
+  candidate: SqlIdentifierComponent,
+  prefix: SqlIdentifierComponent,
+  fullyDecidable: boolean,
+): SqlCteIdentifierPrefixMatch {
+  if (
+    candidate === null ||
+    typeof candidate !== "object" ||
+    prefix === null ||
+    typeof prefix !== "object"
+  ) {
+    return "unknown";
+  }
+  const candidateQuoted = candidate.quoted;
+  const candidateValue = candidate.value;
+  const prefixQuoted = prefix.quoted;
+  const prefixValue = prefix.value;
+  if (
+    !validComparisonValue(candidateValue, candidateQuoted) ||
+    !validComparisonValue(prefixValue, prefixQuoted, true)
+  ) {
+    return "unknown";
+  }
+  if (prefixValue.length === 0) {
+    return "match";
+  }
+  if (candidateValue.startsWith(prefixValue)) {
+    return "match";
+  }
+  if (
+    fullyDecidable ||
+    (isAscii(candidateValue) && isAscii(prefixValue))
+  ) {
+    return identifierPrefixMatches(
+      candidateValue,
+      prefixValue,
+      true,
+      true,
+    )
+      ? "match"
+      : "no-match";
+  }
+  return "unknown";
+}
+
+function validComparisonValue(
+  value: unknown,
+  quoted: unknown,
+  allowEmpty = false,
+): value is string {
+  return (
+    typeof quoted === "boolean" &&
+    typeof value === "string" &&
+    (allowEmpty || value.length > 0) &&
+    value.length <= MAX_IDENTIFIER_LENGTH &&
+    !value.includes("\0") &&
+    isWellFormed(value)
+  );
+}
+
+function quoteDouble(value: string): string {
+  return `"${value.replaceAll("\"", "\"\"")}"`;
+}
+
+function quoteBigQuery(value: string): string {
+  let output = "`";
+  for (let cursor = 0; cursor < value.length; cursor += 1) {
+    const code = value.charCodeAt(cursor);
+    if (code === 96) {
+      output += "\\`";
+    } else if (code === 92) {
+      output += "\\\\";
+    } else if (code === 7) {
+      output += "\\a";
+    } else if (code === 8) {
+      output += "\\b";
+    } else if (code === 9) {
+      output += "\\t";
+    } else if (code === 10) {
+      output += "\\n";
+    } else if (code === 11) {
+      output += "\\v";
+    } else if (code === 12) {
+      output += "\\f";
+    } else if (code === 13) {
+      output += "\\r";
+    } else if (code < 32 || code === 127) {
+      output += `\\x${code.toString(16).padStart(2, "0")}`;
+    } else {
+      output += value[cursor];
+    }
+  }
+  return `${output}\``;
+}
+
+function legalRoleSequence(
+  kind: DialectKind,
+  roles: readonly string[],
+): boolean {
+  if (roles.length === 0 || roles.at(-1) !== "relation") {
+    return false;
+  }
+  const containers = roles.slice(0, -1);
+  if (kind === "postgresql") {
+    return (
+      containers.length === 0 ||
+      (containers.length === 1 && containers[0] === "schema")
+    );
+  }
+  if (kind === "duckdb") {
+    return (
+      containers.length === 0 ||
+      (containers.length === 1 &&
+        (containers[0] === "catalog" ||
+          containers[0] === "schema")) ||
+      (containers.length === 2 &&
+        containers[0] === "catalog" &&
+        containers[1] === "schema")
+    );
+  }
+  if (kind === "bigquery") {
+    return (
+      containers.length === 0 ||
+      (containers.length === 1 && containers[0] === "dataset") ||
+      (containers.length === 2 &&
+        containers[0] === "project" &&
+        containers[1] === "dataset")
+    );
+  }
+  let cursor = 0;
+  if (containers[0] === "catalog") {
+    cursor = 1;
+  }
+  for (; cursor < containers.length; cursor += 1) {
+    if (containers[cursor] !== "schema") {
+      return false;
+    }
+  }
+  return containers.length < MAX_QUERY_SITE_PATH_COMPONENTS;
+}
+
+function canRenderBare(
+  spec: RelationDialectSpec,
+  value: string,
+  role: string,
+  pathLength: number,
+): boolean {
+  if (isSqlRelationReservedWord(spec.kind, value)) {
+    return false;
+  }
+  if (spec.kind !== "bigquery") {
+    return spec.kind === "dremio"
+      ? isDremioBareIdentifier(value)
+      : isBareIdentifier(value, spec.kind === "postgresql");
+  }
+  if (
+    (role === "project" ||
+      (role === "relation" && pathLength === 1)) &&
+    isBigQueryDashedIdentifier(value)
+  ) {
+    return true;
+  }
+  return isAscii(value) && isBareIdentifier(value, false);
+}
+
+function createRenderer(
+  spec: RelationDialectSpec,
+): SqlRelationCompletionDialectRuntime["renderRelationPath"] {
+  return (path): SqlRenderedRelationPath => {
+    try {
+      if (!Array.isArray(path)) {
+        return unsupportedPath();
+      }
+      const pathLength = path.length;
+      if (pathLength === 0 || pathLength > spec.maximumPathDepth) {
+        return unsupportedPath();
+      }
+      const roles: string[] = [];
+      const components: {
+        readonly quoted: boolean;
+        readonly role: string;
+        readonly value: string;
+      }[] = [];
+      for (let index = 0; index < pathLength; index += 1) {
+        const component = path[index];
+        if (
+          component === null ||
+          typeof component !== "object"
+        ) {
+          return unsupportedPath();
+        }
+        const role = component.role;
+        const quoted = component.quoted;
+        const value = component.value;
+        if (
+          typeof role !== "string" ||
+          typeof quoted !== "boolean" ||
+          typeof value !== "string" ||
+          value.length === 0 ||
+          value.length > MAX_IDENTIFIER_LENGTH ||
+          value.includes("\0") ||
+          !isWellFormed(value)
+        ) {
+          return unsupportedPath();
+        }
+        roles.push(role);
+        components.push({ quoted, role, value });
+      }
+      if (!legalRoleSequence(spec.kind, roles)) {
+        return unsupportedPath();
+      }
+      const rendered = components.map((component) => {
+        if (
+          !component.quoted &&
+          canRenderBare(
+            spec,
+            component.value,
+            component.role,
+            pathLength,
+          )
+        ) {
+          return component.value;
+        }
+        return spec.kind === "bigquery"
+          ? quoteBigQuery(component.value)
+          : quoteDouble(component.value);
+      });
+      return Object.freeze({
+        status: "rendered" as const,
+        text: rendered.join("."),
+      });
+    } catch {
+      return unsupportedPath();
+    }
+  };
+}
+
+function unsupportedPath(): SqlRenderedRelationPath {
+  return Object.freeze({
+    reason: "illegal-role-sequence" as const,
+    status: "unsupported" as const,
+  });
+}
+
+function createRuntime(spec: RelationDialectSpec): SqlRelationDialectRuntime {
+  let decodeIdentifierImplementation: SqlRelationCompletionDialectRuntime["decodeIdentifier"];
+  switch (spec.kind) {
+    case "bigquery":
+      decodeIdentifierImplementation = decodeBigQueryIdentifier;
+      break;
+    case "dremio":
+      decodeIdentifierImplementation = (token, mode) =>
+        decodeDoubleQuoted(token, mode, "dremio");
+      break;
+    case "duckdb":
+      decodeIdentifierImplementation = (token, mode) =>
+        decodeDoubleQuoted(token, mode, "duckdb");
+      break;
+    case "postgresql":
+      decodeIdentifierImplementation = (token, mode) =>
+        decodeDoubleQuoted(token, mode, "postgresql");
+      break;
+  }
+  const decodeIdentifier:
+    SqlRelationCompletionDialectRuntime["decodeIdentifier"] = (
+      token,
+      mode,
+    ) => {
+      try {
+        return typeof token === "string" &&
+          (mode === "complete" || mode === "completion-prefix")
+          ? decodeIdentifierImplementation(token, mode)
+          : INVALID_IDENTIFIER;
+      } catch {
+        return INVALID_IDENTIFIER;
+      }
+    };
+  const compareCteIdentifiersImplementation =
+    spec.kind === "postgresql"
+      ? postgresComparison
+      : (left: SqlIdentifierComponent, right: SqlIdentifierComponent) =>
+          asciiInsensitiveComparison(
+            left,
+            right,
+            spec.kind === "duckdb",
+          );
+  const compareCteIdentifiers:
+    SqlRelationCompletionDialectRuntime["compareCteIdentifiers"] = (
+      left,
+      right,
+    ) => {
+      try {
+        return compareCteIdentifiersImplementation(left, right);
+      } catch {
+        return "unknown";
+      }
+    };
+  const cteIdentifierMatchesPrefixImplementation =
+    spec.kind === "postgresql"
+      ? postgresPrefixMatch
+      : (
+          candidate: SqlIdentifierComponent,
+          prefix: SqlIdentifierComponent,
+        ) =>
+          asciiInsensitivePrefixMatch(
+            candidate,
+            prefix,
+            spec.kind === "duckdb",
+          );
+  const cteIdentifierMatchesPrefix:
+    SqlRelationCompletionDialectRuntime["cteIdentifierMatchesPrefix"] = (
+      candidate,
+      prefix,
+    ) => {
+      try {
+        return cteIdentifierMatchesPrefixImplementation(
+          candidate,
+          prefix,
+        );
+      } catch {
+        return "unknown";
+      }
+    };
+  const completion: SqlRelationCompletionDialectRuntime = Object.freeze({
+    compareCteIdentifiers,
+    cteIdentifierMatchesPrefix,
+    decodeIdentifier,
+    renderRelationPath: createRenderer(spec),
+  });
+  const cteLayout: SqlCteLayoutDialect = Object.freeze({
+    classifyIdentifierToken: createCteClassifier(decodeIdentifier),
+    compareCteIdentifiers,
+    grammar: spec.cteGrammar,
+    lexicalProfile: spec.lexicalProfile,
+  });
+  const querySite: SqlQuerySiteDialect = Object.freeze({
+    classifyIdentifierToken: createQueryClassifier(
+      spec.kind,
+      decodeIdentifier,
+    ),
+    decodeRelationPath: createPathDecoder(spec, decodeIdentifier),
+    lexicalProfile: spec.lexicalProfile,
+    maximumPathDepth: spec.maximumPathDepth,
+    supportsNaturalJoin: spec.supportsNaturalJoin,
+  });
+  return Object.freeze({ completion, cteLayout, querySite });
+}
+
+function createGrammar(
+  declaredColumns: boolean,
+  materialization: boolean,
+  maximumDeclarationsPerFrame: number,
+  recursive: boolean,
+): SqlCteLayoutDialect["grammar"] {
+  return Object.freeze({
+    declaredColumns,
+    materialization,
+    maximumDeclarationsPerFrame,
+    recursive,
+  });
+}
+
+export const POSTGRESQL_SQL_RELATION_DIALECT =
+  createRuntime({
+    cteGrammar: createGrammar(
+      true,
+      true,
+      MAX_CTE_DECLARATIONS,
+      true,
+    ),
+    kind: "postgresql",
+    lexicalProfile: POSTGRESQL_SQL_LEXICAL_PROFILE,
+    maximumPathDepth: 2,
+    supportsNaturalJoin: true,
+  });
+
+export const DUCKDB_SQL_RELATION_DIALECT =
+  createRuntime({
+    cteGrammar: createGrammar(
+      true,
+      true,
+      MAX_CTE_DECLARATIONS,
+      true,
+    ),
+    kind: "duckdb",
+    lexicalProfile: DUCKDB_SQL_LEXICAL_PROFILE,
+    maximumPathDepth: 3,
+    supportsNaturalJoin: true,
+  });
+
+export const BIGQUERY_SQL_RELATION_DIALECT =
+  createRuntime({
+    cteGrammar: createGrammar(
+      false,
+      false,
+      MAX_CTE_DECLARATIONS,
+      true,
+    ),
+    kind: "bigquery",
+    lexicalProfile: BIGQUERY_SQL_LEXICAL_PROFILE,
+    maximumPathDepth: 3,
+    supportsNaturalJoin: false,
+  });
+
+export const DREMIO_SQL_RELATION_DIALECT =
+  createRuntime({
+    cteGrammar: createGrammar(true, false, 1, false),
+    kind: "dremio",
+    lexicalProfile: DREMIO_SQL_LEXICAL_PROFILE,
+    maximumPathDepth: MAX_QUERY_SITE_PATH_COMPONENTS,
+    supportsNaturalJoin: false,
+  });

--- a/src/vnext/relation-reserved-words.ts
+++ b/src/vnext/relation-reserved-words.ts
@@ -1,0 +1,99 @@
+type SqlRelationReservedWordKind =
+  | "bigquery"
+  | "dremio"
+  | "duckdb"
+  | "postgresql";
+
+const MAX_RESERVED_WORD_LENGTH = 64;
+
+// Source: https://cloud.google.com/bigquery/docs/reference/standard-sql/lexical#reserved_keywords
+const BIGQUERY_RESERVED_WORDS: ReadonlySet<string> = new Set(
+  "all and any array as asc assert_rows_modified at between by case cast collate contains create cross cube current default define desc distinct else end enum escape except exclude exists extract false fetch following for from full graph_table group grouping groups hash having if ignore in inner intersect interval into is join lateral left like limit lookup merge natural new no not null nulls of on or order outer over partition preceding proto qualify range recursive respect right rollup rows select set some struct tablesample then to treat true unbounded union unnest using when where window with within".split(
+    " ",
+  ),
+);
+
+// Source: https://docs.dremio.com/current/reference/sql/reserved-keywords/
+// Kept local so this SSR-safe module does not import the CodeMirror dialect.
+const DREMIO_RESERVED_WORDS: ReadonlySet<string> = new Set(
+  "abs access acos aes_decrypt aggregate all allocate allow alter analyze and any approx_count_distinct approx_percentile are array array_avg array_cat array_compact array_contains array_generate_range array_max array_max_cardinality array_min array_position array_remove array_remove_at array_size array_sum array_to_string arrow as ascii asensitive asin assign asymmetric at atan atan2 atomic authorization auto avg avoid base64 batch begin begin_frame begin_partition between bigint bin bin_pack binary binary_string bit bit_and bit_length bit_or bitwise_and bitwise_not bitwise_or bitwise_xor blob bool_and bool_or boolean both branch bround btrim by cache call called cardinality cascaded case cast catalog cbrt ceil ceiling change char char_length character character_length check chr classifier clob close cloud coalesce col_like collate collect column columns commit commits_older_than compute concat concat_ws condition connect constraint contains convert convert_from convert_replaceutf8 convert_timezone convert_to copy corr corresponding cos cosh cot count covar_pop covar_samp crc32 create cross cube cume_dist current current_catalog current_date current_date_utc current_default_transform_group current_path current_role current_row current_schema current_time current_timestamp current_transform_group_for_type current_user cursor cycle data databases datasets date date_add date_diff date_format date_part date_sub date_trunc datediff datetype day dayofmonth dayofweek dayofyear deallocate dec decimal declare dedupe_lookback_period default define degrees delete dense_rank deref describe deterministic dimensions disallow disconnect display distinct double drop dynamic e each element else empty empty_as_null encode end end-exec end_frame end_partition ends_with engine equals escape escape_char every except exec execute exists exp expire explain extend external extract factorial false fetch field field_delimiter file_format files filter first_value flatten float floor folder for foreign frame_row free from from_hex full function fusion geo_beyond geo_distance geo_nearby get global grant grants greatest group grouping groups hash hash64 having hex history hold hour identity if ilike imindir import in include indicator initcap initial inner inout insensitive insert instr int integer intersect intersection interval into is is_bigint is_int is_member is_substr is_utf8 is_varchar isdate isnumeric job join json_array json_arrayagg json_exists json_object json_objectagg json_query json_value lag language large last_day last_query_id last_value lateral lazy lcase lead leading least left length levenshtein like like_regex limit listagg ln local localsort localtime localtimestamp locate log log10 logs lower lpad lshift ltrim manifests map_keys map_values mask mask_first_n mask_hash mask_last_n mask_show_first_n mask_show_last_n masking match match_number match_recognize matches max max_file_size_mb maxdir md5 measures median member merge metadata method min min_file_size_mb min_input_files mindir minus minute missing mod modifies module monitor month months_between more multiset national natural nchar nclob ndv new next next_day no none normalize normalize_string not notification_provider notification_queue_reference now nth_value ntile null null_if nullif numeric nvl occurrences_regex octet_length of offset old older_than omit on one only open operate optimize or order orphan out outer over overlaps overlay ownership parameter parse_url partition partitions pattern per percent percent_rank percentile_cont percentile_disc period permute pi pivot pmod policy portion position position_regex pow power precedes precision prepare prev primary procedure project promotion qualify quarter query query_user quote quote_char radians random range rank raw reads real record_delimiter recursive ref reference references referencing reflection reflections refresh regex regexp_col_like regexp_extract regexp_like regexp_matches regexp_replace regexp_split regr_avgx regr_avgy regr_count regr_intercept regr_r2 regr_slope regr_sxy regr_syy release remove rename repeat repeatstr replace reset result retain_last retain_last_commits retain_last_snapshots return returns reverse revoke rewrite right role rollback rollup round route row row_number rows rpad rshift rtrim running savepoint schemas scope scroll search second seek select sensitive session_user set sha sha1 sha256 sha512 show sign similar similar_to sin sinh size skip smallint snapshot snapshots snapshots_older_than some soundex specific specifictype split_part sql sqlexception sqlstate sqlwarning sqrt st_fromgeohash st_geohash start starts_with static statistics stddev stddev_pop stddev_samp stream string_binary strpos submultiset subset substr substring substring_index substring_regex succeeds sum symmetric system system_time system_user table tables tablesample tag tan tanh target_file_size_mb tblproperties then time time_format timestamp timestamp_format timestampadd timestampdiff timestamptype timezone_hour timezone_minute tinyint to to_char to_date to_hex to_number to_time to_timestamp toascii trailing transaction_timestamp translate translate_regex translation treat trigger trim trim_array trim_space true truncate typeof ucase uescape unbase64 unhex union unique unix_timestamp unknown unnest unpivot unset update upper upsert usage use user using vacuum value value_of values var_pop var_samp varbinary varchar varying versioning view views week weekofyear when whenever where width_bucket window with within without write xor year".split(
+    " ",
+  ),
+);
+
+// Source: DuckDB 1.4.5
+// SELECT keyword_name FROM duckdb_keywords()
+// WHERE keyword_category = 'reserved' ORDER BY keyword_name;
+const DUCKDB_RESERVED_WORDS: ReadonlySet<string> = new Set(
+  "all analyse analyze and any array as asc asymmetric both case cast check collate column constraint create default deferrable desc describe distinct do else end except false fetch for foreign from group having in initially intersect into lambda lateral leading limit not null offset on only or order pivot pivot_longer pivot_wider placing primary qualify references returning select show some summarize symmetric table then to trailing true union unique unpivot using variadic when where window with".split(
+    " ",
+  ),
+);
+
+// Source: https://github.com/postgres/postgres/blob/REL_18_STABLE/src/include/parser/kwlist.h
+// RESERVED_KEYWORD and TYPE_FUNC_NAME_KEYWORD entries: both categories are
+// disallowed as unquoted column or relation names.
+const POSTGRESQL_RESERVED_WORDS: ReadonlySet<string> = new Set(
+  "all analyse analyze and any array as asc asymmetric authorization binary both case cast check collate collation column concurrently constraint create cross current_catalog current_date current_role current_schema current_time current_timestamp current_user default deferrable desc distinct do else end except false fetch for foreign freeze from full grant group having ilike in initially inner intersect into is isnull join lateral leading left like limit localtime localtimestamp natural not notnull null offset on only or order outer overlaps placing primary references returning right select session_user similar some symmetric system_user table tablesample then to trailing true union unique user using variadic verbose when where window with".split(
+    " ",
+  ),
+);
+
+function asciiLowercase(value: string): string | null {
+  if (
+    value.length === 0 ||
+    value.length > MAX_RESERVED_WORD_LENGTH
+  ) {
+    return null;
+  }
+  let hasUppercase = false;
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code >= 65 && code <= 90) {
+      hasUppercase = true;
+      continue;
+    }
+    if (
+      (code >= 97 && code <= 122) ||
+      (code >= 48 && code <= 57) ||
+      code === 45 ||
+      code === 95
+    ) {
+      continue;
+    }
+    return null;
+  }
+  if (!hasUppercase) {
+    return value;
+  }
+  let output = "";
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    output += String.fromCharCode(
+      code >= 65 && code <= 90 ? code + 32 : code,
+    );
+  }
+  return output;
+}
+
+export function isSqlRelationReservedWord(
+  kind: SqlRelationReservedWordKind,
+  value: string,
+): boolean {
+  const word = asciiLowercase(value);
+  if (word === null) {
+    return false;
+  }
+  switch (kind) {
+    case "bigquery":
+      return BIGQUERY_RESERVED_WORDS.has(word);
+    case "dremio":
+      return DREMIO_RESERVED_WORDS.has(word);
+    case "duckdb":
+      return DUCKDB_RESERVED_WORDS.has(word);
+    case "postgresql":
+      return POSTGRESQL_RESERVED_WORDS.has(word);
+    default:
+      return false;
+  }
+}

--- a/src/vnext/session.ts
+++ b/src/vnext/session.ts
@@ -10,15 +10,18 @@ import type {
   SqlTextRange,
 } from "./types.js";
 import {
-  BIGQUERY_SQL_LEXICAL_PROFILE,
   buildSqlStatementIndex,
-  DREMIO_SQL_LEXICAL_PROFILE,
-  DUCKDB_SQL_LEXICAL_PROFILE,
-  POSTGRESQL_SQL_LEXICAL_PROFILE,
   type SqlLexicalProfile,
   type SqlStatementIndex,
   updateSqlStatementIndex,
 } from "./statement-index.js";
+import {
+  BIGQUERY_SQL_RELATION_DIALECT,
+  DREMIO_SQL_RELATION_DIALECT,
+  DUCKDB_SQL_RELATION_DIALECT,
+  POSTGRESQL_SQL_RELATION_DIALECT,
+  type SqlRelationDialectRuntime,
+} from "./relation-dialect.js";
 import {
   createIdentitySqlSource,
   createMaskedSqlSource,
@@ -46,6 +49,7 @@ const MAX_DIALECTS = 1_000;
 interface SqlDialectRuntime {
   readonly dialect: SqlDialect;
   readonly lexicalProfile: SqlLexicalProfile;
+  readonly relationDialect: SqlRelationDialectRuntime;
 }
 
 const sqlDialectRuntimes = new WeakMap<object, SqlDialectRuntime>();
@@ -53,12 +57,22 @@ const sqlDialectRuntimes = new WeakMap<object, SqlDialectRuntime>();
 function createBuiltinSqlDialect(
   id: string,
   displayName: string,
-  lexicalProfile: SqlLexicalProfile,
+  relationDialect: SqlRelationDialectRuntime,
 ): SqlDialect {
+  if (
+    relationDialect.querySite.lexicalProfile !==
+      relationDialect.cteLayout.lexicalProfile
+  ) {
+    throw new Error("Built-in SQL dialect lexical profiles must match");
+  }
   const dialect = createSqlDialect(id, displayName);
   sqlDialectRuntimes.set(
     dialect,
-    Object.freeze({ dialect, lexicalProfile }),
+    Object.freeze({
+      dialect,
+      lexicalProfile: relationDialect.querySite.lexicalProfile,
+      relationDialect,
+    }),
   );
   return dialect;
 }
@@ -66,22 +80,22 @@ function createBuiltinSqlDialect(
 const BIGQUERY_DIALECT = createBuiltinSqlDialect(
   "bigquery",
   "BigQuery",
-  BIGQUERY_SQL_LEXICAL_PROFILE,
+  BIGQUERY_SQL_RELATION_DIALECT,
 );
 const DREMIO_DIALECT = createBuiltinSqlDialect(
   "dremio",
   "Dremio",
-  DREMIO_SQL_LEXICAL_PROFILE,
+  DREMIO_SQL_RELATION_DIALECT,
 );
 const DUCKDB_DIALECT = createBuiltinSqlDialect(
   "duckdb",
   "DuckDB",
-  DUCKDB_SQL_LEXICAL_PROFILE,
+  DUCKDB_SQL_RELATION_DIALECT,
 );
 const POSTGRES_DIALECT = createBuiltinSqlDialect(
   "postgresql",
   "PostgreSQL",
-  POSTGRESQL_SQL_LEXICAL_PROFILE,
+  POSTGRESQL_SQL_RELATION_DIALECT,
 );
 
 /** Returns the package-owned BigQuery dialect handle. */
@@ -109,6 +123,12 @@ function getSqlDialectRuntime(candidate: unknown): SqlDialectRuntime | null {
     return null;
   }
   return sqlDialectRuntimes.get(candidate) ?? null;
+}
+
+export function getSqlRelationDialectRuntime(
+  candidate: unknown,
+): SqlRelationDialectRuntime | null {
+  return getSqlDialectRuntime(candidate)?.relationDialect ?? null;
 }
 
 interface PendingContextValue {

--- a/test/vnext-types/marimo-relation-completion.test-d.ts
+++ b/test/vnext-types/marimo-relation-completion.test-d.ts
@@ -19,7 +19,6 @@ import type {
   SqlRelationCompletionItem,
   SqlRelationCompletionList,
   SqlRelationCatalogProvider,
-  SqlRelationCompletionDialectRuntime,
   SqlRelationCompletionSession,
 } from "../../src/vnext/relation-completion-types.js";
 
@@ -144,25 +143,6 @@ const relation: SqlCatalogRelation = {
   relationKind: "table",
 };
 void relation;
-
-const dialectRuntime: SqlRelationCompletionDialectRuntime = {
-  compareCteIdentifiers: (left, right) =>
-    left.quoted === right.quoted && left.value === right.value
-      ? "equal"
-      : "distinct",
-  cteIdentifierMatchesPrefix: (candidate, prefix) =>
-    candidate.value.startsWith(prefix.value) ? "match" : "no-match",
-  decodeIdentifier: (token) => ({
-    component: { quoted: false, value: token },
-    quality: "exact",
-    status: "decoded",
-  }),
-  renderRelationPath: (path) => ({
-    status: "rendered",
-    text: path.map((component) => component.value).join("."),
-  }),
-};
-void dialectRuntime;
 
 // @ts-expect-error semantic catalog roles are a closed set
 const invalidRole: SqlCatalogRelation["canonicalPath"][number]["role"] =

--- a/test/vnext-types/session.test-d.ts
+++ b/test/vnext-types/session.test-d.ts
@@ -26,6 +26,12 @@ interface HostEmbeddedRegion extends SqlEmbeddedRegion {
 
 const dialect = duckdbDialect();
 const typedDialect: SqlDialect = dialect;
+// @ts-expect-error dialect implementation callbacks are package-private
+void typedDialect.decodeIdentifier;
+// @ts-expect-error dialect grammar is package-private
+void typedDialect.grammar;
+// @ts-expect-error dialect rendering policy is package-private
+void typedDialect.renderRelationPath;
 const service = createSqlLanguageService<HostContext>({ dialects: [dialect] });
 const session = service.openDocument({
   context: { dialect: "duckdb", engine: "local" },

--- a/test/worker-placement/README.md
+++ b/test/worker-placement/README.md
@@ -9,17 +9,23 @@ package's dependency. The fixture workspace pins Vite's floating transitive
 versions to the exact versions in the root lock, so the nested frozen install
 can run offline after a clean root CI install.
 
-The minified Vite 8 single-worker baseline is 67,396 gzip bytes for the
-PostgreSQL transitive graph, 50,389 gzip bytes for the BigQuery transitive
-graph, and 118,170 gzip/549,893 raw bytes for the complete worker build output.
-The PostgreSQL and BigQuery figures each include their transitive shared
-chunks; the report also identifies those shared chunks explicitly. The
-fail-closed ceilings include small explicit headroom over that measured
-packed-consumer baseline:
+The minified Vite 8 packed-consumer baseline is 15,028 gzip/47,141 raw
+bytes for the complete parser-free core, 67,573 gzip bytes for the PostgreSQL
+transitive graph, 50,470 gzip bytes for the BigQuery transitive graph, and
+125,937 gzip/572,982 raw bytes for the complete worker build output. The core
+measurement includes the four authenticated relation-dialect runtimes and
+their reserved-word tables. The PostgreSQL and BigQuery figures each include
+their transitive shared chunks; the report also identifies those shared chunks
+explicitly.
 
+The fail-closed ceilings retain approximately 9% gzip and 13% raw headroom for
+the core, 4% gzip and 2% raw headroom for the complete worker output, and the
+existing tight dialect-graph headroom:
+
+- Complete parser-free core: 16 KiB gzip and 52 KiB raw
 - PostgreSQL transitive graph: 68 KiB gzip
 - BigQuery transitive graph: 50 KiB gzip
-- Complete worker build output: 120 KiB gzip and 570 KiB raw
+- Complete worker build output: 128 KiB gzip and 570 KiB raw
 
 These are provisional placement limits, not product bundle promises. The
 orchestration script fails closed when they are exceeded, when the dialects no


### PR DESCRIPTION
## Summary

- add one package-owned relation dialect runtime for PostgreSQL, DuckDB, BigQuery, and Dremio
- unify identifier decoding, CTE equality/prefix rules, query-path decoding, role-aware rendering, reserved words, and CTE/query recognizer policy
- authenticate each runtime through the opaque built-in dialect handle while keeping callbacks private
- add hostile-input bounds and fail-closed behavior, exact dialect corpora, production-backed recognizer tests, and bundle budgets

## Correctness and performance

- changed production coverage: 97.10% statements, 96.18% branches, 100% functions, 97.05% lines
- exact packed core: 15,028 gzip / 47,141 raw bytes under 16 KiB / 52 KiB limits
- exact packed worker output: 125,937 gzip / 572,982 raw bytes under 128 KiB / 570 KiB limits
- comparator hot paths use bounded allocation-free ASCII loops; private path scratch arrays are not copied or frozen

## Verification

- 1,646 tests passed, 1 governed expected failure
- all five TypeScript configurations passed
- oxlint and test-integrity checks passed
- browser suite passed in Chromium
- exact tarball package smoke and SSR import passed
- worker placement, strict CSP, lazy loading, and parser isolation passed
- query-site and CTE benchmarks passed
- exact head 6e80f2fbe70460abb1d6a770f47efe0314b4084c approved independently by three adversarial reviewers

Part of #169.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies the relation dialect runtime across PostgreSQL, DuckDB, BigQuery, and Dremio with a single, package-owned policy for identifiers, CTEs, query paths, and role-aware rendering. Tightens the public API and enforces strict size budgets and hostile-input boundaries. Part of #169.

- **New Features**
  - Added a unified `relation-dialect` runtime for completion, CTE layout, query-site policy, reserved words, and rendering across all built-ins.
  - Introduced fail-closed decoding with hostile-input bounds and exact corpora; added adversarial/production-backed tests.
  - Enforced bundle budgets (core ≤16 KiB gzip/52 KiB raw; worker ≤128 KiB gzip/570 KiB raw) and a smoke check to prevent dialect policy leaks.

- **Refactors**
  - Public dialect handles (`bigQueryDialect()`, `dremioDialect()`, `duckdbDialect()`, `postgresDialect()`) now expose only `displayName` and `id`; callbacks are private and authenticated in `session`.
  - Migrated `cte-layout` and `query-site` to `..._SQL_RELATION_DIALECT` constants; added `MAX_CTE_QUOTED_IDENTIFIER_LENGTH`.
  - Simplified and hardened tests by removing ad-hoc dialects; updated worker placement and docs to report core/worker sizes.

<sup>Written for commit 6e80f2fbe70460abb1d6a770f47efe0314b4084c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marimo-team/codemirror-sql/pull/189?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

