### PR TITLE
feat(vnext): add CodeMirror completion adapter

### DIFF
--- a/docs/vnext/codemirror-adapter.md
+++ b/docs/vnext/codemirror-adapter.md
@@ -1,0 +1,95 @@
+# vNext CodeMirror Adapter
+
+Status: experimental
+
+Import: `@marimo-team/codemirror-sql/vnext/codemirror`
+
+`sqlEditor` connects one caller-owned vNext language service to one or more
+CodeMirror 6 views. Each view owns a document session, cancellation state,
+catalog-refresh intent, and revision subscription. Destroying a view disposes
+that view's session but never disposes the shared service.
+
+```ts
+import { EditorView } from "@codemirror/view";
+import {
+  createSqlLanguageService,
+  duckdbDialect,
+} from "@marimo-team/codemirror-sql/vnext";
+import {
+  sqlEditor,
+} from "@marimo-team/codemirror-sql/vnext/codemirror";
+
+const service = createSqlLanguageService({
+  dialects: [duckdbDialect()],
+});
+const support = sqlEditor({
+  initialContext: {
+    catalog: { scope: "connection-incarnation:1" },
+    dialect: "duckdb",
+  },
+  service,
+});
+const view = new EditorView({
+  doc: "SELECT * FROM ",
+  extensions: [support.extension],
+});
+
+support.setContext(view, {
+  catalog: { scope: "connection-incarnation:2" },
+  dialect: "duckdb",
+});
+
+view.destroy();
+service.dispose();
+```
+
+The adapter installs one coherent `autocompletion` configuration. Additional
+sources belong in `autocomplete.externalSources`; consumers should not install
+a second independently configured `autocompletion` extension.
+
+## Atomic inputs
+
+Context and document changes can share one CodeMirror transaction:
+
+```ts
+view.dispatch({
+  changes,
+  effects: support.contextEffect.of(nextContext),
+});
+```
+
+CodeMirror's composite `ChangeSet` is converted to sorted, non-overlapping
+pre-update UTF-16 changes and sent to the session exactly once.
+
+Embedded-language ranges are explicit. Their effect payload is the complete
+region set in the resulting document's coordinates:
+
+```ts
+view.dispatch({
+  changes,
+  effects: support.embeddedRegionsEffect.of(nextRegions),
+});
+```
+
+When the current document contains embedded regions, every document-changing
+transaction must include the complete resulting region set. The adapter fails
+closed instead of guessing how host-language delimiters map through edits.
+Region-only updates may use `setEmbeddedRegions`.
+
+The adapter's own completion edit is the narrow exception: it maps unrelated
+regions through the exact edit and includes the complete mapped set in the same
+transaction. A completion edit that overlaps an embedded region is ignored.
+
+## Completion currency
+
+The adapter does not use `validFor` or result mapping in this first slice.
+Every result and completion application rechecks the session revision,
+document identity, selection, and context generation.
+
+Loading completion results retain one bounded, token-correlated refresh intent,
+including empty results that open no menu. Only a session event carrying the
+exact task token can schedule a refresh. A newer request, document/context/
+region/selection change, Escape, configured blur, visibility loss, lease
+expiry, or view destruction cancels the intent. Refresh and close operations
+are always queued; provider and session callbacks never synchronously dispatch
+CodeMirror transactions.

--- a/docs/vnext/session-primitives.md
+++ b/docs/vnext/session-primitives.md
@@ -8,6 +8,9 @@ opaque revisions, dialect registration, lifecycle management, and
 parser-independent relation completion. Diagnostics, hover, navigation, and
 general expression completion are not yet available.
 
+CodeMirror consumers should use the separate
+[vNext CodeMirror adapter](./codemirror-adapter.md).
+
 See [source coordinates](./source-coordinates.md) for the shared UTF-16 range
 contract and the internal immutable source-snapshot model.
 

--- a/package.json
+++ b/package.json
@@ -93,6 +93,12 @@
         "default": "./dist/vnext/index.js"
       }
     },
+    "./vnext/codemirror": {
+      "import": {
+        "types": "./dist/vnext/codemirror/index.d.ts",
+        "default": "./dist/vnext/codemirror/index.js"
+      }
+    },
     "./data/common-keywords.json": "./src/data/common-keywords.json",
     "./data/duckdb-keywords.json": "./src/data/duckdb-keywords.json"
   },

--- a/scripts/package-smoke.mjs
+++ b/scripts/package-smoke.mjs
@@ -231,6 +231,7 @@ import {
   type SqlEmbeddedRegion,
   type SqlTextRange,
 } from "@marimo-team/codemirror-sql/vnext";
+import { sqlEditor } from "@marimo-team/codemirror-sql/vnext/codemirror";
 import commonKeywords from "@marimo-team/codemirror-sql/data/common-keywords.json" with { type: "json" };
 import duckdbKeywords from "@marimo-team/codemirror-sql/data/duckdb-keywords.json" with { type: "json" };
 
@@ -245,6 +246,10 @@ const extensions: Extension[] = [
 const parser = new NodeSqlParser();
 const service = createSqlLanguageService<HostContext>({
   dialects: [duckdbDialect()],
+});
+const editorSupport = sqlEditor({
+  initialContext: { dialect: "duckdb", engine: "local" },
+  service,
 });
 const embeddedRegions: readonly SqlEmbeddedRegion[] = [
   { from: 14, language: "python", to: 18 },
@@ -262,6 +267,7 @@ session.update({
 });
 
 void extensions;
+void editorSupport.extension;
 void parser;
 void range;
 void session;
@@ -278,6 +284,7 @@ void duckdbKeywords;
 import * as api from "@marimo-team/codemirror-sql";
 import * as dialects from "@marimo-team/codemirror-sql/dialects";
 import * as vnext from "@marimo-team/codemirror-sql/vnext";
+import * as vnextCodeMirror from "@marimo-team/codemirror-sql/vnext/codemirror";
 import commonKeywords from "@marimo-team/codemirror-sql/data/common-keywords.json" with { type: "json" };
 import duckdbKeywords from "@marimo-team/codemirror-sql/data/duckdb-keywords.json" with { type: "json" };
 
@@ -295,6 +302,9 @@ if (
   typeof vnext.postgresDialect !== "function"
 ) {
   throw new Error("vNext package exports are incomplete");
+}
+if (typeof vnextCodeMirror.sqlEditor !== "function") {
+  throw new Error("vNext CodeMirror package exports are incomplete");
 }
 for (const dialect of [
   vnext.bigQueryDialect(),

--- a/src/vnext/codemirror/__tests__/sql-editor.test.ts
+++ b/src/vnext/codemirror/__tests__/sql-editor.test.ts
@@ -1,0 +1,1172 @@
+import {
+  closeCompletion,
+  completionStatus,
+  currentCompletions,
+  startCompletion,
+} from "@codemirror/autocomplete";
+import { EditorSelection, type Extension } from "@codemirror/state";
+import { EditorView } from "@codemirror/view";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  createSqlLanguageService,
+  duckdbDialect,
+  type SqlCatalogSearchRequest,
+  type SqlCatalogSearchResponse,
+  type SqlCompletionItem,
+  type SqlCompletionRefreshToken,
+  type SqlCompletionResult,
+  type SqlCompletionTask,
+  type SqlContextInput,
+  type SqlDocumentContext,
+  type SqlDocumentSession,
+  type SqlDocumentUpdate,
+  type SqlLanguageService,
+  type SqlRelationCatalogProvider,
+  type SqlRevision,
+  type SqlSessionChangeEvent,
+} from "../../index.js";
+import {
+  createSqlCompletionRefreshToken,
+} from "../../relation-completion-types.js";
+import { createSqlRevisionToken } from "../../types.js";
+import {
+  createSqlEditorInternal,
+  sqlEditor,
+  type SqlEditorRuntime,
+} from "../sql-editor.js";
+
+interface TestContext extends SqlDocumentContext {
+  readonly engine: string;
+}
+
+interface FakeServiceHarness {
+  readonly completeSignals: AbortSignal[];
+  readonly emit: (event: SqlSessionChangeEvent) => void;
+  readonly getLastToken: () => SqlCompletionRefreshToken | null;
+  readonly service: SqlLanguageService<TestContext>;
+  readonly sessionDisposals: () => number;
+  readonly updates: readonly SqlDocumentUpdate<TestContext>[];
+}
+
+const views: EditorView[] = [];
+
+afterEach(() => {
+  for (const view of views.splice(0)) view.destroy();
+});
+
+function relationResponse(
+  relation = "users",
+): SqlCatalogSearchResponse {
+  return {
+    coverage: { kind: "complete" },
+    epoch: { generation: 0, token: "ready" },
+    relations: [{
+      canonicalPath: [
+        {
+          quoted: false,
+          role: "schema",
+          value: "main",
+        },
+        {
+          quoted: false,
+          role: "relation",
+          value: relation,
+        },
+      ],
+      completionPathStart: 1,
+      entityId: `main.${relation}`,
+      matchQuality: "exact",
+      relationKind: "table",
+    }],
+    status: "ready",
+  };
+}
+
+function completionItem(
+  from = 14,
+  to = 16,
+  relationKind: "cte" | "table" = "table",
+): SqlCompletionItem {
+  const edit = {
+    from,
+    insert: "users",
+    to,
+  };
+  return relationKind === "cte"
+    ? {
+        edit,
+        kind: "relation",
+        label: "users",
+        provenance: {
+          declarationPosition: 0,
+          kind: "cte",
+        },
+        relationKind,
+      }
+    : {
+        detail: "Table",
+        edit,
+        kind: "relation",
+        label: "users",
+        provenance: {
+          entityId: "main.users",
+          kind: "catalog",
+          providerId: "fake",
+        },
+        relationKind,
+      };
+}
+
+function fakeService(
+  result: (
+    revision: SqlRevision,
+    token: SqlCompletionRefreshToken,
+  ) => SqlCompletionResult | Promise<SqlCompletionResult>,
+  rejectUpdates = false,
+): FakeServiceHarness {
+  const completeSignals: AbortSignal[] = [];
+  const updates: SqlDocumentUpdate<TestContext>[] = [];
+  let listener:
+    | ((event: SqlSessionChangeEvent) => void)
+    | null = null;
+  let lastToken: SqlCompletionRefreshToken | null = null;
+  let sessionDisposalCount = 0;
+  const service: SqlLanguageService<TestContext> = {
+    dispose: () => undefined,
+    openDocument: () => {
+      let disposed = false;
+      let revision = createSqlRevisionToken();
+      const session: SqlDocumentSession<TestContext> = {
+        complete: (request): SqlCompletionTask => {
+          completeSignals.push(request.signal ?? new AbortController().signal);
+          const token = createSqlCompletionRefreshToken();
+          lastToken = token;
+          return Object.assign(
+            Promise.resolve(result(revision, token)),
+            { refreshToken: token },
+          );
+        },
+        dispose: () => {
+          if (disposed) return;
+          disposed = true;
+          sessionDisposalCount += 1;
+        },
+        isCurrent: (candidate) => !disposed && candidate === revision,
+        onDidChange: (nextListener) => {
+          listener = nextListener;
+          return {
+            dispose: () => {
+              if (listener === nextListener) listener = null;
+            },
+          };
+        },
+        get revision() {
+          return revision;
+        },
+        update: (update) => {
+          updates.push(update);
+          if (rejectUpdates) {
+            throw new Error("update rejected");
+          }
+          revision = createSqlRevisionToken();
+          return revision;
+        },
+      };
+      return session;
+    },
+  };
+  return {
+    completeSignals,
+    emit: (event) => listener?.(event),
+    getLastToken: () => lastToken,
+    service,
+    sessionDisposals: () => sessionDisposalCount,
+    updates,
+  };
+}
+
+function readyResult(
+  revision: SqlRevision,
+  items: readonly SqlCompletionItem[],
+  refreshToken: SqlCompletionRefreshToken | null = null,
+): SqlCompletionResult {
+  return {
+    refreshToken,
+    revision,
+    sources: [],
+    status: "ready",
+    value: refreshToken === null
+      ? {
+          isIncomplete: false,
+          issues: [],
+          items,
+        }
+      : {
+          isIncomplete: true,
+          issues: [{
+            reason: "catalog-loading",
+            remainingIntentLeaseMs: 1_000,
+          }],
+          items,
+        },
+  };
+}
+
+function context(
+  scope = "connection:fake",
+): SqlContextInput<TestContext> {
+  return {
+    catalog: { scope },
+    dialect: "duckdb",
+    engine: "local",
+  };
+}
+
+function controlledRuntime(): {
+  readonly closes: EditorView[];
+  readonly queued: Array<() => void>;
+  readonly runtime: SqlEditorRuntime;
+  readonly starts: EditorView[];
+  readonly timerDelays: number[];
+  readonly timers: Array<() => void>;
+} {
+  const closes: EditorView[] = [];
+  const queued: Array<() => void> = [];
+  const starts: EditorView[] = [];
+  const timerDelays: number[] = [];
+  const timers: Array<() => void> = [];
+  return {
+    closes,
+    queued,
+    runtime: {
+      clearTimeout: (handle) => clearTimeout(handle),
+      closeCompletion: (view) => {
+        closes.push(view);
+        return true;
+      },
+      queueMicrotask: (callback) => {
+        queued.push(callback);
+      },
+      setTimeout: (callback, delayMs) => {
+        timerDelays.push(delayMs);
+        timers.push(callback);
+        return setTimeout(() => undefined, 60_000);
+      },
+      startCompletion: (view) => {
+        starts.push(view);
+        return true;
+      },
+    },
+    starts,
+    timerDelays,
+    timers,
+  };
+}
+
+function createView(
+  extension: Extension,
+  doc = "SELECT * FROM us",
+): EditorView {
+  const view = new EditorView({
+    doc,
+    extensions: extension,
+    parent: document.body,
+    selection: EditorSelection.cursor(doc.length),
+  });
+  views.push(view);
+  return view;
+}
+
+async function waitForActiveCompletion(view: EditorView): Promise<void> {
+  await vi.waitFor(() => {
+    expect(completionStatus(view.state)).toBe("active");
+  });
+}
+
+describe("sqlEditor", () => {
+  it("maps current service completions and applies the exact core edit", async () => {
+    const service = createSqlLanguageService<TestContext>({
+      catalog: {
+        id: "catalog",
+        search: async () => relationResponse(),
+      },
+      dialects: [duckdbDialect()],
+    });
+    const support = sqlEditor({
+      initialContext: {
+        catalog: {
+          scope: "connection:1",
+          searchPath: [[{
+            quoted: false,
+            value: "main",
+          }]],
+        },
+        dialect: "duckdb",
+        engine: "local",
+      },
+      service,
+    });
+    const view = createView(support.extension);
+
+    expect(startCompletion(view)).toBe(true);
+    await waitForActiveCompletion(view);
+    const completion = currentCompletions(view.state).find(
+      (item) => item.label === "users",
+    );
+    expect(completion).toBeDefined();
+    if (!completion || typeof completion.apply !== "function") {
+      throw new Error("Expected an exact completion apply callback");
+    }
+    completion.apply(view, completion, 14, 16);
+    expect(view.state.doc.toString()).toBe("SELECT * FROM users");
+
+    view.destroy();
+    service.dispose();
+  });
+
+  it("maps embedded regions through its own non-overlapping apply edit", async () => {
+    const harness = fakeService((revision) =>
+      readyResult(revision, [completionItem(16, 18)])
+    );
+    const support = sqlEditor({
+      initialContext: context(),
+      initialEmbeddedRegions: [{
+        from: 0,
+        language: "host",
+        to: 2,
+      }, {
+        from: 18,
+        language: "host",
+        to: 20,
+      }],
+      service: harness.service,
+    });
+    const view = createView(support.extension, "xxSELECT * FROM usYY");
+    view.dispatch({ selection: { anchor: 18 } });
+    expect(startCompletion(view)).toBe(true);
+    await waitForActiveCompletion(view);
+    const completion = currentCompletions(view.state)[0];
+    if (!completion || typeof completion.apply !== "function") {
+      throw new Error("Expected completion apply callback");
+    }
+
+    completion.apply(view, completion, 16, 18);
+    expect(view.state.doc.toString()).toBe("xxSELECT * FROM usersYY");
+    expect(harness.updates.at(-1)).toMatchObject({
+      document: {
+        changes: [{ from: 16, insert: "users", to: 18 }],
+      },
+      embeddedRegions: [{
+        from: 0,
+        language: "host",
+        to: 2,
+      }, {
+        from: 21,
+        language: "host",
+        to: 23,
+      }],
+    });
+    expect(harness.sessionDisposals()).toBe(0);
+  });
+
+  it("combines document and final context effects into one current input", async () => {
+    const requests: SqlCatalogSearchRequest[] = [];
+    const service = createSqlLanguageService<TestContext>({
+      catalog: {
+        id: "catalog",
+        search: async (request) => {
+          requests.push(request);
+          return relationResponse("orders");
+        },
+      },
+      dialects: [duckdbDialect()],
+    });
+    const support = sqlEditor({
+      initialContext: {
+        catalog: { scope: "connection:old" },
+        dialect: "duckdb",
+        engine: "local",
+      },
+      service,
+    });
+    const view = createView(support.extension, "SELECT * FROM ");
+    view.dispatch(
+      {
+        changes: { from: 14, insert: "or" },
+        effects: support.contextEffect.of({
+          catalog: { scope: "connection:middle" },
+          dialect: "duckdb",
+          engine: "remote",
+        }),
+      },
+      {
+        changes: { from: 16, insert: "d" },
+        effects: support.contextEffect.of({
+          catalog: { scope: "connection:final" },
+          dialect: "duckdb",
+          engine: "remote",
+        }),
+        selection: { anchor: 17 },
+        sequential: true,
+      },
+    );
+
+    expect(startCompletion(view)).toBe(true);
+    await waitForActiveCompletion(view);
+    expect(requests.at(-1)).toMatchObject({
+      prefix: { value: "ord" },
+      scope: "connection:final",
+    });
+
+    view.destroy();
+    service.dispose();
+  });
+
+  it("refreshes an empty loading result once when its exact work becomes ready", async () => {
+    let resolveSearch:
+      | ((response: SqlCatalogSearchResponse) => void)
+      | undefined;
+    const pending = new Promise<SqlCatalogSearchResponse>((resolve) => {
+      resolveSearch = resolve;
+    });
+    let searches = 0;
+    const provider: SqlRelationCatalogProvider = {
+      id: "deferred",
+      search: async () => {
+        searches += 1;
+        return pending;
+      },
+    };
+    const service = createSqlLanguageService<TestContext>({
+      catalog: provider,
+      completion: { catalogResponseBudgetMs: 0 },
+      dialects: [duckdbDialect()],
+    });
+    const support = sqlEditor({
+      autocomplete: { closeOnBlur: false },
+      initialContext: {
+        catalog: {
+          scope: "connection:deferred",
+          searchPath: [[{
+            quoted: false,
+            value: "main",
+          }]],
+        },
+        dialect: "duckdb",
+        engine: "local",
+      },
+      service,
+    });
+    const view = createView(support.extension, "SELECT * FROM ");
+
+    expect(startCompletion(view)).toBe(true);
+    await vi.waitFor(() => {
+      expect(searches).toBe(1);
+      expect(completionStatus(view.state)).toBeNull();
+    });
+    resolveSearch?.(relationResponse());
+    await vi.waitFor(() => {
+      expect(currentCompletions(view.state).map((item) => item.label))
+        .toContain("users");
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(currentCompletions(view.state).map((item) => item.label))
+      .toEqual(["users"]);
+
+    view.destroy();
+    service.dispose();
+  });
+
+  it("keeps shared-service ownership with the caller", () => {
+    const service = createSqlLanguageService<TestContext>({
+      dialects: [duckdbDialect()],
+    });
+    const support = sqlEditor({
+      initialContext: {
+        dialect: "duckdb",
+        engine: "local",
+      },
+      service,
+    });
+    const first = createView(support.extension);
+    const second = createView(support.extension);
+    first.destroy();
+    second.destroy();
+
+    const session = service.openDocument({
+      context: {
+        dialect: "duckdb",
+        engine: "local",
+      },
+      text: "SELECT 1",
+    });
+    expect(session.revision).toBeDefined();
+    session.dispose();
+    service.dispose();
+  });
+
+  it("contains caller service disposal before its view is destroyed", () => {
+    const service = createSqlLanguageService<TestContext>({
+      dialects: [duckdbDialect()],
+    });
+    const support = sqlEditor({
+      initialContext: context(),
+      service,
+    });
+    const view = createView(support.extension);
+    service.dispose();
+
+    expect(() => {
+      support.setContext(view, context("connection:disposed"));
+    }).not.toThrow();
+    expect(() => view.destroy()).not.toThrow();
+  });
+
+  it("composes external sources and maps CTE presentation", async () => {
+    const harness = fakeService((revision) =>
+      readyResult(revision, [completionItem(14, 16, "cte")])
+    );
+    const support = sqlEditor({
+      autocomplete: {
+        externalSources: [() => ({
+          from: 14,
+          options: [{ label: "user_external" }],
+        })],
+      },
+      initialContext: context(),
+      service: harness.service,
+    });
+    const view = createView(support.extension);
+
+    expect(startCompletion(view)).toBe(true);
+    await waitForActiveCompletion(view);
+    expect(currentCompletions(view.state)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ label: "user_external" }),
+        expect.objectContaining({ label: "users", type: "type" }),
+      ]),
+    );
+  });
+
+  it.each([
+    "cancelled",
+    "failed",
+    "unavailable",
+  ] as const)("maps %s service results to no CodeMirror result", async (status) => {
+    const harness = fakeService((revision) => {
+      if (status === "cancelled") {
+        return {
+          reason: "caller",
+          revision,
+          status,
+        };
+      }
+      if (status === "failed") {
+        return {
+          failure: { code: "internal", retryable: false },
+          revision,
+          status,
+        };
+      }
+      return {
+        reason: "inactive",
+        retryable: false,
+        revision,
+        status,
+      };
+    });
+    const support = sqlEditor({
+      initialContext: context(),
+      service: harness.service,
+    });
+    const view = createView(support.extension);
+
+    expect(startCompletion(view)).toBe(true);
+    await vi.waitFor(() => {
+      expect(harness.completeSignals).toHaveLength(1);
+      expect(completionStatus(view.state)).toBeNull();
+    });
+  });
+
+  it("fails closed for mixed edit ranges and token/list mismatches", async () => {
+    const runtime = controlledRuntime();
+    let malformed = false;
+    const harness = fakeService((revision, token) =>
+      malformed
+        ? {
+            refreshToken: token,
+            revision,
+            sources: [],
+            status: "ready",
+            value: {
+              isIncomplete: true,
+              issues: [{
+                reason: "catalog-partial",
+              }],
+              items: [completionItem()],
+            },
+          }
+        : readyResult(
+            revision,
+            [
+              completionItem(),
+              completionItem(13, 16),
+            ],
+            token,
+          )
+    );
+    const support = createSqlEditorInternal({
+      autocomplete: { closeOnBlur: false },
+      initialContext: context(),
+      service: harness.service,
+    }, runtime.runtime);
+    const view = createView(support.extension);
+
+    expect(startCompletion(view)).toBe(true);
+    await vi.waitFor(() => {
+      expect(harness.completeSignals).toHaveLength(1);
+      expect(completionStatus(view.state)).toBeNull();
+    });
+    const mixedToken = harness.getLastToken();
+    if (!mixedToken) throw new Error("Expected mixed-result token");
+    harness.emit({
+      reason: "catalog-availability",
+      refreshToken: mixedToken,
+      revision: createSqlRevisionToken(),
+    });
+    expect(runtime.timers).toHaveLength(0);
+    expect(runtime.queued).toHaveLength(0);
+    malformed = true;
+    expect(startCompletion(view)).toBe(true);
+    await vi.waitFor(() => {
+      expect(harness.completeSignals).toHaveLength(2);
+      expect(completionStatus(view.state)).toBeNull();
+    });
+  });
+
+  it("rejects a refresh token that does not match its task", async () => {
+    const runtime = controlledRuntime();
+    const mismatchedToken = createSqlCompletionRefreshToken();
+    const harness = fakeService((revision) =>
+      readyResult(revision, [], mismatchedToken)
+    );
+    const support = createSqlEditorInternal({
+      autocomplete: { closeOnBlur: false },
+      initialContext: context(),
+      service: harness.service,
+    }, runtime.runtime);
+    const view = createView(support.extension, "SELECT * FROM ");
+    expect(startCompletion(view)).toBe(true);
+    await vi.waitFor(() => {
+      expect(harness.completeSignals).toHaveLength(1);
+      expect(completionStatus(view.state)).toBeNull();
+    });
+    const taskToken = harness.getLastToken();
+    if (!taskToken) throw new Error("Expected task token");
+
+    for (const refreshToken of [taskToken, mismatchedToken]) {
+      harness.emit({
+        reason: "catalog-availability",
+        refreshToken,
+        revision: createSqlRevisionToken(),
+      });
+    }
+    expect(runtime.timers).toHaveLength(0);
+    expect(runtime.queued).toHaveLength(0);
+  });
+
+  it("uses the service-reported remaining refresh lease", async () => {
+    const runtime = controlledRuntime();
+    let resolveResult:
+      | ((result: SqlCompletionResult) => void)
+      | undefined;
+    let resultRevision: SqlRevision | null = null;
+    let resultToken: SqlCompletionRefreshToken | null = null;
+    const harness = fakeService((revision, token) => {
+      resultRevision = revision;
+      resultToken = token;
+      return new Promise((resolve) => {
+        resolveResult = resolve;
+      });
+    });
+    const support = createSqlEditorInternal({
+      autocomplete: { closeOnBlur: false },
+      initialContext: context(),
+      service: harness.service,
+    }, runtime.runtime);
+    const view = createView(support.extension, "SELECT * FROM ");
+    expect(startCompletion(view)).toBe(true);
+    await vi.waitFor(() =>
+      expect(harness.completeSignals).toHaveLength(1)
+    );
+    if (!resultRevision || !resultToken) {
+      throw new Error("Expected deferred completion identity");
+    }
+    resolveResult?.(readyResult(resultRevision, [], resultToken));
+
+    await vi.waitFor(() => {
+      expect(runtime.timerDelays).toEqual([1_000]);
+    });
+  });
+
+  it("rejects a stale completion apply after a context update", async () => {
+    const harness = fakeService((revision) =>
+      readyResult(revision, [completionItem()])
+    );
+    const support = sqlEditor({
+      initialContext: context(),
+      service: harness.service,
+    });
+    const view = createView(support.extension);
+    expect(startCompletion(view)).toBe(true);
+    await waitForActiveCompletion(view);
+    const completion = currentCompletions(view.state)[0];
+    if (!completion || typeof completion.apply !== "function") {
+      throw new Error("Expected completion apply callback");
+    }
+
+    support.setContext(view, context("connection:new"));
+    completion.apply(view, completion, 14, 16);
+    expect(view.state.doc.toString()).toBe("SELECT * FROM us");
+    expect(harness.updates).toHaveLength(1);
+    expect(harness.updates[0]).not.toHaveProperty("embeddedRegions");
+  });
+
+  it("updates regions explicitly and requires them for transformed documents", () => {
+    const harness = fakeService((revision) => readyResult(revision, []));
+    const support = sqlEditor({
+      initialContext: context(),
+      service: harness.service,
+    });
+    const view = createView(support.extension, "xxSELECT 1");
+    support.setEmbeddedRegions(view, [{
+      from: 0,
+      language: "host",
+      to: 2,
+    }]);
+    expect(harness.updates.at(-1)).toMatchObject({
+      embeddedRegions: [{ from: 0, language: "host", to: 2 }],
+    });
+
+    view.dispatch({
+      effects: [
+        support.contextEffect.of(context("connection:regions")),
+        support.embeddedRegionsEffect.of([{
+          from: 0,
+          language: "host",
+          to: 2,
+        }]),
+      ],
+    });
+    view.dispatch({
+      changes: { from: 10, insert: " " },
+      effects: support.embeddedRegionsEffect.of([{
+        from: 0,
+        language: "host",
+        to: 2,
+      }]),
+    });
+    expect(harness.updates).toHaveLength(3);
+
+    const removeEventListener = vi.spyOn(
+      document,
+      "removeEventListener",
+    );
+    const error = vi.spyOn(console, "error").mockImplementation(
+      () => undefined,
+    );
+    view.dispatch({ changes: { from: 10, insert: "x" } });
+    expect(harness.sessionDisposals()).toBe(1);
+    expect(removeEventListener).toHaveBeenCalledWith(
+      "visibilitychange",
+      expect.any(Function),
+    );
+    removeEventListener.mockRestore();
+    error.mockRestore();
+  });
+
+  it("destroys owned resources when a session update is rejected", () => {
+    const harness = fakeService(
+      (revision) => readyResult(revision, []),
+      true,
+    );
+    const support = sqlEditor({
+      initialContext: context(),
+      service: harness.service,
+    });
+    const view = createView(support.extension);
+    const error = vi.spyOn(console, "error").mockImplementation(
+      () => undefined,
+    );
+
+    support.setContext(view, context("connection:rejected"));
+    expect(harness.sessionDisposals()).toBe(1);
+    expect(harness.updates).toHaveLength(1);
+    expect(error).not.toHaveBeenCalled();
+    error.mockRestore();
+  });
+
+  it.each(["sync", "async"] as const)(
+    "contains a %s completion service failure",
+    async (failureKind) => {
+      const harness = fakeService(() => {
+        if (failureKind === "sync") {
+          throw new Error("synchronous service failure");
+        }
+        return Promise.reject(new Error("asynchronous service failure"));
+      });
+      const support = sqlEditor({
+        initialContext: context(),
+        service: harness.service,
+      });
+      const view = createView(support.extension);
+
+      expect(startCompletion(view)).toBe(true);
+      await vi.waitFor(() => {
+        expect(completionStatus(view.state)).toBeNull();
+        expect(harness.sessionDisposals()).toBe(1);
+      });
+      view.destroy();
+      expect(harness.sessionDisposals()).toBe(1);
+    },
+  );
+
+  it("cancels invisible intent on selection, Escape, expiry, and visibility", async () => {
+    const runtime = controlledRuntime();
+    const harness = fakeService((revision, token) =>
+      readyResult(revision, [], token)
+    );
+    const support = createSqlEditorInternal({
+      autocomplete: { closeOnBlur: false },
+      initialContext: context(),
+      service: harness.service,
+    }, runtime.runtime);
+    const view = createView(support.extension, "SELECT * FROM ");
+
+    expect(startCompletion(view)).toBe(true);
+    await vi.waitFor(() => expect(runtime.timers).toHaveLength(1));
+    const selectionToken = harness.getLastToken();
+    view.dispatch({ selection: { anchor: 0 } });
+    if (!selectionToken) throw new Error("Expected completion token");
+    harness.emit({
+      reason: "catalog-availability",
+      refreshToken: selectionToken,
+      revision: createSqlRevisionToken(),
+    });
+    expect(runtime.queued).toHaveLength(0);
+
+    view.dispatch({ selection: { anchor: 14 } });
+    expect(startCompletion(view)).toBe(true);
+    await vi.waitFor(() => expect(runtime.timers).toHaveLength(2));
+    view.focus();
+    view.contentDOM.dispatchEvent(new KeyboardEvent("keydown", {
+      bubbles: true,
+      key: "Escape",
+    }));
+    const escapeToken = harness.getLastToken();
+    if (!escapeToken) throw new Error("Expected completion token");
+    harness.emit({
+      reason: "catalog-availability",
+      refreshToken: escapeToken,
+      revision: createSqlRevisionToken(),
+    });
+    expect(runtime.queued).toHaveLength(0);
+
+    expect(startCompletion(view)).toBe(true);
+    await vi.waitFor(() => expect(runtime.timers).toHaveLength(3));
+    runtime.timers.at(-1)?.();
+    const expiredToken = harness.getLastToken();
+    if (!expiredToken) throw new Error("Expected completion token");
+    harness.emit({
+      reason: "catalog-availability",
+      refreshToken: expiredToken,
+      revision: createSqlRevisionToken(),
+    });
+    expect(runtime.queued).toHaveLength(0);
+
+    let resolveResult:
+      | ((result: SqlCompletionResult) => void)
+      | undefined;
+    const deferredHarness = fakeService(
+      () => new Promise((resolve) => {
+        resolveResult = resolve;
+      }),
+    );
+    const deferredSupport = sqlEditor({
+      autocomplete: { closeOnBlur: false },
+      initialContext: context(),
+      service: deferredHarness.service,
+    });
+    const deferredView = createView(deferredSupport.extension);
+    expect(startCompletion(deferredView)).toBe(true);
+    await vi.waitFor(() =>
+      expect(deferredHarness.completeSignals).toHaveLength(1)
+    );
+    const visibilityDescriptor = Object.getOwnPropertyDescriptor(
+      document,
+      "visibilityState",
+    );
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      value: "hidden",
+    });
+    document.dispatchEvent(new Event("visibilitychange"));
+    expect(deferredHarness.completeSignals[0]?.aborted).toBe(true);
+    if (visibilityDescriptor) {
+      Object.defineProperty(
+        document,
+        "visibilityState",
+        visibilityDescriptor,
+      );
+    } else {
+      Reflect.deleteProperty(document, "visibilityState");
+    }
+    resolveResult?.({
+      reason: "caller",
+      revision: createSqlRevisionToken(),
+      status: "cancelled",
+    });
+  });
+
+  it("coalesces matching refreshes and suppresses queued work after destroy", async () => {
+    const runtime = controlledRuntime();
+    const harness = fakeService((revision, token) =>
+      readyResult(revision, [], token)
+    );
+    const support = createSqlEditorInternal({
+      initialContext: context(),
+      service: harness.service,
+    }, runtime.runtime);
+    const view = createView(support.extension, "SELECT * FROM ");
+    view.focus();
+    expect(startCompletion(view)).toBe(true);
+    await vi.waitFor(() => expect(runtime.timers).toHaveLength(1));
+    const token = harness.getLastToken();
+    if (!token) throw new Error("Expected completion token");
+    const event: SqlSessionChangeEvent = {
+      reason: "catalog-availability",
+      refreshToken: token,
+      revision: createSqlRevisionToken(),
+    };
+    harness.emit(event);
+    harness.emit(event);
+    expect(runtime.queued).toHaveLength(1);
+    runtime.queued[0]?.();
+    expect(runtime.starts).toEqual([view]);
+
+    harness.emit({
+      reason: "provider-configuration",
+      refreshToken: null,
+      revision: createSqlRevisionToken(),
+    });
+    expect(runtime.queued).toHaveLength(2);
+    runtime.queued[1]?.();
+    expect(runtime.closes).toEqual([view]);
+
+    harness.emit({
+      reason: "provider-configuration",
+      refreshToken: null,
+      revision: createSqlRevisionToken(),
+    });
+    expect(runtime.queued).toHaveLength(3);
+    view.destroy();
+    runtime.queued[2]?.();
+    expect(runtime.closes).toEqual([view]);
+    view.destroy();
+    expect(harness.sessionDisposals()).toBe(1);
+  });
+
+  it("invalidates active and scheduled work across hostile lifecycle timing", async () => {
+    const runtime = controlledRuntime();
+    let resolveResult:
+      | ((result: SqlCompletionResult) => void)
+      | undefined;
+    const harness = fakeService(
+      () => new Promise((resolve) => {
+        resolveResult = resolve;
+      }),
+    );
+    const support = createSqlEditorInternal({
+      autocomplete: { closeOnBlur: false },
+      initialContext: context(),
+      service: harness.service,
+    }, runtime.runtime);
+    const view = createView(support.extension, "SELECT * FROM ");
+    expect(startCompletion(view)).toBe(true);
+    await vi.waitFor(() =>
+      expect(harness.completeSignals).toHaveLength(1)
+    );
+    const token = harness.getLastToken();
+    if (!token) throw new Error("Expected active token");
+    harness.emit({
+      reason: "catalog-availability",
+      refreshToken: token,
+      revision: createSqlRevisionToken(),
+    });
+    expect(runtime.queued).toHaveLength(1);
+    expect(harness.completeSignals[0]?.aborted).toBe(true);
+
+    support.setContext(view, context("connection:new"));
+    runtime.queued[0]?.();
+    expect(runtime.starts).toHaveLength(0);
+    document.dispatchEvent(new Event("visibilitychange"));
+
+    resolveResult?.({
+      reason: "caller",
+      revision: createSqlRevisionToken(),
+      status: "cancelled",
+    });
+  });
+
+  it("does not let a stale rejected task destroy its queued replacement", async () => {
+    const runtime = controlledRuntime();
+    let rejectResult:
+      | ((reason: Error) => void)
+      | undefined;
+    const harness = fakeService(
+      () => new Promise((_resolve, reject) => {
+        rejectResult = reject;
+      }),
+    );
+    const support = createSqlEditorInternal({
+      autocomplete: { closeOnBlur: false },
+      initialContext: context(),
+      service: harness.service,
+    }, runtime.runtime);
+    const view = createView(support.extension, "SELECT * FROM ");
+    expect(startCompletion(view)).toBe(true);
+    await vi.waitFor(() =>
+      expect(harness.completeSignals).toHaveLength(1)
+    );
+    const token = harness.getLastToken();
+    if (!token) throw new Error("Expected active token");
+    harness.emit({
+      reason: "catalog-availability",
+      refreshToken: token,
+      revision: createSqlRevisionToken(),
+    });
+    expect(harness.completeSignals[0]?.aborted).toBe(true);
+    expect(runtime.queued).toHaveLength(1);
+
+    rejectResult?.(new Error("late aborted rejection"));
+    await vi.waitFor(() => {
+      expect(completionStatus(view.state)).toBeNull();
+    });
+    expect(harness.sessionDisposals()).toBe(0);
+    runtime.queued[0]?.();
+    expect(runtime.starts).toEqual([view]);
+  });
+
+  it("keeps a replacement intent when an older lease timer fires", async () => {
+    const runtime = controlledRuntime();
+    const harness = fakeService((revision, token) =>
+      readyResult(revision, [], token)
+    );
+    const support = createSqlEditorInternal({
+      autocomplete: { closeOnBlur: false },
+      initialContext: context(),
+      service: harness.service,
+    }, runtime.runtime);
+    const view = createView(support.extension, "SELECT * FROM ");
+    expect(startCompletion(view)).toBe(true);
+    await vi.waitFor(() => expect(runtime.timers).toHaveLength(1));
+    const oldTimer = runtime.timers[0];
+
+    expect(startCompletion(view)).toBe(true);
+    await vi.waitFor(() => expect(runtime.timers).toHaveLength(2));
+    oldTimer?.();
+    const token = harness.getLastToken();
+    if (!token) throw new Error("Expected replacement token");
+    harness.emit({
+      reason: "catalog-availability",
+      refreshToken: token,
+      revision: createSqlRevisionToken(),
+    });
+    expect(runtime.queued).toHaveLength(1);
+  });
+
+  it("does not retain a zero-duration loading intent", async () => {
+    const runtime = controlledRuntime();
+    const harness = fakeService((revision, token) => ({
+      refreshToken: token,
+      revision,
+      sources: [],
+      status: "ready",
+      value: {
+        isIncomplete: true,
+        issues: [{
+          reason: "catalog-loading",
+          remainingIntentLeaseMs: 0,
+        }],
+        items: [],
+      },
+    }));
+    const support = createSqlEditorInternal({
+      autocomplete: { closeOnBlur: false },
+      initialContext: context(),
+      service: harness.service,
+    }, runtime.runtime);
+    const view = createView(support.extension, "SELECT * FROM ");
+    expect(startCompletion(view)).toBe(true);
+    await vi.waitFor(() =>
+      expect(harness.completeSignals).toHaveLength(1)
+    );
+    const token = harness.getLastToken();
+    if (!token) throw new Error("Expected completion token");
+    harness.emit({
+      reason: "catalog-availability",
+      refreshToken: token,
+      revision: createSqlRevisionToken(),
+    });
+    expect(runtime.timers).toHaveLength(0);
+    expect(runtime.queued).toHaveLength(0);
+  });
+
+  it("bridges CodeMirror cancellation and blur into the service signal", async () => {
+    let resolveResult:
+      | ((result: SqlCompletionResult) => void)
+      | undefined;
+    const harness = fakeService(
+      () => new Promise((resolve) => {
+        resolveResult = resolve;
+      }),
+    );
+    const support = sqlEditor({
+      initialContext: context(),
+      service: harness.service,
+    });
+    const view = createView(support.extension);
+    expect(startCompletion(view)).toBe(true);
+    await vi.waitFor(() =>
+      expect(harness.completeSignals).toHaveLength(1)
+    );
+    expect(closeCompletion(view)).toBe(true);
+    await vi.waitFor(() => {
+      expect(harness.completeSignals[0]?.aborted).toBe(true);
+    });
+    resolveResult?.({
+      reason: "caller",
+      revision: createSqlRevisionToken(),
+      status: "cancelled",
+    });
+    await vi.waitFor(() => {
+      expect(completionStatus(view.state)).toBeNull();
+    });
+
+    view.focus();
+    view.dispatch({ selection: { anchor: 15 } });
+    expect(startCompletion(view)).toBe(true);
+    await vi.waitFor(() =>
+      expect(harness.completeSignals).toHaveLength(2)
+    );
+    view.contentDOM.blur();
+    await vi.waitFor(() => {
+      expect(harness.completeSignals[1]?.aborted).toBe(true);
+    });
+    resolveResult?.({
+      reason: "caller",
+      revision: createSqlRevisionToken(),
+      status: "cancelled",
+    });
+  });
+});

--- a/src/vnext/codemirror/index.ts
+++ b/src/vnext/codemirror/index.ts
@@ -1,0 +1,6 @@
+export {
+  sqlEditor,
+  type SqlEditorAutocompleteOptions,
+  type SqlEditorOptions,
+  type SqlEditorSupport,
+} from "./sql-editor.js";

--- a/src/vnext/codemirror/sql-editor.ts
+++ b/src/vnext/codemirror/sql-editor.ts
@@ -1,0 +1,668 @@
+import {
+  autocompletion,
+  closeCompletion,
+  completionStatus,
+  pickedCompletion,
+  startCompletion,
+  type Completion,
+  type CompletionContext,
+  type CompletionResult,
+  type CompletionSource,
+} from "@codemirror/autocomplete";
+import {
+  Prec,
+  StateEffect,
+  StateField,
+  type EditorSelection,
+  type Extension,
+  type StateEffectType,
+  type Text,
+} from "@codemirror/state";
+import {
+  EditorView,
+  keymap,
+  ViewPlugin,
+  type ViewUpdate,
+} from "@codemirror/view";
+import type {
+  SqlCompletionItem,
+  SqlCompletionRefreshToken,
+  SqlCompletionResult,
+  SqlCompletionTask,
+} from "../relation-completion-types.js";
+import type {
+  SqlContextInput,
+  SqlDocumentContext,
+  SqlDocumentSession,
+  SqlEmbeddedRegion,
+  SqlLanguageService,
+  SqlRevision,
+  SqlTextChange,
+} from "../types.js";
+
+export interface SqlEditorAutocompleteOptions {
+  readonly activateOnTyping?: boolean;
+  readonly activateOnTypingDelay?: number;
+  readonly closeOnBlur?: boolean;
+  readonly defaultKeymap?: boolean;
+  readonly externalSources?: readonly CompletionSource[];
+  readonly maxRenderedOptions?: number;
+  readonly selectOnOpen?: boolean;
+  readonly updateSyncTime?: number;
+}
+
+export interface SqlEditorOptions<
+  Context extends SqlDocumentContext,
+> {
+  readonly autocomplete?: SqlEditorAutocompleteOptions;
+  readonly initialContext: SqlContextInput<Context>;
+  readonly initialEmbeddedRegions?:
+    | readonly SqlEmbeddedRegion[]
+    | undefined;
+  readonly service: SqlLanguageService<Context>;
+}
+
+export interface SqlEditorSupport<
+  Context extends SqlDocumentContext,
+> {
+  readonly contextEffect: StateEffectType<SqlContextInput<Context>>;
+  readonly embeddedRegionsEffect: StateEffectType<
+    readonly SqlEmbeddedRegion[]
+  >;
+  readonly extension: Extension;
+  readonly setContext: (
+    view: EditorView,
+    context: SqlContextInput<Context>,
+  ) => void;
+  readonly setEmbeddedRegions: (
+    view: EditorView,
+    regions: readonly SqlEmbeddedRegion[],
+  ) => void;
+}
+
+export interface SqlEditorRuntime {
+  readonly clearTimeout: (
+    handle: ReturnType<typeof setTimeout>,
+  ) => void;
+  readonly closeCompletion: (view: EditorView) => boolean;
+  readonly queueMicrotask: (callback: () => void) => void;
+  readonly setTimeout: (
+    callback: () => void,
+    delayMs: number,
+  ) => ReturnType<typeof setTimeout>;
+  readonly startCompletion: (view: EditorView) => boolean;
+}
+
+interface CompletionCapture {
+  readonly contextGeneration: number;
+  readonly document: Text;
+  readonly selection: EditorSelection;
+}
+
+interface ActiveCompletion {
+  readonly capture: CompletionCapture;
+  readonly controller: AbortController;
+  readonly sequence: number;
+  readonly token: SqlCompletionRefreshToken;
+}
+
+interface CompletionIntent {
+  readonly capture: CompletionCapture;
+  readonly sequence: number;
+  readonly token: SqlCompletionRefreshToken;
+}
+
+const defaultRuntime: SqlEditorRuntime = Object.freeze({
+  clearTimeout: (handle: ReturnType<typeof setTimeout>) =>
+    clearTimeout(handle),
+  closeCompletion,
+  queueMicrotask: (callback: () => void) => queueMicrotask(callback),
+  setTimeout: (callback: () => void, delayMs: number) =>
+    setTimeout(callback, delayMs),
+  startCompletion,
+});
+
+function completionTrigger(): { readonly kind: "invoked" } {
+  return { kind: "invoked" };
+}
+
+function collectChanges(update: ViewUpdate): readonly SqlTextChange[] {
+  const changes: SqlTextChange[] = [];
+  update.changes.iterChanges((from, to, _fromNew, _toNew, inserted) => {
+    changes.push(Object.freeze({
+      from,
+      insert: inserted.toString(),
+      to,
+    }));
+  });
+  return Object.freeze(changes);
+}
+
+function loadingLeaseMs(
+  result: Extract<SqlCompletionResult, { readonly status: "ready" }>,
+): number | null {
+  for (const issue of result.value.issues) {
+    if (issue.reason === "catalog-loading") {
+      return issue.remainingIntentLeaseMs;
+    }
+  }
+  return null;
+}
+
+function haveOneEditRange(items: readonly SqlCompletionItem[]): boolean {
+  const first = items[0];
+  if (!first) return true;
+  for (const item of items) {
+    if (
+      item.edit.from !== first.edit.from ||
+      item.edit.to !== first.edit.to
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function completionType(item: SqlCompletionItem): string {
+  return item.relationKind === "cte" ? "type" : "table";
+}
+
+function mapEmbeddedRegions(
+  regions: readonly SqlEmbeddedRegion[],
+  change: SqlTextChange,
+): readonly SqlEmbeddedRegion[] | null {
+  const offset =
+    change.insert.length - (change.to - change.from);
+  const mapped: SqlEmbeddedRegion[] = [];
+  for (const region of regions) {
+    if (change.to <= region.from) {
+      mapped.push(Object.freeze({
+        from: region.from + offset,
+        language: region.language,
+        to: region.to + offset,
+      }));
+    } else if (change.from >= region.to) {
+      mapped.push(region);
+    } else {
+      return null;
+    }
+  }
+  return Object.freeze(mapped);
+}
+
+export function createSqlEditorInternal<
+  Context extends SqlDocumentContext,
+>(
+  options: SqlEditorOptions<Context>,
+  runtime: SqlEditorRuntime,
+): SqlEditorSupport<Context> {
+  const contextEffect =
+    StateEffect.define<SqlContextInput<Context>>();
+  const embeddedRegionsEffect =
+    StateEffect.define<readonly SqlEmbeddedRegion[]>();
+  const contextField = StateField.define<SqlContextInput<Context>>({
+    create: () => options.initialContext,
+    update: (context, transaction) => {
+      let next = context;
+      for (const effect of transaction.effects) {
+        if (effect.is(contextEffect)) next = effect.value;
+      }
+      return next;
+    },
+  });
+  const embeddedRegionsField = StateField.define<
+    readonly SqlEmbeddedRegion[]
+  >({
+    create: () => options.initialEmbeddedRegions ?? [],
+    update: (regions, transaction) => {
+      let next = regions;
+      for (const effect of transaction.effects) {
+        if (effect.is(embeddedRegionsEffect)) next = effect.value;
+      }
+      return next;
+    },
+  });
+
+  let plugin: ViewPlugin<SqlEditorPlugin>;
+  let completionSource: CompletionSource;
+
+  class SqlEditorPlugin {
+    readonly #view: EditorView;
+    readonly #session: SqlDocumentSession<Context>;
+    #active: ActiveCompletion | null = null;
+    #contextGeneration = 0;
+    #destroyed = false;
+    #hasEmbeddedRegions: boolean;
+    #intent: CompletionIntent | null = null;
+    #intentTimer: ReturnType<typeof setTimeout> | null = null;
+    #lastCompletionStatus: ReturnType<typeof completionStatus>;
+    #refreshScheduled = false;
+    #sequence = 0;
+    readonly #subscription;
+    readonly #visibilityListener: () => void;
+
+    constructor(view: EditorView) {
+      this.#view = view;
+      const initialRegions = view.state.field(embeddedRegionsField);
+      this.#session = options.service.openDocument({
+        context: view.state.field(contextField),
+        embeddedRegions: initialRegions,
+        text: view.state.doc.toString(),
+      });
+      this.#hasEmbeddedRegions = initialRegions.length > 0;
+      this.#lastCompletionStatus = completionStatus(view.state);
+      this.#subscription = this.#session.onDidChange((event) => {
+        if (event.refreshToken === null) {
+          this.#clearCompletionState();
+          this.#scheduleClose();
+          return;
+        }
+        if (event.refreshToken === this.#active?.token) {
+          this.#scheduleRefresh(this.#active.capture);
+        } else if (event.refreshToken === this.#intent?.token) {
+          this.#scheduleRefresh(this.#intent.capture);
+        }
+      });
+      this.#visibilityListener = () => {
+        if (view.dom.ownerDocument.visibilityState === "hidden") {
+          this.#clearCompletionState();
+        }
+      };
+      view.dom.ownerDocument.addEventListener(
+        "visibilitychange",
+        this.#visibilityListener,
+      );
+    }
+
+    #abortActive(): void {
+      this.#active?.controller.abort();
+      this.#active = null;
+    }
+
+    #clearIntent(): void {
+      if (this.#intentTimer !== null) {
+        runtime.clearTimeout(this.#intentTimer);
+        this.#intentTimer = null;
+      }
+      this.#intent = null;
+    }
+
+    #clearCompletionState(): void {
+      this.#sequence += 1;
+      this.#abortActive();
+      this.#clearIntent();
+      this.#refreshScheduled = false;
+    }
+
+    #captureIsCurrent(capture: CompletionCapture): boolean {
+      const state = this.#view.state;
+      return (
+        !this.#destroyed &&
+        capture.contextGeneration === this.#contextGeneration &&
+        capture.document === state.doc &&
+        capture.selection.eq(state.selection)
+      );
+    }
+
+    #scheduleClose(): void {
+      const sequence = this.#sequence;
+      runtime.queueMicrotask(() => {
+        if (
+          this.#destroyed ||
+          sequence !== this.#sequence
+        ) {
+          return;
+        }
+        runtime.closeCompletion(this.#view);
+      });
+    }
+
+    #scheduleRefresh(capture: CompletionCapture): void {
+      if (
+        this.#refreshScheduled ||
+        !this.#captureIsCurrent(capture)
+      ) {
+        return;
+      }
+      this.#abortActive();
+      this.#clearIntent();
+      this.#refreshScheduled = true;
+      const sequence = ++this.#sequence;
+      runtime.queueMicrotask(() => {
+        if (
+          this.#destroyed ||
+          !this.#refreshScheduled ||
+          sequence !== this.#sequence ||
+          !this.#captureIsCurrent(capture) ||
+          (options.autocomplete?.closeOnBlur !== false &&
+            !this.#view.hasFocus)
+        ) {
+          return;
+        }
+        this.#refreshScheduled = false;
+        runtime.startCompletion(this.#view);
+      });
+    }
+
+    #installIntent(
+      token: SqlCompletionRefreshToken,
+      capture: CompletionCapture,
+      leaseMs: number,
+    ): void {
+      this.#clearIntent();
+      if (leaseMs <= 0 || !this.#captureIsCurrent(capture)) return;
+      const sequence = this.#sequence;
+      const intent: CompletionIntent = {
+        capture,
+        sequence,
+        token,
+      };
+      this.#intent = intent;
+      this.#intentTimer = runtime.setTimeout(() => {
+        if (
+          this.#intent === intent &&
+          this.#sequence === intent.sequence
+        ) {
+          this.#intent = null;
+          this.#intentTimer = null;
+        }
+      }, leaseMs);
+    }
+
+    #mapCompletion(
+      item: SqlCompletionItem,
+      revision: SqlRevision,
+      capture: CompletionCapture,
+    ): Completion {
+      const completion: Completion = {
+        apply: (view, completion) => {
+          const current = view.plugin(plugin);
+          if (
+            current !== this ||
+            !this.#captureIsCurrent(capture) ||
+            !this.#session.isCurrent(revision)
+          ) {
+            return;
+          }
+          const regions = mapEmbeddedRegions(
+            view.state.field(embeddedRegionsField),
+            item.edit,
+          );
+          if (regions === null) return;
+          view.dispatch({
+            annotations: pickedCompletion.of(completion),
+            changes: {
+              from: item.edit.from,
+              insert: item.edit.insert,
+              to: item.edit.to,
+            },
+            effects: embeddedRegionsEffect.of(regions),
+          });
+        },
+        label: item.label,
+        type: completionType(item),
+      };
+      return item.detail === undefined
+        ? completion
+        : { ...completion, detail: item.detail };
+    }
+
+    readonly complete = async (
+      context: CompletionContext,
+    ): Promise<CompletionResult | null> => {
+      this.#clearCompletionState();
+      const capture: CompletionCapture = {
+        contextGeneration: this.#contextGeneration,
+        document: this.#view.state.doc,
+        selection: this.#view.state.selection,
+      };
+      const controller = new AbortController();
+      let task: SqlCompletionTask;
+      try {
+        task = this.#session.complete({
+          position: context.pos,
+          signal: controller.signal,
+          trigger: completionTrigger(),
+        });
+      } catch {
+        this.destroy();
+        return null;
+      }
+      const active: ActiveCompletion = {
+        capture,
+        controller,
+        sequence: this.#sequence,
+        token: task.refreshToken,
+      };
+      this.#active = active;
+      context.addEventListener(
+        "abort",
+        () => {
+          controller.abort();
+          if (this.#active === active) this.#active = null;
+        },
+        { onDocChange: true },
+      );
+      if (context.aborted) controller.abort();
+
+      let result: SqlCompletionResult;
+      try {
+        result = await task;
+      } catch {
+        if (
+          this.#active === active &&
+          active.sequence === this.#sequence &&
+          !controller.signal.aborted
+        ) {
+          this.destroy();
+        }
+        return null;
+      }
+      if (
+        controller.signal.aborted ||
+        this.#active !== active ||
+        active.sequence !== this.#sequence ||
+        !this.#captureIsCurrent(capture) ||
+        !this.#session.isCurrent(result.revision)
+      ) {
+        return null;
+      }
+      this.#active = null;
+      if (result.status !== "ready") return null;
+
+      if (!haveOneEditRange(result.value.items)) return null;
+      const leaseMs = loadingLeaseMs(result);
+      if (result.refreshToken !== null) {
+        if (
+          result.refreshToken !== active.token ||
+          leaseMs === null
+        ) {
+          return null;
+        }
+        this.#installIntent(
+          result.refreshToken,
+          capture,
+          leaseMs,
+        );
+      }
+      const first = result.value.items[0];
+      if (!first) return null;
+      return {
+        from: first.edit.from,
+        options: result.value.items.map((item) =>
+          this.#mapCompletion(item, result.revision, capture)
+        ),
+        to: first.edit.to,
+      };
+    };
+
+    readonly cancelCompletion = (): void => {
+      this.#clearCompletionState();
+    };
+
+    readonly update = (update: ViewUpdate): void => {
+      let contextChanged = false;
+      let regionsChanged = false;
+      for (const transaction of update.transactions) {
+        for (const effect of transaction.effects) {
+          if (effect.is(contextEffect)) contextChanged = true;
+          if (effect.is(embeddedRegionsEffect)) regionsChanged = true;
+        }
+      }
+      if (
+        update.docChanged &&
+        this.#hasEmbeddedRegions &&
+        !regionsChanged
+      ) {
+        this.destroy();
+        throw new Error(
+          "SQL document changes with embedded regions require the complete resulting region set",
+        );
+      }
+      if (update.docChanged || contextChanged || regionsChanged) {
+        this.#clearCompletionState();
+        const regions = regionsChanged
+          ? update.state.field(embeddedRegionsField)
+          : [];
+        const baseRevision = this.#session.revision;
+        try {
+          if (update.docChanged) {
+            const document = {
+              changes: collectChanges(update),
+              kind: "changes" as const,
+            };
+            this.#session.update(
+              contextChanged
+                ? {
+                    baseRevision,
+                    context: update.state.field(contextField),
+                    document,
+                    embeddedRegions: regions,
+                  }
+                : {
+                    baseRevision,
+                    document,
+                    embeddedRegions: regions,
+                  },
+            );
+          } else if (contextChanged) {
+            const context = update.state.field(contextField);
+            this.#session.update(
+              regionsChanged
+                ? {
+                    baseRevision,
+                    context,
+                    embeddedRegions: regions,
+                  }
+                : {
+                    baseRevision,
+                    context,
+                  },
+            );
+          } else {
+            this.#session.update({
+              baseRevision,
+              embeddedRegions: regions,
+            });
+          }
+        } catch {
+          this.destroy();
+          return;
+        }
+        if (contextChanged) this.#contextGeneration += 1;
+        if (update.docChanged || regionsChanged) {
+          this.#hasEmbeddedRegions = regions.length > 0;
+        }
+      } else if (update.selectionSet) {
+        this.#clearCompletionState();
+      }
+      if (
+        update.focusChanged &&
+        !update.view.hasFocus &&
+        options.autocomplete?.closeOnBlur !== false
+      ) {
+        this.#clearCompletionState();
+      }
+      const nextCompletionStatus = completionStatus(update.state);
+      if (
+        nextCompletionStatus === null &&
+        (this.#lastCompletionStatus === "active" ||
+          (this.#lastCompletionStatus === "pending" &&
+            this.#active !== null))
+      ) {
+        this.#clearCompletionState();
+      }
+      this.#lastCompletionStatus = nextCompletionStatus;
+    };
+
+    readonly destroy = (): void => {
+      if (this.#destroyed) return;
+      this.#destroyed = true;
+      this.#clearCompletionState();
+      this.#view.dom.ownerDocument.removeEventListener(
+        "visibilitychange",
+        this.#visibilityListener,
+      );
+      this.#subscription.dispose();
+      this.#session.dispose();
+    };
+  }
+
+  plugin = ViewPlugin.define(
+    (view) => new SqlEditorPlugin(view),
+  );
+  completionSource = (context) => {
+    const instance = context.view?.plugin(plugin);
+    return instance?.complete(context) ?? null;
+  };
+  const autocomplete = options.autocomplete ?? {};
+  const {
+    externalSources = [],
+    ...autocompleteOptions
+  } = autocomplete;
+  const escapeKeymap = Prec.high(
+    keymap.of([{
+      key: "Escape",
+      run: (view) => {
+        view.plugin(plugin)?.cancelCompletion();
+        return false;
+      },
+    }]),
+  );
+  return Object.freeze({
+    contextEffect,
+    embeddedRegionsEffect,
+    extension: [
+      contextField,
+      embeddedRegionsField,
+      plugin,
+      escapeKeymap,
+      autocompletion({
+        ...autocompleteOptions,
+        override: [completionSource, ...externalSources],
+      }),
+    ],
+    setContext: (
+      view: EditorView,
+      context: SqlContextInput<Context>,
+    ): void => {
+      view.dispatch({ effects: contextEffect.of(context) });
+    },
+    setEmbeddedRegions: (
+      view: EditorView,
+      regions: readonly SqlEmbeddedRegion[],
+    ): void => {
+      view.dispatch({
+        effects: embeddedRegionsEffect.of(regions),
+      });
+    },
+  });
+}
+
+export function sqlEditor<
+  Context extends SqlDocumentContext,
+>(
+  options: SqlEditorOptions<Context>,
+): SqlEditorSupport<Context> {
+  return createSqlEditorInternal(options, defaultRuntime);
+}


### PR DESCRIPTION
## Summary

- add an explicit `@marimo-team/codemirror-sql/vnext/codemirror` entry point with one caller-owned service and one session per `EditorView`
- translate composite CodeMirror document, context, and embedded-region effects into one atomic session update
- map current relation results to exact CodeMirror edits with revision, document, selection, context, and embedded-region guards
- coalesce exact-token catalog refreshes across active menus and empty loading results without synchronous provider-driven dispatch
- contain Escape, close, blur, visibility, expiry, service-first disposal, stale rejection, and repeated teardown races

## Why

The framework-independent service now has the identity and lease contracts needed for a thin editor boundary. This adapter makes those contracts usable without leaking CodeMirror into the core, while preserving marimo's external completion sources and treating transformed-document regions explicitly rather than guessing their mapping.

## Validation

- 2,028 tests pass; 1 intentional expected failure
- adapter coverage: 97.70% statements, 95.86% branches, 100% functions, 99.01% lines
- all strict and loose-optional TypeScript configurations pass
- oxlint and test-integrity checks pass
- packed-consumer source covers the new package subpath; hosted package CI will run the isolated install
- two independent exact-commit adversarial reviews approved `8d72a4c`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a CodeMirror 6 adapter for the vNext SQL language service, exposed as `@marimo-team/codemirror-sql/vnext/codemirror`. This enables exact, guarded completion edits and atomic document/context/region updates without leaking CodeMirror into the core.

- **New Features**
  - New `sqlEditor` adapter with one document session per `EditorView`; caller owns the shared `service`.
  - Atomic updates: merges document changes with `support.contextEffect` and `support.embeddedRegionsEffect`.
  - Exact completion edits with revision/context/selection guards; maps unrelated embedded regions through its own edit; ignores overlaps.
  - Coalesced refresh intents keyed by service tokens; cancels on Escape, blur (configurable), visibility loss, selection change, or lease expiry; no synchronous provider-driven dispatch.
  - Single `autocompletion` configuration; supports `externalSources` for extra providers.
  - New docs: `docs/vnext/codemirror-adapter.md`; subpath export added in `package.json`; smoke test updated.

- **Migration**
  - Import from `@marimo-team/codemirror-sql/vnext/codemirror`, create a service from `@marimo-team/codemirror-sql/vnext`, then add `support.extension` to the editor.
  - Do not install a second `autocompletion` extension; pass extra providers via `externalSources`.
  - Update context/regions via `support.setContext` or by dispatching `support.contextEffect` and `support.embeddedRegionsEffect`. If embedded regions exist, include the complete resulting set on every document-changing transaction.

<sup>Written for commit 8d72a4ceb895b6614c36d35b3457fea4be5e9bb0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marimo-team/codemirror-sql/pull/199?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

